### PR TITLE
Phase 5: lock Blender preflight

### DIFF
--- a/docs/unified-assistant-spec/ARCHITECTURE.md
+++ b/docs/unified-assistant-spec/ARCHITECTURE.md
@@ -60,7 +60,8 @@ merge plan for the unified frontend.
 |        v                  v                  v                   |
 |   Local Code        External GIMP      Blender hybrid           |
 |   provider          MCP provider       provider                 |
-|                                         (bridge first)          |
+|                                         (local bridge server    |
+|                                          + external addon)      |
 |                                                                  |
 |                    LibreOffice MCP provider                      |
 |                    shared by Writer/Calc/Slides                  |
@@ -93,7 +94,7 @@ The engine is never duplicated per mode.
 ### 4.3 External provider runtimes
 
 - GIMP MCP server
-- Blender bridge and optional supplementary MCP tooling
+- Blender bridge server hosted by the unified app plus the external addon
 - LibreOffice MCP runtime
 
 These are provider-owned integrations. They are not inference runtimes.
@@ -163,7 +164,9 @@ only in the command layer.
 
 - `CodeProvider` wraps in-app behavior and current Codehelper capabilities.
 - `GimpProvider` ports behavior from the GIMP assistant into new unified files.
-- `BlenderProvider` ports bridge-based Blender behavior into new unified files.
+- `BlenderProvider` ports bridge-based Blender behavior into new unified files
+  and owns the bridge runtime, scene cache, and retrieval index for the
+  unified app.
 - `LibreOfficeProvider` ports behavior from the LibreOffice branch into new
   unified files and serves three frontend submodes.
 
@@ -213,10 +216,22 @@ Mode switching does **not**:
 7. Backend streams:
    - status events
    - tool call/result events
-   - token events
+   - token events when the mode uses streaming generation
    - completion or error
 8. Frontend stores final response metadata
 ```
+
+### Phase 5 Blender request path
+
+After Phase 5:
+
+1. `assistant_send` is operational for `gimp` and `blender`.
+2. Blender requests use the hybrid provider path:
+   - ensure the local bridge runtime is available
+   - fetch current scene snapshot through the provider
+   - optionally retrieve Blender-doc contexts
+   - generate the tutoring answer through the shared engine
+3. Blender remains bridge-first. Supplemental MCP work stays deferred.
 
 ## 9. Repository Boundaries
 
@@ -226,6 +241,7 @@ All unified implementation lands under:
 
 - `apps/codehelper/`
 - new shared crates for assistant DTOs / MCP transport if needed
+- provider-owned bundled assets for modes such as Blender retrieval metadata
 
 ### 9.2 Reference-only app zones during the port
 

--- a/docs/unified-assistant-spec/CURRENT_STATE.md
+++ b/docs/unified-assistant-spec/CURRENT_STATE.md
@@ -1,7 +1,7 @@
 # Current State
 
 **Last Updated:** 2026-03-16
-**Phase:** Phase 4 GIMP mode is merged; Phase 5 Blender preflight is next
+**Phase:** Phase 5 Blender preflight is locked; implementation is next after docs merge into `dev/unified-assistant`
 
 ## Branch Roles
 
@@ -22,6 +22,7 @@
 | `codex/unified-gimp-mode-docs` | Merged Phase 4 preflight docs branch |
 | `codex/unified-gimp-mode` | Merged Phase 4 implementation branch |
 | `codex/unified-gimp-mode-status-docs` | Phase 4 closeout docs branch |
+| `codex/unified-blender-mode-docs` | Phase 5 preflight docs branch |
 
 ## What Is Done
 
@@ -196,6 +197,22 @@ Validation completed for the merged GIMP mode:
 - `npm run check --workspace apps/codehelper`
 - PR `#67` merged into `dev/unified-assistant`
 
+Phase 5 Blender preflight decisions are now locked on
+`docs/unified-assistant-spec`.
+
+Locked Blender Phase 5 behavior:
+
+- Blender becomes the second live non-Code mode after GIMP
+- `assistant_send` becomes operational for `mode === blender`
+- Blender stays bridge-first and shared-engine-only
+- Blender uses the existing addon protocol unchanged
+- bridge startup is lazy and non-fatal to unified app startup
+- Blender includes local Blender-doc retrieval grounding
+- Blender uses token streaming with cancellation
+- Blender keeps tutoring-style conversation actions that already fit the
+  unified shell
+- Writer / Calc / Slides remain placeholders
+
 The standalone apps remain source references during the future port:
 
 - `apps/gimp-assistant`
@@ -212,28 +229,29 @@ The standalone apps remain source references during the future port:
 
 ## Next Workstreams
 
-The next official step after these docs merge is `codex/unified-blender-mode-docs`:
+The next official step after this Blender preflight docs merge is the Phase 5
+implementation branch:
 
-1. create `codex/unified-blender-mode-docs`
-2. lock Phase 5 Blender behavior before code
-3. merge `codex/unified-blender-mode-docs` into `docs/unified-assistant-spec`
-4. merge `docs/unified-assistant-spec` into `dev/unified-assistant`
-5. create `codex/unified-blender-mode`
-6. port the bridge-backed Blender provider path into the unified adapter
-7. close out Phase 5 in docs
-8. continue serial merge order:
+1. merge `codex/unified-blender-mode-docs` into `docs/unified-assistant-spec`
+2. merge `docs/unified-assistant-spec` into `dev/unified-assistant`
+3. create `codex/unified-blender-mode`
+4. port the bridge-backed Blender provider path into the unified adapter
+5. close out Phase 5 in docs
+6. continue serial merge order:
    - Blender provider port
    - LibreOffice provider port
    - Hardening and Windows packaging validation
 
-The current merged GIMP implementation leaves these future phase boundaries
+The current merged GIMP implementation plus Blender preflight leaves these
+future phase boundaries
 intact:
 
-1. `assistant_send` remains scaffold-only for non-GIMP modes
+1. `assistant_send` remains scaffold-only for Writer / Calc / Slides
 2. Code mode still does not use the unified provider/orchestration path
 3. packaging still assumes an external GIMP install plus external MCP
    plugin/server runtime
-4. no standalone app directories were taken over by the unified branch
+4. Blender stays bridge-first and does not require `blender-mcp` in Phase 5
+5. no standalone app directories were taken over by the unified branch
 
 ## Known Risks
 

--- a/docs/unified-assistant-spec/FRONTEND_SPEC.md
+++ b/docs/unified-assistant-spec/FRONTEND_SPEC.md
@@ -108,7 +108,7 @@ export type AssistantStreamEvent =
 |---|---|---|---|
 | `code` | Code | local | Preserves current Codehelper experience |
 | `gimp` | GIMP | mcp | Adds tool status and undo affordances |
-| `blender` | Blender | hybrid | Uses bridge-backed scene workflows |
+| `blender` | Blender | hybrid | Uses bridge-backed scene tutoring with local retrieval grounding |
 | `writer` | Writer | mcp | LibreOffice submode |
 | `calc` | Calc | mcp | LibreOffice submode |
 | `impress` | Slides | mcp | LibreOffice submode with Slides label |
@@ -279,6 +279,22 @@ During Phase 4 GIMP work:
 - GIMP mode uses structured status / tool events and does not require token
   streaming in this phase.
 
+### Phase 5 Blender rule
+
+During Phase 5 Blender work:
+
+- Blender mode becomes a live shell mode with an enabled composer.
+- Blender mode uses `assistant_send()` rather than the existing Codehelper
+  inference path.
+- Blender mode uses the shared engine for final tutoring generation.
+- Blender mode uses token streaming with cancellation.
+- Blender mode uses bridge-backed scene status and local Blender-doc retrieval.
+- Code mode keeps the existing Codehelper inference path unchanged.
+- GIMP mode keeps the current Phase 4 structured-result path unchanged.
+- Writer, Calc, and Slides remain placeholder-only.
+- active Blender-mode status in the header should come from real provider state
+  rather than placeholder copy.
+
 ## 10. Suggestion Chips
 
 Suggestion chips are mode-specific empty-state actions.
@@ -287,7 +303,7 @@ Examples:
 
 - Code: "Explain this error", "Write a function", "Review this snippet"
 - GIMP: "Blur the top half of the image", "Crop this image to a square", "Rotate the image 90 degrees clockwise"
-- Blender: "Explain this scene", "Create a simple material", "Fix this modifier"
+- Blender: "What is in my scene right now?", "How do I add a bevel to the selected object?", "Explain what this modifier stack is doing"
 - Writer: "Draft a paragraph", "Rewrite this passage", "Summarize this text"
 - Calc: "Explain this formula", "Build a grade table", "Clean this data"
 - Slides: "Draft slide bullets", "Turn notes into slides", "Improve this outline"
@@ -320,6 +336,8 @@ mode work begins.
 - Phase 4 note: becomes operational for `gimp` only; it remains scaffold-only
   for the remaining non-Code modes and is still not used by active Code mode
   yet
+- Phase 5 note: becomes operational for `blender` as well, using token
+  streaming plus structured provider events
 
 ### `assistant_cancel()`
 
@@ -394,6 +412,23 @@ Before provider integrations land:
 - switching away from GIMP during execution is allowed and must not corrupt the
   originating GIMP chat.
 
+### Phase 5 Blender activation
+
+- Blender becomes the second live non-Code execution mode after GIMP.
+- Blender mode uses `assistantSend()` with token streaming.
+- Blender assistant messages may include:
+  - `reply`
+  - `toolResults`
+  - `plan`
+- Blender assistant messages keep tutoring-style chat actions where they fit
+  the unified shell:
+  - `Regenerate`
+  - `Continue`
+  - `Branch Chat`
+- Blender assistant messages do not render Undo in Phase 5.
+- switching away from Blender during execution is allowed and must not corrupt
+  the originating Blender chat.
+
 ## 14. Migration Path
 
 1. Preserve the current Codehelper shell as the shared shell.
@@ -403,7 +438,8 @@ Before provider integrations land:
    `assistant_send`.
 5. Port GIMP behavior into a new GIMP provider and activate `assistant_send`
    for `gimp` only.
-6. Port Blender behavior into a new Blender provider.
+6. Port Blender behavior into a new Blender provider and activate
+   `assistant_send` for `blender`.
 7. Port LibreOffice behavior into one provider with Writer/Calc/Slides
    frontend configs.
 

--- a/docs/unified-assistant-spec/IMPLEMENTATION_PHASES.md
+++ b/docs/unified-assistant-spec/IMPLEMENTATION_PHASES.md
@@ -1,7 +1,7 @@
 # Unified Assistant Implementation Phases
 
 **Last Updated:** 2026-03-16
-**Status:** Phase 4 GIMP mode is merged; Phase 5 Blender preflight is next
+**Status:** Phase 5 Blender preflight is locked; Blender implementation is next after docs merge into `dev/unified-assistant`
 
 ## Phase 0: Documentation Baseline
 
@@ -204,7 +204,30 @@
 **Scope**
 
 - port Blender bridge behavior into a Blender provider
-- preserve bridge-first workflows
+- keep Blender bridge-first and shared-engine-only
+- include scene-aware tutoring chat plus local Blender-doc retrieval grounding
+- preserve token streaming with cancellation
+- keep standalone Blender app code as a reference source rather than merging it
+
+**Phase 5 preflight decisions**
+
+- Blender becomes the second live non-Code mode after GIMP
+- `assistant_send` becomes operational for `blender`
+- Blender stays bridge-first and does not require `blender-mcp`
+- Blender keeps the existing addon bridge contract:
+  - `127.0.0.1:5179`
+  - `%LOCALAPPDATA%/SmolPC/engine-runtime/bridge-token.txt`
+- bridge startup is lazy and non-fatal to unified app startup
+- Blender uses shared engine only; no Ollama fallback UI or backend toggle in
+  the unified shell
+- Blender includes the standalone app's lightweight local retrieval path
+- Blender uses token streaming plus structured provider events
+- Blender keeps tutoring-style chat actions that fit the unified shell:
+  - `Regenerate`
+  - `Continue`
+  - `Branch Chat`
+- Blender undo remains unsupported in Phase 5
+- Writer / Calc / Slides remain placeholders
 
 **Exit criteria**
 
@@ -212,9 +235,15 @@
 
 **Current branch status**
 
-- Blender preflight docs are the next official step
-- `codex/unified-blender-mode` should not branch until its docs are merged into
-  both `docs/unified-assistant-spec` and `dev/unified-assistant`
+- Blender preflight docs are now locked on `docs/unified-assistant-spec`
+- `codex/unified-blender-mode` should not branch until these docs are merged
+  into both `docs/unified-assistant-spec` and `dev/unified-assistant`
+- the implementation branch should deliver:
+  - lazy bridge runtime startup
+  - live `mode_status(blender)` and `mode_refresh_tools(blender)`
+  - `assistant_send(mode=blender)` with token streaming
+  - scene snapshot plus retrieval-grounded tutoring prompts
+  - no edits to `apps/blender-assistant/`
 
 ## Phase 6: LibreOffice Modes
 

--- a/docs/unified-assistant-spec/MCP_INTEGRATION.md
+++ b/docs/unified-assistant-spec/MCP_INTEGRATION.md
@@ -174,7 +174,7 @@ Blender uses a hybrid provider.
 
 Primary path:
 
-- existing Blender bridge behavior
+- existing Blender bridge behavior hosted by the unified app
 
 Secondary path:
 
@@ -184,6 +184,95 @@ Rules:
 
 - bridge-backed workflows remain the primary behavior for parity
 - MCP expansion must not block the initial unified port
+- Phase 5 keeps Blender bridge-first and does not require `smolpc-mcp-client`
+  or `blender-mcp`
+- the unified app reuses the existing addon contract without modifying the
+  addon itself
+
+### 5.3.1 Blender Phase 5 bridge contract
+
+Phase 5 keeps the existing bridge compatibility surface:
+
+- bridge bind address: `127.0.0.1:5179`
+- auth token path:
+  `%LOCALAPPDATA%/SmolPC/engine-runtime/bridge-token.txt`
+- the unified app hosts the bridge server
+- the external Blender addon connects to that bridge
+
+Phase 5 startup rule:
+
+- bridge startup is lazy and non-fatal
+- a bridge bind failure degrades Blender mode only
+- a bind conflict must not stop the unified app from launching
+
+### 5.3.2 Blender Phase 5 tutoring surface
+
+Phase 5 Blender scope is scene-aware tutoring chat, not full standalone-app
+parity.
+
+Included in Phase 5:
+
+- live scene-aware question answering
+- local Blender-doc retrieval grounding
+- shared-engine generation
+- token streaming with cancellation
+- bridge-backed scene status in the unified shell
+- existing tutoring-style chat actions that fit the unified shell
+
+Deferred from Phase 5:
+
+- backend toggle UI
+- Ollama fallback UI
+- separate scene-analysis UI
+- standalone scene panel recreation
+- Blender undo
+- Blender export emphasis
+- Blender benchmark surfaces
+
+### 5.3.3 Blender Phase 5 pseudo-tools
+
+Phase 5 Blender does not add a general MCP tool surface.
+
+The provider exposes exactly two internal pseudo-tools:
+
+- `scene_current`
+- `retrieve_rag_context`
+
+The final tutoring answer is produced by the shared engine, not by a provider
+tool.
+
+### 5.3.4 Blender Phase 5 retrieval model
+
+Phase 5 ports the standalone Blender assistant's local retrieval approach:
+
+- bundled Blender documentation metadata
+- local keyword retrieval only
+- no vector database expansion
+- no remote retrieval service
+
+Retrieval rules:
+
+- skip retrieval for obvious scene-state questions
+- use retrieval for broader Blender workflow questions
+- retrieval load failure must degrade gracefully to scene-aware chat only
+
+### 5.3.5 Blender Phase 5 status semantics
+
+`mode_status(blender)` uses these states:
+
+- `disconnected`: bridge runtime is unavailable or could not be started
+- `connecting`: transient during explicit start or refresh work
+- `connected`: bridge runtime is healthy, even if no live scene snapshot is
+  currently available
+- `error`: startup or bridge interaction failed after the provider was tried
+
+Detail rules:
+
+- no scene snapshot yet must be surfaced clearly
+- stale scene snapshot must be surfaced clearly
+- missing live scene data does not disable generic Blender tutoring chat
+- `supports_tools = true`
+- `supports_undo = false`
 
 ### 5.4 LibreOffice provider
 
@@ -272,7 +361,7 @@ pub struct ModeStatusDto {
 |---|---|---|
 | Code | Not applicable | No-op |
 | GIMP | No, depends on external app availability | Disconnect cleanly; do not claim ownership of the external app |
-| Blender | Connect to bridge first; start helper process only if part of bridge contract | Clean disconnect from bridge |
+| Blender | Lazy-start local bridge server on first Blender use | Cleanly stop bridge runtime on app exit; do not claim ownership of Blender itself |
 | LibreOffice | Yes, provider may own its MCP runtime | Keep shared runtime alive across Writer/Calc/Slides switches |
 
 ## 8. Undo Support
@@ -281,7 +370,7 @@ pub struct ModeStatusDto {
 |---|---|
 | Code | Optional; not guaranteed in v1 |
 | GIMP | Yes, first-class where provider supports it |
-| Blender | Optional; depends on bridge/provider parity |
+| Blender | No in Phase 5 |
 | Writer | Optional; provider-backed if available |
 | Calc | Optional; provider-backed if available |
 | Slides | Optional; provider-backed if available |
@@ -326,6 +415,23 @@ Phase 4 activates the provider-backed command surface only for GIMP:
   `impress`
 - Code mode keeps the existing Codehelper inference path rather than routing
   through `assistant_send`
+
+## 9.3 Phase 5 Blender activation rule
+
+Phase 5 activates the provider-backed command surface for Blender while keeping
+Code and GIMP behavior stable:
+
+- `assistant_send` is operational for `mode == blender`
+- `assistant_send` remains shared-engine-backed for Blender rather than using
+  MCP transport
+- `mode_status(blender)` reports live bridge runtime state and internal
+  pseudo-tool availability
+- `mode_refresh_tools(blender)` performs a real bridge/runtime refresh and
+  retrieval reload attempt
+- `mode_undo(blender)` remains unsupported
+- Code mode keeps the existing Codehelper inference path
+- GIMP mode keeps the current Phase 4 MCP-backed execution path
+- `assistant_send` remains scaffold-only for `writer`, `calc`, and `impress`
 
 ## 10. Planner Boundary
 

--- a/docs/unified-assistant-spec/PACKAGING.md
+++ b/docs/unified-assistant-spec/PACKAGING.md
@@ -89,6 +89,22 @@ Phase 4 assumes:
 Phase 4 packaging validation covers connection to an external GIMP setup, not
 auto-install or first-run provisioning of GIMP.
 
+### 5.2.2 Phase 5 Blender runtime rule
+
+Phase 5 does not bundle Blender itself and does not bundle the Blender addon as
+part of the unified app.
+
+Phase 5 assumes:
+
+- Blender is installed separately
+- the Blender addon is installed separately
+- the unified app hosts the local bridge server used by the addon
+- the unified app bundles only Blender-provider-owned assets such as retrieval
+  metadata and bridge helper support files
+
+Phase 5 packaging validation covers connection to an external Blender setup and
+addon, not Blender installation or addon auto-provisioning.
+
 ### 5.3 No launcher-owned runtime paths
 
 Do not require packaged resources to live under a launcher-specific directory.
@@ -115,6 +131,8 @@ The packaging plan is valid only after Windows verification covers:
   Tauri build-time path checks
 - external apps are launched separately for provider testing
 - engine host may resolve from workspace `target/`
+- Blender provider testing assumes the unified app hosts the bridge and the
+  separately installed addon connects to it
 
 ### Packaged
 
@@ -139,6 +157,7 @@ Before calling the packaging plan complete, verify:
 - runtime assets resolve correctly
 - GIMP mode fails gracefully if GIMP is not installed or not running
 - Blender mode fails gracefully if Blender bridge is unavailable
+- Blender mode fails gracefully if port `5179` is already occupied
 - Writer/Calc/Slides can each connect through the shared LibreOffice provider
 
 ## 10. Deferred Packaging Questions


### PR DESCRIPTION
## Summary\n- lock Phase 5 Blender bridge-first/shared-engine-only preflight decisions\n- define Phase 5 Blender shell behavior, packaging assumptions, and activation scope\n- update current state and implementation phase tracking\n\n## Validation\n- git diff --check