### PR TITLE
Phase 3: polish unified Code mode

### DIFF
--- a/apps/codehelper/src-tauri/src/modes/config.rs
+++ b/apps/codehelper/src-tauri/src/modes/config.rs
@@ -19,14 +19,14 @@ pub fn mode_config(mode: AppMode) -> ModeConfigDto {
         AppMode::Code => ModeConfigDto {
             id: AppMode::Code,
             label: "Code".to_string(),
-            subtitle: "Coding help inside the shared SmolPC app".to_string(),
+            subtitle: "Codehelper workspace for fixes, explanations, and new code".to_string(),
             icon: "code".to_string(),
             provider_kind: ProviderKind::Local,
             system_prompt_key: "mode.code.default".to_string(),
             suggestions: vec![
-                "Explain this error".to_string(),
-                "Write a function".to_string(),
-                "Review this snippet".to_string(),
+                "Fix this bug and explain the root cause".to_string(),
+                "Write a function from this prompt".to_string(),
+                "Review this snippet for mistakes".to_string(),
             ],
             capabilities: ModeCapabilitiesDto {
                 supports_tools: false,

--- a/apps/codehelper/src/App.svelte
+++ b/apps/codehelper/src/App.svelte
@@ -18,7 +18,12 @@
 	import { uiStore } from '$lib/stores/ui.svelte';
 	import { applyTheme, watchSystemTheme } from '$lib/utils/theme';
 	import type { Message } from '$lib/types/chat';
-	import type { GenerationConfig, InferenceChatMessage } from '$lib/types/inference';
+	import type {
+		GenerationConfig,
+		InferenceBackend,
+		InferenceChatMessage,
+		InferenceStatus
+	} from '$lib/types/inference';
 	import type { AppMode } from '$lib/types/mode';
 
 	let messagesContainer: HTMLDivElement | undefined = $state();
@@ -33,6 +38,7 @@
 	const activeMode = $derived(modeStore.activeMode);
 	const activeModeConfig = $derived(modeStore.activeConfig);
 	const activeModeStatus = $derived(modeStore.activeStatus);
+	const inferenceStatus = $derived(inferenceStore.status);
 	const currentChat = $derived(chatsStore.getCurrentChatForMode(activeMode));
 	const messages = $derived(currentChat?.messages ?? []);
 	const hasNoChats = $derived(chatsStore.chats.length === 0);
@@ -45,7 +51,9 @@
 		Boolean(activeModeConfig?.capabilities.showExport) && messages.length > 0
 	);
 	const composerDisabledReason = $derived(canUseCodePath ? null : NON_CODE_DISABLED_REASON);
-	const pageTitle = $derived(currentChat?.title ?? 'New Chat');
+	const pageTitle = $derived(
+		currentChat?.title ?? (activeMode === 'code' ? 'New Code Chat' : 'New Chat')
+	);
 	const showBenchmarkPanel = $derived(uiStore.activeOverlay === 'benchmark');
 	const showHardwarePanel = $derived(uiStore.activeOverlay === 'hardware');
 	const showModelInfoPanel = $derived(uiStore.activeOverlay === 'modelInfo');
@@ -53,16 +61,96 @@
 	const latestAssistantMessageId = $derived(
 		[...messages].reverse().find((message) => message.role === 'assistant')?.id ?? null
 	);
+	function formatBackendLabel(backend: InferenceBackend | null): string | null {
+		if (!backend) {
+			return null;
+		}
+
+		switch (backend) {
+			case 'openvino_npu':
+				return 'OpenVINO NPU';
+			case 'directml':
+				return 'DirectML';
+			case 'cpu':
+				return 'CPU';
+			default:
+				return backend;
+		}
+	}
+
+	function buildCodeModeStatusLabel(status: InferenceStatus): string {
+		if (status.isGenerating) {
+			return 'generating';
+		}
+
+		switch (status.readinessState) {
+			case 'ready':
+				return formatBackendLabel(status.activeBackend)?.toLowerCase() ?? 'ready';
+			case 'failed':
+				return 'startup failed';
+			case 'idle':
+				return 'engine idle';
+			case 'starting':
+			case 'probing':
+			case 'resolving_assets':
+			case 'loading_model':
+				return 'starting engine';
+			default:
+				return 'status pending';
+		}
+	}
+
+	function buildCodeModeStatusDetail(
+		status: InferenceStatus,
+		shellWarning: string | null
+	): string | null {
+		const details: string[] = [];
+
+		if (shellWarning) {
+			details.push(`Shell warning: ${shellWarning}`);
+		}
+
+		if (status.readinessState === 'failed') {
+			if (status.startupErrorMessage) {
+				details.push(status.startupErrorMessage);
+			} else if (status.startupErrorCode) {
+				details.push(`Startup error: ${status.startupErrorCode}`);
+			}
+			return details.length > 0 ? details.join(' · ') : null;
+		}
+
+		if (status.currentModel) {
+			details.push(`Model: ${status.currentModel}`);
+		}
+
+		const backendLabel = formatBackendLabel(status.activeBackend);
+		if (backendLabel) {
+			details.push(`Backend: ${backendLabel}`);
+		}
+
+		if (status.isGenerating) {
+			details.push('Streaming response');
+		}
+
+		return details.length > 0 ? details.join(' · ') : null;
+	}
+
 	const modeStatusLabel = $derived(
-		activeModeStatus?.providerState
-			? activeModeStatus.providerState.state.replace(/_/g, ' ')
-			: modeStore.error
-				? 'fallback active'
-				: modeStore.loading
-					? 'loading'
-					: 'status pending'
+		canUseCodePath
+			? buildCodeModeStatusLabel(inferenceStatus)
+			: activeModeStatus?.providerState
+				? activeModeStatus.providerState.state.replace(/_/g, ' ')
+				: modeStore.error
+					? 'fallback active'
+					: modeStore.loading
+						? 'loading'
+						: 'status pending'
 	);
 	const modeStatusDetail = $derived.by(() => {
+		if (canUseCodePath) {
+			return buildCodeModeStatusDetail(inferenceStatus, modeStore.error);
+		}
+
 		const details = [
 			modeStore.error ? `Shell warning: ${modeStore.error}` : null,
 			activeModeStatus?.providerState.detail ?? null
@@ -527,7 +615,7 @@ Teaching rules:
 			modes={modeStore.modeConfigs}
 			{activeMode}
 			showSidebarToggle={!uiStore.isSidebarOpen}
-			status={inferenceStore.status}
+			status={inferenceStatus}
 			modelInfoActive={showModelInfoPanel}
 			hardwareActive={showHardwarePanel}
 			shortcutsOpen={showShortcutsOverlay}
@@ -548,6 +636,8 @@ Teaching rules:
 			{modeSubtitle}
 			suggestions={modeSuggestions}
 			providerState={activeModeStatus?.providerState ?? null}
+			statusLabel={modeStatusLabel}
+			statusDetail={modeStatusDetail}
 			{messages}
 			{latestAssistantMessageId}
 			showQuickExamples={uiStore.showQuickExamples}

--- a/apps/codehelper/src/lib/components/Sidebar.svelte
+++ b/apps/codehelper/src/lib/components/Sidebar.svelte
@@ -42,6 +42,10 @@
 	let pendingDeleteId: string | null = $state(null);
 	let recentlyDeleted = $state<DeletedChatSnapshot | null>(null);
 	let undoTimeoutId = $state<number | null>(null);
+	const appTitle = $derived(
+		activeMode === 'code' ? 'SmolPC Codehelper' : 'SmolPC Unified Assistant'
+	);
+	const newChatLabel = $derived(activeMode === 'code' ? 'New Code Chat' : 'New Chat');
 
 	const normalizedQuery = $derived(searchQuery.trim().toLowerCase());
 	const currentChatId = $derived(chatsStore.getCurrentChatIdForMode(activeMode));
@@ -189,7 +193,7 @@
 	<div class="sidebar__header">
 		<div class="sidebar__header-row">
 			<div>
-				<h1>SmolPC Unified Assistant</h1>
+				<h1>{appTitle}</h1>
 				<p>{activeModeLabel} · {activeModeSubtitle}</p>
 			</div>
 			{#if onClose}
@@ -208,7 +212,7 @@
 	</div>
 
 	<div class="sidebar__action">
-		<Button onclick={handleNewChat} class="sidebar__new-chat">New Chat</Button>
+		<Button onclick={handleNewChat} class="sidebar__new-chat">{newChatLabel}</Button>
 
 		<div class="sidebar__search-wrap">
 			<span class="sidebar__search-icon" aria-hidden="true">

--- a/apps/codehelper/src/lib/components/chat/ConversationView.svelte
+++ b/apps/codehelper/src/lib/components/chat/ConversationView.svelte
@@ -12,6 +12,8 @@
 		modeSubtitle: string;
 		suggestions: string[];
 		providerState?: ProviderStateDto | null;
+		statusLabel?: string | null;
+		statusDetail?: string | null;
 		messages: Message[];
 		latestAssistantMessageId: string | null;
 		showQuickExamples: boolean;
@@ -35,6 +37,8 @@
 		modeSubtitle,
 		suggestions,
 		providerState = null,
+		statusLabel = null,
+		statusDetail = null,
 		messages,
 		latestAssistantMessageId,
 		showQuickExamples,
@@ -98,6 +102,8 @@
 				{modeSubtitle}
 				{suggestions}
 				{providerState}
+				{statusLabel}
+				{statusDetail}
 				{showQuickExamples}
 				{disabledExamples}
 				{disabledReason}

--- a/apps/codehelper/src/lib/components/chat/WelcomeState.svelte
+++ b/apps/codehelper/src/lib/components/chat/WelcomeState.svelte
@@ -10,6 +10,8 @@
 		modeSubtitle: string;
 		suggestions: string[];
 		providerState?: ProviderStateDto | null;
+		statusLabel?: string | null;
+		statusDetail?: string | null;
 		showQuickExamples: boolean;
 		disabledExamples?: boolean;
 		disabledReason?: string | null;
@@ -23,6 +25,8 @@
 		modeSubtitle,
 		suggestions,
 		providerState = null,
+		statusLabel = null,
+		statusDetail = null,
 		showQuickExamples,
 		disabledExamples = false,
 		disabledReason = null,
@@ -32,34 +36,34 @@
 
 	const MODE_COPY: Record<AppMode, { chip: string; headline: string; description: string }> = {
 		code: {
-			chip: 'Code Mode',
-			headline: 'Build, debug, and explain code inside the unified shell.',
+			chip: 'Codehelper',
+			headline: 'Fix bugs, write new code, and ask for clear explanations.',
 			description:
-				'Phase 2 keeps the current Codehelper generation flow active while the rest of the unified frontend comes online.'
+				'Phase 3 keeps the real Codehelper generation path, model controls, and diagnostics active while the unified shell becomes its long-term home.'
 		},
 		gimp: {
 			chip: 'GIMP Mode',
 			headline: 'Stage image-edit workflows before the tool bridge is wired.',
 			description:
-				'Use this shell pass to see the final GIMP mode layout, prompts, and provider status without enabling execution yet.'
+				'The GIMP mode already reserves its shell layout, prompt surface, and provider status while execution is still disabled.'
 		},
 		blender: {
 			chip: 'Blender Mode',
 			headline: 'Preview scene-assistant workflows from the shared desktop shell.',
 			description:
-				'The Blender bridge is not connected in Phase 2, but the shell already reserves its mode identity and prompt surface.'
+				'The Blender bridge is not connected yet, but the shell already reserves its mode identity and prompt surface.'
 		},
 		writer: {
 			chip: 'Writer Mode',
 			headline: 'Draft document assistance stays visible while LibreOffice wiring lands later.',
 			description:
-				'Writer is present in the unified shell now so the later LibreOffice provider can drop into a stable, reviewed UI.'
+				'Writer is already present in the unified shell so the later LibreOffice provider can drop into a stable, reviewed UI.'
 		},
 		calc: {
 			chip: 'Calc Mode',
 			headline: 'Spreadsheet help gets a dedicated workspace before execution is enabled.',
 			description:
-				'Calc shares the same future LibreOffice backend, but Phase 2 only exposes the shell, history, and prompt starters.'
+				'Calc shares the future LibreOffice backend, but the shell currently only exposes its history, prompt starters, and provider status.'
 		},
 		impress: {
 			chip: 'Slides Mode',
@@ -88,9 +92,10 @@
 	);
 
 	const providerLabel = $derived(
-		providerState ? providerState.state.replace(/_/g, ' ') : 'status pending'
+		statusLabel ?? (providerState ? providerState.state.replace(/_/g, ' ') : 'status pending')
 	);
 	const heroCopy = $derived(MODE_COPY[mode]);
+	const detailCopy = $derived(statusDetail ?? providerState?.detail ?? null);
 </script>
 
 <div class="welcome-state">
@@ -106,8 +111,8 @@
 		<h2>{heroCopy.headline}</h2>
 		<p>{heroCopy.description}</p>
 		<p class="welcome-state__subtitle">{modeLabel} · {modeSubtitle}</p>
-		{#if providerState?.detail}
-			<p class="welcome-state__detail">{providerState.detail}</p>
+		{#if detailCopy}
+			<p class="welcome-state__detail">{detailCopy}</p>
 		{/if}
 	</div>
 

--- a/apps/codehelper/src/lib/types/mode.ts
+++ b/apps/codehelper/src/lib/types/mode.ts
@@ -29,11 +29,15 @@ export const FALLBACK_MODE_CONFIGS: ModeConfigDto[] = [
 	{
 		id: 'code',
 		label: 'Code',
-		subtitle: 'Coding help inside the shared SmolPC app',
+		subtitle: 'Codehelper workspace for fixes, explanations, and new code',
 		icon: 'code',
 		providerKind: 'local',
 		systemPromptKey: 'mode.code.default',
-		suggestions: ['Explain this error', 'Write a function', 'Review this snippet'],
+		suggestions: [
+			'Fix this bug and explain the root cause',
+			'Write a function from this prompt',
+			'Review this snippet for mistakes'
+		],
 		capabilities: {
 			supportsTools: false,
 			supportsUndo: false,


### PR DESCRIPTION
## Summary
- polish Code mode inside the unified shell without activating `assistant_send`
- show real Code-mode engine/backend status in the shell instead of scaffold provider copy
- align Code-mode metadata and shell wording so Code feels like Codehelper, not a placeholder

## Scope
- keeps the existing Codehelper inference path active
- does not change unified backend command contracts
- does not touch GIMP, Blender, or LibreOffice integrations

## Validation
- `npm run check --workspace apps/codehelper`
- `cargo check -p smolpc-code-helper`
- `cargo test -p smolpc-code-helper --lib`
- `npx prettier --check` on changed frontend files
- `npx eslint --max-warnings 0` on changed frontend files