### PR TITLE
Docs: close out Phase 5 Blender state

### DIFF
--- a/docs/unified-assistant-spec/CURRENT_STATE.md
+++ b/docs/unified-assistant-spec/CURRENT_STATE.md
@@ -1,7 +1,7 @@
 # Current State
 
 **Last Updated:** 2026-03-16
-**Phase:** Phase 5 Blender preflight is locked; implementation is next after docs merge into `dev/unified-assistant`
+**Phase:** Phase 5 Blender mode is merged; Phase 6 LibreOffice preflight is next
 
 ## Branch Roles
 
@@ -22,7 +22,9 @@
 | `codex/unified-gimp-mode-docs` | Merged Phase 4 preflight docs branch |
 | `codex/unified-gimp-mode` | Merged Phase 4 implementation branch |
 | `codex/unified-gimp-mode-status-docs` | Phase 4 closeout docs branch |
-| `codex/unified-blender-mode-docs` | Phase 5 preflight docs branch |
+| `codex/unified-blender-mode-docs` | Merged Phase 5 preflight docs branch |
+| `codex/unified-blender-mode` | Merged Phase 5 implementation branch |
+| `codex/unified-blender-mode-status-docs` | Phase 5 closeout docs branch |
 
 ## What Is Done
 
@@ -197,21 +199,42 @@ Validation completed for the merged GIMP mode:
 - `npm run check --workspace apps/codehelper`
 - PR `#67` merged into `dev/unified-assistant`
 
-Phase 5 Blender preflight decisions are now locked on
-`docs/unified-assistant-spec`.
+Phase 5 Blender mode is now merged into `dev/unified-assistant` via PR `#69`.
 
-Locked Blender Phase 5 behavior:
+Merged Blender behavior now present in `dev/unified-assistant`:
 
-- Blender becomes the second live non-Code mode after GIMP
-- `assistant_send` becomes operational for `mode === blender`
+- `assistant_send` is now operational for `mode === blender`
+- `mode_status(blender)` now reports live provider state from the lazy-start
+  bridge-backed Blender provider
+- `mode_refresh_tools(blender)` now refreshes bridge/runtime health and
+  pseudo-tool availability
 - Blender stays bridge-first and shared-engine-only
-- Blender uses the existing addon protocol unchanged
-- bridge startup is lazy and non-fatal to unified app startup
-- Blender includes local Blender-doc retrieval grounding
-- Blender uses token streaming with cancellation
-- Blender keeps tutoring-style conversation actions that already fit the
-  unified shell
-- Writer / Calc / Slides remain placeholders
+- the unified app now hosts the local Blender bridge server on
+  `127.0.0.1:5179`
+- bridge startup is lazy and non-fatal to unified app startup; port conflicts
+  degrade Blender mode only
+- the unified app now bundles provider-owned Blender retrieval metadata under
+  `apps/codehelper/src-tauri/resources/blender/rag_system/simple_db/metadata.json`
+- Blender questions now use scene snapshot plus local Blender-doc retrieval
+  grounding when appropriate
+- Blender uses token streaming with cancellation through the shared
+  `assistant_send` surface
+- Blender assistant messages keep tutoring-style conversation actions that fit
+  the unified shell:
+  - `Regenerate`
+  - `Continue`
+  - `Branch Chat`
+- Blender undo remains unsupported
+- Code mode still uses the existing Codehelper inference path
+- GIMP keeps the Phase 4 MCP-backed path unchanged
+- Writer / Calc / Slides remain visible placeholders
+
+Validation completed for the merged Blender mode:
+
+- `cargo check -p smolpc-code-helper`
+- `cargo test -p smolpc-code-helper --lib`
+- `npm run check --workspace apps/codehelper`
+- PR `#69` merged into `dev/unified-assistant`
 
 The standalone apps remain source references during the future port:
 
@@ -221,7 +244,7 @@ The standalone apps remain source references during the future port:
 
 ## What Has Not Started
 
-- real provider integrations for Blender or LibreOffice
+- real provider integrations for LibreOffice
 - mode provider ports
 - launcher cleanup beyond the foundation test fix
 - unified-app packaging hardening beyond the tracked OpenVINO placeholder
@@ -229,22 +252,21 @@ The standalone apps remain source references during the future port:
 
 ## Next Workstreams
 
-The next official step after this Blender preflight docs merge is the Phase 5
-implementation branch:
+The next official step after this Blender closeout docs merge is the Phase 6
+LibreOffice docs preflight branch:
 
-1. merge `codex/unified-blender-mode-docs` into `docs/unified-assistant-spec`
-2. merge `docs/unified-assistant-spec` into `dev/unified-assistant`
-3. create `codex/unified-blender-mode`
-4. port the bridge-backed Blender provider path into the unified adapter
-5. close out Phase 5 in docs
-6. continue serial merge order:
-   - Blender provider port
+1. create `codex/unified-libreoffice-mode-docs`
+2. lock the shared LibreOffice provider design in docs
+3. merge docs into `docs/unified-assistant-spec`
+4. merge `docs/unified-assistant-spec` into `dev/unified-assistant`
+5. create `codex/unified-libreoffice-mode`
+6. close out Phase 6 in docs
+7. continue serial merge order:
    - LibreOffice provider port
    - Hardening and Windows packaging validation
 
-The current merged GIMP implementation plus Blender preflight leaves these
-future phase boundaries
-intact:
+The current merged GIMP and Blender implementations leave these future phase
+boundaries intact:
 
 1. `assistant_send` remains scaffold-only for Writer / Calc / Slides
 2. Code mode still does not use the unified provider/orchestration path

--- a/docs/unified-assistant-spec/FRONTEND_SPEC.md
+++ b/docs/unified-assistant-spec/FRONTEND_SPEC.md
@@ -294,6 +294,9 @@ During Phase 5 Blender work:
 - Writer, Calc, and Slides remain placeholder-only.
 - active Blender-mode status in the header should come from real provider state
   rather than placeholder copy.
+- switching away from Blender during generation is allowed, but starting a
+  competing live-mode request while Blender still owns the shared engine is
+  blocked until the active request finishes or is cancelled.
 
 ## 10. Suggestion Chips
 
@@ -428,6 +431,8 @@ Before provider integrations land:
 - Blender assistant messages do not render Undo in Phase 5.
 - switching away from Blender during execution is allowed and must not corrupt
   the originating Blender chat.
+- the shell must not allow a competing live-mode request to start while Blender
+  is still streaming through the shared engine.
 
 ## 14. Migration Path
 

--- a/docs/unified-assistant-spec/IMPLEMENTATION_PHASES.md
+++ b/docs/unified-assistant-spec/IMPLEMENTATION_PHASES.md
@@ -1,7 +1,7 @@
 # Unified Assistant Implementation Phases
 
 **Last Updated:** 2026-03-16
-**Status:** Phase 5 Blender preflight is locked; Blender implementation is next after docs merge into `dev/unified-assistant`
+**Status:** Phase 5 Blender mode is merged; Phase 6 LibreOffice preflight is next
 
 ## Phase 0: Documentation Baseline
 
@@ -44,17 +44,15 @@
   - tracked OpenVINO placeholder directory
   - clean frontend audit lockfile
 
-## Branch Order After Phase 4
+## Branch Order After Phase 5
 
-1. `codex/unified-blender-mode-docs`
+1. `codex/unified-libreoffice-mode-docs`
 2. merge into `docs/unified-assistant-spec`
 3. merge `docs/unified-assistant-spec` into `dev/unified-assistant`
-4. `codex/unified-blender-mode`
+4. `codex/unified-libreoffice-mode`
 5. closeout docs
-6. `codex/unified-libreoffice-mode-docs`
-7. `codex/unified-libreoffice-mode`
-8. `codex/unified-hardening-docs`
-9. `codex/unified-hardening`
+6. `codex/unified-hardening-docs`
+7. `codex/unified-hardening`
 
 ## Phase 2: Unified Shell
 
@@ -235,14 +233,17 @@
 
 **Current branch status**
 
-- Blender preflight docs are now locked on `docs/unified-assistant-spec`
-- `codex/unified-blender-mode` should not branch until these docs are merged
-  into both `docs/unified-assistant-spec` and `dev/unified-assistant`
-- the implementation branch should deliver:
-  - lazy bridge runtime startup
+- preflight docs merged into `docs/unified-assistant-spec`, then into
+  `dev/unified-assistant`
+- implementation merged via PR `#69`
+- merged Blender behavior now present in `dev/unified-assistant`:
+  - lazy bridge runtime startup hosted by the unified app
   - live `mode_status(blender)` and `mode_refresh_tools(blender)`
   - `assistant_send(mode=blender)` with token streaming
   - scene snapshot plus retrieval-grounded tutoring prompts
+  - Blender shell copy and prompt starters now reflect a live mode
+  - Blender assistant messages keep `Regenerate`, `Continue`, and
+    `Branch Chat`
   - no edits to `apps/blender-assistant/`
 
 ## Phase 6: LibreOffice Modes

--- a/docs/unified-assistant-spec/LEARNINGS.md
+++ b/docs/unified-assistant-spec/LEARNINGS.md
@@ -73,6 +73,8 @@
 
 - **Optional message metadata is the safest way to mix mode-specific UIs** (2026-03): Phase 4 needed GIMP assistant messages to carry `explain`, `undoable`, `toolResults`, and `plan` without breaking existing Code chats. Extending the shared `Message` shape with optional fields preserved backward compatibility while still allowing mode-specific rendering and actions.
 
+- **Live non-Code modes still need a single shared-generation gate** (2026-03): Phase 5 made Blender a second live non-Code mode, but it still shares the same engine runtime as Code. The shell can allow mode switching during Blender generation, yet it must block starting a competing Code or GIMP request until the active non-Code run finishes or is cancelled.
+
 ---
 
 ## MCP
@@ -94,6 +96,8 @@
 - **Mode-by-mode activation can reuse one command surface** (2026-03): Phase 4 made `assistant_send`, `mode_status`, `mode_refresh_tools`, and `mode_undo` real for GIMP without changing command names or DTOs. The stable command surface from Phase 1 was sufficient; only the mode-specific implementation behind it changed.
 
 - **GIMP status must attempt a real connection to be useful** (2026-03): A cached placeholder state is not enough once GIMP becomes a live mode. The unified GIMP provider needs `status()` to attempt live MCP initialization and tool discovery so the header and welcome state can show an honest connected/disconnected result immediately on mode switch.
+
+- **Scene-query heuristics must stay narrower than workflow questions** (2026-03): Blender retrieval should be skipped for pure scene-state questions like "What is in my scene right now?", but not for workflow questions that happen to mention scene nouns such as "selected object". Broad substring heuristics accidentally suppress retrieval on legitimate tutoring questions.
 
 ---
 
@@ -140,6 +144,8 @@
 - **Context compaction is the biggest risk** (2026-03): Long AI sessions lose synthesized research when context compacts. Always persist findings to documentation files before they're lost. This entire docs/unified-assistant-spec directory was created specifically to prevent research loss.
 
 - **Dirty clones need selective staging, not cleanup churn** (2026-03): The shared clone used for unified work can contain unrelated local diffs from other workstreams. For implementation branches, stage only the files that belong to the phase and leave unrelated dirt alone instead of widening the branch scope with cleanup commits.
+
+- **Bridge handles need explicit drop cleanup or Rust tests can hang** (2026-03): Lazy-start provider runtimes that spawn local servers must stop those tasks when the handle is dropped. Without explicit cleanup, the lib test binary can finish its assertions but never exit because detached bridge tasks are still alive.
 
 ---
 

--- a/docs/unified-assistant-spec/PACKAGING.md
+++ b/docs/unified-assistant-spec/PACKAGING.md
@@ -101,6 +101,10 @@ Phase 5 assumes:
 - the unified app hosts the local bridge server used by the addon
 - the unified app bundles only Blender-provider-owned assets such as retrieval
   metadata and bridge helper support files
+- the current Phase 5 retrieval bundle is
+  `apps/codehelper/src-tauri/resources/blender/rag_system/simple_db/metadata.json`
+  because the unified Blender provider uses lightweight keyword retrieval and
+  does not need vector-database assets in v1
 
 Phase 5 packaging validation covers connection to an external Blender setup and
 addon, not Blender installation or addon auto-provisioning.


### PR DESCRIPTION
## Summary
- record the merged Phase 5 Blender implementation state
- note the live Blender mode behavior now present in dev/unified-assistant
- set Phase 6 LibreOffice docs preflight as the next official step