### PR TITLE
fix(inference): resolve DirectML startup probe race and DLL path mismatch

### DIFF
--- a/crates/smolpc-engine-core/src/inference/genai/directml.rs
+++ b/crates/smolpc-engine-core/src/inference/genai/directml.rs
@@ -214,6 +214,13 @@ fn find_genai_dll() -> Option<PathBuf> {
         }
     }
 
+    if let Some(path) = std::env::var_os("SMOLPC_ORT_DYLIB_DIR") {
+        let candidate = PathBuf::from(path).join("onnxruntime-genai.dll");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+
     let mut candidates = Vec::new();
 
     if let Ok(exe) = std::env::current_exe() {

--- a/crates/smolpc-engine-core/src/inference/mod.rs
+++ b/crates/smolpc-engine-core/src/inference/mod.rs
@@ -52,6 +52,14 @@ pub fn init_onnx_runtime(resource_dir: Option<&Path>) -> Result<(), String> {
             log::info!("Initializing ONNX Runtime from: {}", dylib_path.display());
 
             #[cfg(target_os = "windows")]
+            {
+                // Keep GenAI lookup anchored to the exact ORT directory to avoid mixed DLL sets.
+                if let Some(parent) = dylib_path.parent() {
+                    std::env::set_var("SMOLPC_ORT_DYLIB_DIR", parent);
+                }
+            }
+
+            #[cfg(target_os = "windows")]
             preload_directml_dll(resource_dir, &dylib_path);
 
             match ort::init_from(dylib_path.to_string_lossy().to_string()) {

--- a/crates/smolpc-engine-host/src/main.rs
+++ b/crates/smolpc-engine-host/src/main.rs
@@ -527,9 +527,57 @@ impl EngineState {
 
         let force_override = parse_force_override();
         let forced_device_id = parse_dml_device_id_env();
-        let probe = self
+        let mut probe = self
             .wait_for_startup_probe(Duration::from_millis(STARTUP_PROBE_WAIT_MS))
             .await;
+        let probe_ready = self.startup_probe.lock().await.is_some();
+        if directml_required && !probe_ready {
+            log::warn!(
+                "Startup backend probe not ready within {}ms while loading '{}'; running on-demand probe",
+                STARTUP_PROBE_WAIT_MS,
+                model_id
+            );
+            probe = tokio::task::spawn_blocking(probe_backend_capabilities)
+                .await
+                .unwrap_or_else(|error| {
+                    log::warn!("On-demand backend probe task failed: {error}");
+                    BackendProbeResult::default()
+                });
+
+            {
+                let mut probe_guard = self.startup_probe.lock().await;
+                if probe_guard.is_none() {
+                    *probe_guard = Some(probe.clone());
+                    self.startup_probe_ready.notify_waiters();
+                }
+            }
+
+            {
+                let mut status = self.backend_status.lock().await;
+                status.available_backends = probe.available_backends.clone();
+                status.directml_probe_passed = Some(probe.directml_candidate.is_some());
+                status.directml_probe_error = if probe.directml_candidate.is_some() {
+                    None
+                } else {
+                    Some("No DirectML-capable adapter detected".to_string())
+                };
+                status.directml_probe_at = Some(Utc::now().to_rfc3339());
+                status.selected_device_id =
+                    probe.directml_candidate.as_ref().map(|c| c.device_id);
+                status.selected_device_name = probe
+                    .directml_candidate
+                    .as_ref()
+                    .map(|c| c.device_name.clone());
+                if status.selection_state.as_deref() == Some("pending") {
+                    status.selection_state = Some("ready".to_string());
+                    status.selection_reason = Some(if probe.directml_candidate.is_some() {
+                        "startup_probe_ready".to_string()
+                    } else {
+                        "startup_probe_cpu_only".to_string()
+                    });
+                }
+            }
+        }
 
         let mut available_backends = probe.available_backends.clone();
         if !available_backends.contains(&InferenceBackend::Cpu) {

--- a/src-tauri/src/inference/genai/directml.rs
+++ b/src-tauri/src/inference/genai/directml.rs
@@ -214,6 +214,13 @@ fn find_genai_dll() -> Option<PathBuf> {
         }
     }
 
+    if let Some(path) = std::env::var_os("SMOLPC_ORT_DYLIB_DIR") {
+        let candidate = PathBuf::from(path).join("onnxruntime-genai.dll");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+
     let mut candidates = Vec::new();
 
     if let Ok(exe) = std::env::current_exe() {

--- a/src-tauri/src/inference/mod.rs
+++ b/src-tauri/src/inference/mod.rs
@@ -52,6 +52,14 @@ pub fn init_onnx_runtime(resource_dir: Option<&Path>) -> Result<(), String> {
             log::info!("Initializing ONNX Runtime from: {}", dylib_path.display());
 
             #[cfg(target_os = "windows")]
+            {
+                // Keep GenAI lookup anchored to the exact ORT directory to avoid mixed DLL sets.
+                if let Some(parent) = dylib_path.parent() {
+                    std::env::set_var("SMOLPC_ORT_DYLIB_DIR", parent);
+                }
+            }
+
+            #[cfg(target_os = "windows")]
             preload_directml_dll(resource_dir, &dylib_path);
 
             match ort::init_from(dylib_path.to_string_lossy().to_string()) {


### PR DESCRIPTION
## Summary
- Fix a startup race where loading a DirectML-required model could occur before the async startup probe completed, causing a false `no DirectML-capable adapter was detected` error.
- Add an on-demand capability probe path in the host load flow when startup probe state is still pending for DirectML-required models.
- Keep ONNX Runtime GenAI DLL resolution aligned with the exact ORT DLL directory used at runtime by setting and consuming `SMOLPC_ORT_DYLIB_DIR`.
- Apply the ORT/GenAI alignment in both shared engine core and the mirrored `src-tauri` inference modules.

## Validation
- `cargo check -p smolpc-engine-core -p smolpc-engine-host`
- `cargo check -p smolpc-code-helper`
- Manual host smoke: immediate `POST /engine/load` for `qwen3-4b-instruct-2507` succeeds and selects `directml` / `genai_dml`.

## Notes
- This PR intentionally excludes unrelated local edits (`package-lock.json`, `src-tauri/Cargo.toml`, local temp folders).