### PR TITLE
Docs: normalize Phase 5 Blender cleanup notes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docs/unified-assistant-spec/*.md text eol=lf

--- a/docs/unified-assistant-spec/ARCHITECTURE.md
+++ b/docs/unified-assistant-spec/ARCHITECTURE.md
@@ -17,14 +17,14 @@ merge plan for the unified frontend.
 
 ## 2. Modes
 
-| Mode | Internal Id | Provider Kind | Source Reference |
-|---|---|---|---|
-| Code | `code` | Local provider | `apps/codehelper/` |
-| GIMP | `gimp` | MCP provider | `apps/gimp-assistant/` |
-| Blender | `blender` | Hybrid provider | `apps/blender-assistant/` |
-| Writer | `writer` | MCP provider | `apps/libreoffice-assistant/` |
-| Calc | `calc` | MCP provider | `apps/libreoffice-assistant/` |
-| Slides | `impress` | MCP provider | `apps/libreoffice-assistant/` |
+| Mode    | Internal Id | Provider Kind   | Source Reference              |
+| ------- | ----------- | --------------- | ----------------------------- |
+| Code    | `code`      | Local provider  | `apps/codehelper/`            |
+| GIMP    | `gimp`      | MCP provider    | `apps/gimp-assistant/`        |
+| Blender | `blender`   | Hybrid provider | `apps/blender-assistant/`     |
+| Writer  | `writer`    | MCP provider    | `apps/libreoffice-assistant/` |
+| Calc    | `calc`      | MCP provider    | `apps/libreoffice-assistant/` |
+| Slides  | `impress`   | MCP provider    | `apps/libreoffice-assistant/` |
 
 ## 3. High-Level System
 
@@ -268,13 +268,13 @@ and then be pulled into the unified branches.
 
 ## 10. Merge-Safe Boundaries
 
-| Area | Rule |
-|---|---|
-| Unified shell | Implement in `apps/codehelper` only |
-| Standalone apps | Port behavior into adapters; do not merge directories |
-| Engine | Prefer contract reuse over direct internal edits |
-| Packaging | Document and validate after provider integration, not before |
-| Launcher | Out of scope for runtime ownership |
+| Area            | Rule                                                         |
+| --------------- | ------------------------------------------------------------ |
+| Unified shell   | Implement in `apps/codehelper` only                          |
+| Standalone apps | Port behavior into adapters; do not merge directories        |
+| Engine          | Prefer contract reuse over direct internal edits             |
+| Packaging       | Document and validate after provider integration, not before |
+| Launcher        | Out of scope for runtime ownership                           |
 
 ## 11. Critical Invariants
 

--- a/docs/unified-assistant-spec/CURRENT_STATE.md
+++ b/docs/unified-assistant-spec/CURRENT_STATE.md
@@ -5,26 +5,26 @@
 
 ## Branch Roles
 
-| Branch | Role |
-|---|---|
-| `docs/unified-assistant-spec` | Canonical architecture/spec branch |
-| `dev/unified-assistant` | Implementation mainline after docs merge |
-| `codex/unified-foundation` | Merged Phase 1 implementation branch |
-| `codex/unified-foundation-status-docs` | Phase 1 closeout docs branch |
-| `codex/unified-shell-docs` | Merged Phase 2 preflight docs branch |
-| `codex/unified-shell` | Merged Phase 2 shell implementation branch |
-| `codex/unified-shell-status-docs` | Merged Phase 2 closeout docs branch |
-| `codex/unified-shell-followups` | Merged post-Phase-2 shell hardening branch |
-| `codex/unified-shell-followups-status-docs` | Merged shell follow-up docs sync branch |
-| `codex/unified-code-mode-docs` | Merged Phase 3 preflight docs branch |
-| `codex/unified-code-mode` | Merged Phase 3 implementation branch |
-| `codex/unified-code-mode-status-docs` | Merged Phase 3 closeout docs branch |
-| `codex/unified-gimp-mode-docs` | Merged Phase 4 preflight docs branch |
-| `codex/unified-gimp-mode` | Merged Phase 4 implementation branch |
-| `codex/unified-gimp-mode-status-docs` | Phase 4 closeout docs branch |
-| `codex/unified-blender-mode-docs` | Merged Phase 5 preflight docs branch |
-| `codex/unified-blender-mode` | Merged Phase 5 implementation branch |
-| `codex/unified-blender-mode-status-docs` | Phase 5 closeout docs branch |
+| Branch                                      | Role                                       |
+| ------------------------------------------- | ------------------------------------------ |
+| `docs/unified-assistant-spec`               | Canonical architecture/spec branch         |
+| `dev/unified-assistant`                     | Implementation mainline after docs merge   |
+| `codex/unified-foundation`                  | Merged Phase 1 implementation branch       |
+| `codex/unified-foundation-status-docs`      | Phase 1 closeout docs branch               |
+| `codex/unified-shell-docs`                  | Merged Phase 2 preflight docs branch       |
+| `codex/unified-shell`                       | Merged Phase 2 shell implementation branch |
+| `codex/unified-shell-status-docs`           | Merged Phase 2 closeout docs branch        |
+| `codex/unified-shell-followups`             | Merged post-Phase-2 shell hardening branch |
+| `codex/unified-shell-followups-status-docs` | Merged shell follow-up docs sync branch    |
+| `codex/unified-code-mode-docs`              | Merged Phase 3 preflight docs branch       |
+| `codex/unified-code-mode`                   | Merged Phase 3 implementation branch       |
+| `codex/unified-code-mode-status-docs`       | Merged Phase 3 closeout docs branch        |
+| `codex/unified-gimp-mode-docs`              | Merged Phase 4 preflight docs branch       |
+| `codex/unified-gimp-mode`                   | Merged Phase 4 implementation branch       |
+| `codex/unified-gimp-mode-status-docs`       | Phase 4 closeout docs branch               |
+| `codex/unified-blender-mode-docs`           | Merged Phase 5 preflight docs branch       |
+| `codex/unified-blender-mode`                | Merged Phase 5 implementation branch       |
+| `codex/unified-blender-mode-status-docs`    | Phase 5 closeout docs branch               |
 
 ## What Is Done
 
@@ -277,13 +277,13 @@ boundaries intact:
 
 ## Known Risks
 
-| Risk | Impact |
-|---|---|
-| Engine branch churn | unified app may need contract updates while the engine is still evolving |
-| Standalone app branch churn | Blender and LibreOffice behavior may continue changing during the remaining ports |
+| Risk                              | Impact                                                                                   |
+| --------------------------------- | ---------------------------------------------------------------------------------------- |
+| Engine branch churn               | unified app may need contract updates while the engine is still evolving                 |
+| Standalone app branch churn       | Blender and LibreOffice behavior may continue changing during the remaining ports        |
 | External GIMP runtime assumptions | Phase 4 depends on a separate GIMP install and MCP plugin/server already being available |
-| Packaging/runtime validation | third-party runtime paths may behave differently in packaged Windows builds |
-| LibreOffice port alignment | the LibreOffice branch must stay aligned with the unified provider design |
+| Packaging/runtime validation      | third-party runtime paths may behave differently in packaged Windows builds              |
+| LibreOffice port alignment        | the LibreOffice branch must stay aligned with the unified provider design                |
 
 ## Merge-Safe Rules
 

--- a/docs/unified-assistant-spec/FRONTEND_SPEC.md
+++ b/docs/unified-assistant-spec/FRONTEND_SPEC.md
@@ -31,87 +31,81 @@ for six modes:
 ## 3. Frontend Types
 
 ```ts
-export type AppMode =
-  | 'code'
-  | 'gimp'
-  | 'blender'
-  | 'writer'
-  | 'calc'
-  | 'impress';
+export type AppMode = 'code' | 'gimp' | 'blender' | 'writer' | 'calc' | 'impress';
 
 export interface ModeCapabilities {
-  supportsTools: boolean;
-  supportsUndo: boolean;
-  showModelInfo: boolean;
-  showHardwarePanel: boolean;
-  showBenchmarkPanel: boolean;
-  showExport: boolean;
-  showContextControls: boolean;
+	supportsTools: boolean;
+	supportsUndo: boolean;
+	showModelInfo: boolean;
+	showHardwarePanel: boolean;
+	showBenchmarkPanel: boolean;
+	showExport: boolean;
+	showContextControls: boolean;
 }
 
 export interface ModeConfig {
-  id: AppMode;
-  label: string;
-  subtitle: string;
-  icon: string;
-  providerKind: 'local' | 'mcp' | 'hybrid';
-  systemPromptKey: string;
-  suggestions: string[];
-  capabilities: ModeCapabilities;
+	id: AppMode;
+	label: string;
+	subtitle: string;
+	icon: string;
+	providerKind: 'local' | 'mcp' | 'hybrid';
+	systemPromptKey: string;
+	suggestions: string[];
+	capabilities: ModeCapabilities;
 }
 
 export interface Chat {
-  id: string;
-  mode: AppMode;
-  title: string;
-  messages: Message[];
-  createdAt: number;
-  updatedAt: number;
-  model: string;
-  pinned?: boolean;
-  archived?: boolean;
+	id: string;
+	mode: AppMode;
+	title: string;
+	messages: Message[];
+	createdAt: number;
+	updatedAt: number;
+	model: string;
+	pinned?: boolean;
+	archived?: boolean;
 }
 
 export interface Message {
-  id: string;
-  role: 'user' | 'assistant';
-  content: string;
-  timestamp: number;
-  isStreaming?: boolean;
-  explain?: string | null;
-  undoable?: boolean;
-  toolResults?: ToolExecutionResultDto[];
-  plan?: unknown;
-  status?: 'pending' | 'complete' | 'error';
+	id: string;
+	role: 'user' | 'assistant';
+	content: string;
+	timestamp: number;
+	isStreaming?: boolean;
+	explain?: string | null;
+	undoable?: boolean;
+	toolResults?: ToolExecutionResultDto[];
+	plan?: unknown;
+	status?: 'pending' | 'complete' | 'error';
 }
 
 export interface ModeStatus {
-  mode: AppMode;
-  engineReady: boolean;
-  providerState: ProviderStateDto;
-  availableTools: ToolDefinitionDto[];
-  lastError: string | null;
+	mode: AppMode;
+	engineReady: boolean;
+	providerState: ProviderStateDto;
+	availableTools: ToolDefinitionDto[];
+	lastError: string | null;
 }
 
 export type AssistantStreamEvent =
-  | { kind: 'status'; phase: string; detail: string }
-  | { kind: 'tool_call'; name: string; arguments: unknown }
-  | { kind: 'tool_result'; name: string; result: ToolExecutionResultDto }
-  | { kind: 'token'; token: string }
-  | { kind: 'complete'; response: AssistantResponseDto }
-  | { kind: 'error'; code: string; message: string };
+	| { kind: 'status'; phase: string; detail: string }
+	| { kind: 'tool_call'; name: string; arguments: unknown }
+	| { kind: 'tool_result'; name: string; result: ToolExecutionResultDto }
+	| { kind: 'token'; token: string }
+	| { kind: 'complete'; response: AssistantResponseDto }
+	| { kind: 'error'; code: string; message: string };
 ```
 
 ## 4. Mode Configuration
 
-| Mode | Label | Provider | Shared shell notes |
-|---|---|---|---|
-| `code` | Code | local | Preserves current Codehelper experience |
-| `gimp` | GIMP | mcp | Adds tool status and undo affordances |
-| `blender` | Blender | hybrid | Uses bridge-backed scene tutoring with local retrieval grounding |
-| `writer` | Writer | mcp | LibreOffice submode |
-| `calc` | Calc | mcp | LibreOffice submode |
-| `impress` | Slides | mcp | LibreOffice submode with Slides label |
+| Mode      | Label   | Provider | Shared shell notes                                               |
+| --------- | ------- | -------- | ---------------------------------------------------------------- |
+| `code`    | Code    | local    | Preserves current Codehelper experience                          |
+| `gimp`    | GIMP    | mcp      | Adds tool status and undo affordances                            |
+| `blender` | Blender | hybrid   | Uses bridge-backed scene tutoring with local retrieval grounding |
+| `writer`  | Writer  | mcp      | LibreOffice submode                                              |
+| `calc`    | Calc    | mcp      | LibreOffice submode                                              |
+| `impress` | Slides  | mcp      | LibreOffice submode with Slides label                            |
 
 ## 5. Shared Shell
 
@@ -432,7 +426,8 @@ Before provider integrations land:
 - switching away from Blender during execution is allowed and must not corrupt
   the originating Blender chat.
 - the shell must not allow a competing live-mode request to start while Blender
-  is still streaming through the shared engine.
+  is still streaming through the shared engine until the active request finishes
+  or is cancelled.
 
 ## 14. Migration Path
 

--- a/docs/unified-assistant-spec/IMPLEMENTATION_PHASES.md
+++ b/docs/unified-assistant-spec/IMPLEMENTATION_PHASES.md
@@ -215,6 +215,9 @@
 - Blender keeps the existing addon bridge contract:
   - `127.0.0.1:5179`
   - `%LOCALAPPDATA%/SmolPC/engine-runtime/bridge-token.txt`
+- the Windows packaging path above is canonical; non-Windows dev/test
+  environments may use the platform-appropriate local app-data equivalent while
+  preserving the same addon-facing token-file contract
 - bridge startup is lazy and non-fatal to unified app startup
 - Blender uses shared engine only; no Ollama fallback UI or backend toggle in
   the unified shell
@@ -285,12 +288,12 @@ These apply to every implementation phase:
 
 ## Windows Validation Milestones
 
-| Milestone | Required proof |
-|---|---|
-| Foundation ready | commands and DTOs compile cleanly |
-| Shell ready | six modes visible in one shell |
-| Code ready | existing Codehelper experience preserved |
-| GIMP ready | tool call and undo work |
-| Blender ready | bridge-backed workflow works |
+| Milestone         | Required proof                               |
+| ----------------- | -------------------------------------------- |
+| Foundation ready  | commands and DTOs compile cleanly            |
+| Shell ready       | six modes visible in one shell               |
+| Code ready        | existing Codehelper experience preserved     |
+| GIMP ready        | tool call and undo work                      |
+| Blender ready     | bridge-backed workflow works                 |
 | LibreOffice ready | Writer/Calc/Slides all work via one provider |
-| Packaging ready | packaged app runs without launcher ownership |
+| Packaging ready   | packaged app runs without launcher ownership |

--- a/docs/unified-assistant-spec/LEARNINGS.md
+++ b/docs/unified-assistant-spec/LEARNINGS.md
@@ -73,7 +73,7 @@
 
 - **Optional message metadata is the safest way to mix mode-specific UIs** (2026-03): Phase 4 needed GIMP assistant messages to carry `explain`, `undoable`, `toolResults`, and `plan` without breaking existing Code chats. Extending the shared `Message` shape with optional fields preserved backward compatibility while still allowing mode-specific rendering and actions.
 
-- **Live non-Code modes still need a single shared-generation gate** (2026-03): Phase 5 made Blender a second live non-Code mode, but it still shares the same engine runtime as Code. The shell can allow mode switching during Blender generation, yet it must block starting a competing Code or GIMP request until the active non-Code run finishes or is cancelled.
+- **Live non-Code modes still need a single shared-generation gate** (2026-03): Phase 5 made Blender a second live non-Code mode, but it still shares the same engine runtime as Code. The shell can allow mode switching during Blender generation, yet it must block starting any competing live-mode request until the active non-Code run finishes or is cancelled.
 
 ---
 

--- a/docs/unified-assistant-spec/MCP_INTEGRATION.md
+++ b/docs/unified-assistant-spec/MCP_INTEGRATION.md
@@ -14,11 +14,11 @@ every mode uses MCP, so this document defines a **provider model** that covers:
 
 ## 2. Provider Taxonomy
 
-| Provider kind | Used by | Notes |
-|---|---|---|
-| `local` | Code | No external MCP process required |
-| `mcp` | GIMP, Writer, Calc, Slides | JSON-RPC tool execution via MCP transport |
-| `hybrid` | Blender | Bridge-backed primary path, MCP-compatible extension path later |
+| Provider kind | Used by                    | Notes                                                           |
+| ------------- | -------------------------- | --------------------------------------------------------------- |
+| `local`       | Code                       | No external MCP process required                                |
+| `mcp`         | GIMP, Writer, Calc, Slides | JSON-RPC tool execution via MCP transport                       |
+| `hybrid`      | Blender                    | Bridge-backed primary path, MCP-compatible extension path later |
 
 ## 3. `ToolProvider` Abstraction
 
@@ -196,6 +196,9 @@ Phase 5 keeps the existing bridge compatibility surface:
 - bridge bind address: `127.0.0.1:5179`
 - auth token path:
   `%LOCALAPPDATA%/SmolPC/engine-runtime/bridge-token.txt`
+- on Windows packaging this is the canonical token path; non-Windows dev and
+  test environments may use the platform-appropriate local app-data equivalent
+  while preserving the same addon-facing token-file contract
 - the unified app hosts the bridge server
 - the external Blender addon connects to that bridge
 
@@ -255,6 +258,8 @@ Retrieval rules:
 - skip retrieval for obvious scene-state questions
 - use retrieval for broader Blender workflow questions
 - retrieval load failure must degrade gracefully to scene-aware chat only
+- retrieval load failure must be surfaced in provider detail so the shell can
+  report that Blender-doc grounding is temporarily unavailable
 
 ### 5.3.5 Blender Phase 5 status semantics
 
@@ -271,7 +276,9 @@ Detail rules:
 - no scene snapshot yet must be surfaced clearly
 - stale scene snapshot must be surfaced clearly
 - missing live scene data does not disable generic Blender tutoring chat
-- `supports_tools = true`
+- `supports_tools = true` because Blender exposes the internal pseudo-tools
+  `scene_current` and `retrieve_rag_context`, not because Phase 5 adds a
+  general external tool surface
 - `supports_undo = false`
 
 ### 5.4 LibreOffice provider
@@ -357,23 +364,23 @@ pub struct ModeStatusDto {
 
 ### Per-provider rules
 
-| Provider | Auto-start | Disconnect behavior |
-|---|---|---|
-| Code | Not applicable | No-op |
-| GIMP | No, depends on external app availability | Disconnect cleanly; do not claim ownership of the external app |
-| Blender | Lazy-start local bridge server on first Blender use | Cleanly stop bridge runtime on app exit; do not claim ownership of Blender itself |
-| LibreOffice | Yes, provider may own its MCP runtime | Keep shared runtime alive across Writer/Calc/Slides switches |
+| Provider    | Auto-start                                          | Disconnect behavior                                                               |
+| ----------- | --------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Code        | Not applicable                                      | No-op                                                                             |
+| GIMP        | No, depends on external app availability            | Disconnect cleanly; do not claim ownership of the external app                    |
+| Blender     | Lazy-start local bridge server on first Blender use | Cleanly stop bridge runtime on app exit; do not claim ownership of Blender itself |
+| LibreOffice | Yes, provider may own its MCP runtime               | Keep shared runtime alive across Writer/Calc/Slides switches                      |
 
 ## 8. Undo Support
 
-| Mode | Undo support |
-|---|---|
-| Code | Optional; not guaranteed in v1 |
-| GIMP | Yes, first-class where provider supports it |
-| Blender | No in Phase 5 |
-| Writer | Optional; provider-backed if available |
-| Calc | Optional; provider-backed if available |
-| Slides | Optional; provider-backed if available |
+| Mode    | Undo support                                |
+| ------- | ------------------------------------------- |
+| Code    | Optional; not guaranteed in v1              |
+| GIMP    | Yes, first-class where provider supports it |
+| Blender | No in Phase 5                               |
+| Writer  | Optional; provider-backed if available      |
+| Calc    | Optional; provider-backed if available      |
+| Slides  | Optional; provider-backed if available      |
 
 The frontend should only render undo affordances when:
 
@@ -382,13 +389,13 @@ The frontend should only render undo affordances when:
 
 ## 9. Failure Behavior
 
-| Failure | Meaning | User-facing message style |
-|---|---|---|
-| provider unavailable | external tool stack is not ready | tell the user what to start or reconnect |
-| tools missing | provider connected but did not expose required tools | explain that the mode is connected but incomplete |
-| validation failure | model proposed a bad tool or arguments | tell the user the action could not be safely executed |
-| execution failure | provider tool failed | explain what failed and suggest retry or a simpler action |
-| disconnect during run | provider died mid-request | surface a reconnect / retry action |
+| Failure               | Meaning                                              | User-facing message style                                 |
+| --------------------- | ---------------------------------------------------- | --------------------------------------------------------- |
+| provider unavailable  | external tool stack is not ready                     | tell the user what to start or reconnect                  |
+| tools missing         | provider connected but did not expose required tools | explain that the mode is connected but incomplete         |
+| validation failure    | model proposed a bad tool or arguments               | tell the user the action could not be safely executed     |
+| execution failure     | provider tool failed                                 | explain what failed and suggest retry or a simpler action |
+| disconnect during run | provider died mid-request                            | surface a reconnect / retry action                        |
 
 Messages must stay student-friendly and actionable.
 
@@ -427,7 +434,8 @@ Code and GIMP behavior stable:
 - `mode_status(blender)` reports live bridge runtime state and internal
   pseudo-tool availability
 - `mode_refresh_tools(blender)` performs a real bridge/runtime refresh and
-  retrieval reload attempt
+  one explicit retrieval reload attempt without a background retry loop or
+  backoff contract in Phase 5
 - `mode_undo(blender)` remains unsupported
 - Code mode keeps the existing Codehelper inference path
 - GIMP mode keeps the current Phase 4 MCP-backed execution path

--- a/docs/unified-assistant-spec/PACKAGING.md
+++ b/docs/unified-assistant-spec/PACKAGING.md
@@ -44,13 +44,13 @@ scope of the unified frontend.
 
 ## 4. Bundled Resource Categories
 
-| Resource group | Needed for | Notes |
-|---|---|---|
-| Engine runtime bundle | all modes | shared engine startup and backend runtime selection |
-| Models | all modes | shared model discovery |
-| GIMP provider assets | GIMP | provider-owned configuration or helper assets only; not the GIMP app itself |
-| Blender bridge assets | Blender | bridge helpers and any bundled support files |
-| LibreOffice MCP runtime | Writer/Calc/Slides | bundled provider runtime and support assets |
+| Resource group          | Needed for         | Notes                                                                       |
+| ----------------------- | ------------------ | --------------------------------------------------------------------------- |
+| Engine runtime bundle   | all modes          | shared engine startup and backend runtime selection                         |
+| Models                  | all modes          | shared model discovery                                                      |
+| GIMP provider assets    | GIMP               | provider-owned configuration or helper assets only; not the GIMP app itself |
+| Blender bridge assets   | Blender            | bridge helpers and any bundled support files                                |
+| LibreOffice MCP runtime | Writer/Calc/Slides | bundled provider runtime and support assets                                 |
 
 ## 5. Resource Rules
 


### PR DESCRIPTION
## Summary\n- fix the Phase 5 Blender doc wording nits from the post-merge PR comments\n- format the docs files that previously failed Incremental Style Gates\n- keep  aligned before the Blender hardening pass\n\n## Validation\n- npx prettier --check docs/unified-assistant-spec/ARCHITECTURE.md docs/unified-assistant-spec/MCP_INTEGRATION.md docs/unified-assistant-spec/FRONTEND_SPEC.md docs/unified-assistant-spec/CURRENT_STATE.md docs/unified-assistant-spec/IMPLEMENTATION_PHASES.md docs/unified-assistant-spec/LEARNINGS.md docs/unified-assistant-spec/PACKAGING.md