### PR TITLE
Shell: harden mode fallback and init flow

### DIFF
--- a/apps/codehelper/src/App.svelte
+++ b/apps/codehelper/src/App.svelte
@@ -56,11 +56,20 @@
 	const modeStatusLabel = $derived(
 		activeModeStatus?.providerState
 			? activeModeStatus.providerState.state.replace(/_/g, ' ')
-			: modeStore.loading
-				? 'loading'
-				: 'status pending'
+			: modeStore.error
+				? 'fallback active'
+				: modeStore.loading
+					? 'loading'
+					: 'status pending'
 	);
-	const modeStatusDetail = $derived(activeModeStatus?.providerState.detail ?? null);
+	const modeStatusDetail = $derived.by(() => {
+		const details = [
+			modeStore.error ? `Shell warning: ${modeStore.error}` : null,
+			activeModeStatus?.providerState.detail ?? null
+		].filter((detail): detail is string => Boolean(detail));
+
+		return details.length > 0 ? details.join(' · ') : null;
+	});
 
 	function setMessagesContainer(element: HTMLDivElement) {
 		messagesContainer = element;
@@ -160,11 +169,6 @@ Teaching rules:
 		await modeStore.setActiveMode(mode);
 		uiStore.resetScrollState();
 		uiStore.setShowQuickExamples(true);
-
-		const supportsBenchmark = modeStore.getConfig(mode)?.capabilities.showBenchmarkPanel ?? false;
-		if (!supportsBenchmark && uiStore.activeOverlay === 'benchmark') {
-			uiStore.closeOverlay();
-		}
 	}
 
 	async function handleSendMessage(content: string) {
@@ -453,7 +457,9 @@ Teaching rules:
 			}
 		}
 
-		initApp();
+		initApp().catch((error) => {
+			console.error('[initApp]', error);
+		});
 
 		window.addEventListener('keydown', handleKeyDown);
 
@@ -480,6 +486,8 @@ Teaching rules:
 
 	$effect(() => {
 		const canShowBenchmark = activeModeConfig?.capabilities.showBenchmarkPanel ?? false;
+		// Centralize benchmark overlay cleanup here so mode changes and config refreshes
+		// follow the same capability gate.
 		if (!canShowBenchmark && uiStore.activeOverlay === 'benchmark') {
 			uiStore.closeOverlay();
 		}

--- a/apps/codehelper/src/lib/components/QuickExamples.svelte
+++ b/apps/codehelper/src/lib/components/QuickExamples.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { X } from '@lucide/svelte';
+
 	export interface QuickExampleCard {
 		id: string;
 		title: string;
@@ -49,7 +51,7 @@
 		</div>
 		{#if onClose}
 			<button onclick={onClose} class="quick-examples__close" aria-label="Close examples">
-				<span aria-hidden="true">×</span>
+				<X class="quick-examples__close-icon" aria-hidden="true" />
 			</button>
 		{/if}
 	</div>
@@ -123,6 +125,11 @@
 		color: var(--color-foreground);
 		border-color: var(--outline-soft);
 		background: var(--surface-hover);
+	}
+
+	:global(.quick-examples__close-icon) {
+		width: 1rem;
+		height: 1rem;
 	}
 
 	.quick-examples__grid {

--- a/apps/codehelper/src/lib/stores/mode.svelte.ts
+++ b/apps/codehelper/src/lib/stores/mode.svelte.ts
@@ -1,19 +1,24 @@
 import { getModeStatus, listModes } from '$lib/api/unified';
 import { loadFromStorage, saveToStorage } from '$lib/utils/storage';
-import type { AppMode, ModeConfigDto } from '$lib/types/mode';
+import { FALLBACK_MODE_CONFIGS, type AppMode, type ModeConfigDto } from '$lib/types/mode';
 import type { ModeStatusDto } from '$lib/types/provider';
 
 const ACTIVE_MODE_KEY = 'smolpc_unified_active_mode_v1';
 
 let activeMode = $state<AppMode>('code');
-let modeConfigs = $state<ModeConfigDto[]>([]);
+let modeConfigs = $state<ModeConfigDto[]>(FALLBACK_MODE_CONFIGS);
 let statusByMode = $state<Partial<Record<AppMode, ModeStatusDto>>>({});
 let loading = $state(false);
-let error = $state<string | null>(null);
+let configError = $state<string | null>(null);
+let statusError = $state<string | null>(null);
 let initialized = $state(false);
 
 function getModeConfig(mode: AppMode): ModeConfigDto | null {
 	return modeConfigs.find((config) => config.id === mode) ?? null;
+}
+
+function toErrorMessage(cause: unknown): string {
+	return cause instanceof Error ? cause.message : String(cause);
 }
 
 async function loadModeStatus(mode: AppMode): Promise<void> {
@@ -38,7 +43,10 @@ export const modeStore = {
 		return loading;
 	},
 	get error() {
-		return error;
+		return (
+			[configError, statusError].filter((value): value is string => Boolean(value)).join(' · ') ||
+			null
+		);
 	},
 	get initialized() {
 		return initialized;
@@ -64,21 +72,31 @@ export const modeStore = {
 		}
 
 		loading = true;
-		error = null;
+		configError = null;
+		statusError = null;
+		const storedMode = loadFromStorage<AppMode>(ACTIVE_MODE_KEY, 'code');
 
 		try {
-			modeConfigs = await listModes();
-			const storedMode = loadFromStorage<AppMode>(ACTIVE_MODE_KEY, 'code');
-			const resolvedMode = getModeConfig(storedMode) ? storedMode : 'code';
-
-			activeMode = resolvedMode;
-			saveToStorage(ACTIVE_MODE_KEY, activeMode);
-
-			await loadModeStatus(activeMode);
-			initialized = true;
+			const remoteModes = await listModes();
+			if (remoteModes.length === 0) {
+				throw new Error('list_modes returned no modes');
+			}
+			modeConfigs = remoteModes;
 		} catch (cause) {
-			error = cause instanceof Error ? cause.message : String(cause);
+			configError = `Mode list unavailable; using local fallback config. ${toErrorMessage(cause)}`;
+			modeConfigs = FALLBACK_MODE_CONFIGS;
+		}
+
+		const resolvedMode = getModeConfig(storedMode) ? storedMode : 'code';
+		activeMode = resolvedMode;
+		saveToStorage(ACTIVE_MODE_KEY, activeMode);
+
+		try {
+			await loadModeStatus(activeMode);
+		} catch (cause) {
+			statusError = toErrorMessage(cause);
 		} finally {
+			initialized = true;
 			loading = false;
 		}
 	},
@@ -96,12 +114,12 @@ export const modeStore = {
 
 	async refreshModeStatus(mode: AppMode = activeMode): Promise<void> {
 		loading = true;
-		error = null;
+		statusError = null;
 
 		try {
 			await loadModeStatus(mode);
 		} catch (cause) {
-			error = cause instanceof Error ? cause.message : String(cause);
+			statusError = toErrorMessage(cause);
 		} finally {
 			loading = false;
 		}

--- a/apps/codehelper/src/lib/types/mode.ts
+++ b/apps/codehelper/src/lib/types/mode.ts
@@ -24,3 +24,114 @@ export interface ModeConfigDto {
 	suggestions: string[];
 	capabilities: ModeCapabilitiesDto;
 }
+
+export const FALLBACK_MODE_CONFIGS: ModeConfigDto[] = [
+	{
+		id: 'code',
+		label: 'Code',
+		subtitle: 'Coding help inside the shared SmolPC app',
+		icon: 'code',
+		providerKind: 'local',
+		systemPromptKey: 'mode.code.default',
+		suggestions: ['Explain this error', 'Write a function', 'Review this snippet'],
+		capabilities: {
+			supportsTools: false,
+			supportsUndo: false,
+			showModelInfo: true,
+			showHardwarePanel: true,
+			showBenchmarkPanel: true,
+			showExport: true,
+			showContextControls: true
+		}
+	},
+	{
+		id: 'gimp',
+		label: 'GIMP',
+		subtitle: 'Image editing assistance for GIMP workflows',
+		icon: 'image',
+		providerKind: 'mcp',
+		systemPromptKey: 'mode.gimp.default',
+		suggestions: ['Resize an image', 'Remove the background', 'Undo the last change'],
+		capabilities: {
+			supportsTools: true,
+			supportsUndo: true,
+			showModelInfo: true,
+			showHardwarePanel: true,
+			showBenchmarkPanel: false,
+			showExport: false,
+			showContextControls: false
+		}
+	},
+	{
+		id: 'blender',
+		label: 'Blender',
+		subtitle: '3D scene assistance for Blender workflows',
+		icon: 'box',
+		providerKind: 'hybrid',
+		systemPromptKey: 'mode.blender.default',
+		suggestions: ['Explain this scene', 'Create a simple material', 'Fix this modifier'],
+		capabilities: {
+			supportsTools: true,
+			supportsUndo: false,
+			showModelInfo: true,
+			showHardwarePanel: true,
+			showBenchmarkPanel: false,
+			showExport: false,
+			showContextControls: false
+		}
+	},
+	{
+		id: 'writer',
+		label: 'Writer',
+		subtitle: 'Writing help for LibreOffice Writer',
+		icon: 'file-text',
+		providerKind: 'mcp',
+		systemPromptKey: 'mode.writer.default',
+		suggestions: ['Draft a paragraph', 'Rewrite this passage', 'Summarize this text'],
+		capabilities: {
+			supportsTools: true,
+			supportsUndo: false,
+			showModelInfo: true,
+			showHardwarePanel: true,
+			showBenchmarkPanel: false,
+			showExport: false,
+			showContextControls: false
+		}
+	},
+	{
+		id: 'calc',
+		label: 'Calc',
+		subtitle: 'Spreadsheet help for LibreOffice Calc',
+		icon: 'table',
+		providerKind: 'mcp',
+		systemPromptKey: 'mode.calc.default',
+		suggestions: ['Explain this formula', 'Build a grade table', 'Clean this data'],
+		capabilities: {
+			supportsTools: true,
+			supportsUndo: false,
+			showModelInfo: true,
+			showHardwarePanel: true,
+			showBenchmarkPanel: false,
+			showExport: false,
+			showContextControls: false
+		}
+	},
+	{
+		id: 'impress',
+		label: 'Slides',
+		subtitle: 'Presentation help for LibreOffice Slides',
+		icon: 'presentation',
+		providerKind: 'mcp',
+		systemPromptKey: 'mode.impress.default',
+		suggestions: ['Draft slide bullets', 'Turn notes into slides', 'Improve this outline'],
+		capabilities: {
+			supportsTools: true,
+			supportsUndo: false,
+			showModelInfo: true,
+			showHardwarePanel: true,
+			showBenchmarkPanel: false,
+			showExport: false,
+			showContextControls: false
+		}
+	}
+];


### PR DESCRIPTION
## Summary
- catch top-level shell init failures so startup does not produce unhandled rejections
- seed the mode shell with local fallback configs so the mode dropdown still works if `list_modes` fails
- surface shell fallback/status errors in the header and restore the close icon in quick examples

## Review notes addressed
- addressed: initApp fire-and-forget rejection risk
- addressed: empty mode dropdown when `list_modes` fails
- addressed: `modeStore.error` was previously silent
- addressed: close button icon regression in `QuickExamples.svelte`
- addressed: duplicate benchmark close path by centralizing cleanup in the reactive effect
- intentionally not changed: Phase 2 chat migration, because the docs explicitly lock fresh unified storage with no migration
- intentionally not changed: `MODE_COPY` staying frontend-owned for Phase 2

## Validation
- `npm run check --workspace apps/codehelper`
- `cargo check -p smolpc-code-helper`
- `cargo test -p smolpc-code-helper --lib`
- `npx prettier --check` on changed frontend files
- `npx eslint --max-warnings 0` on changed frontend files