### PR TITLE
Docs: split LibreOffice phase into scaffold and activation

### DIFF
--- a/docs/unified-assistant-spec/ARCHITECTURE.md
+++ b/docs/unified-assistant-spec/ARCHITECTURE.md
@@ -169,6 +169,8 @@ only in the command layer.
   unified app.
 - `LibreOfficeProvider` ports behavior from the LibreOffice branch into new
   unified files and serves three frontend submodes.
+- Phase 6A lands only the LibreOffice provider scaffold and shared stdio MCP
+  prep; live LibreOffice execution is deferred to a later activation branch.
 
 ## 7. Frontend Shell
 
@@ -232,6 +234,18 @@ After Phase 5:
    - optionally retrieve Blender-doc contexts
    - generate the tutoring answer through the shared engine
 3. Blender remains bridge-first. Supplemental MCP work stays deferred.
+
+### Phase 6A LibreOffice scaffold path
+
+After Phase 6A:
+
+1. `LibreOfficeProvider` is still shared by Writer / Calc / Slides.
+2. Writer / Calc / Slides remain disabled placeholder modes in the shell.
+3. `assistant_send` remains scaffold-only for LibreOffice modes.
+4. Shared stdio MCP transport support exists in `smolpc-mcp-client`, but the
+   LibreOffice provider does not activate the runtime yet.
+5. The tracked staged resource root for future LibreOffice MCP assets is:
+   `apps/codehelper/src-tauri/resources/libreoffice/mcp_server/`
 
 ## 9. Repository Boundaries
 

--- a/docs/unified-assistant-spec/CURRENT_STATE.md
+++ b/docs/unified-assistant-spec/CURRENT_STATE.md
@@ -242,27 +242,34 @@ The standalone apps remain source references during the future port:
 - `apps/blender-assistant`
 - `apps/libreoffice-assistant`
 
+LibreOffice source-branch progress currently lives on
+`origin/codex/libreoffice-port-track-a`:
+
+- standalone shared-engine baseline complete
+- standalone MCP runtime port complete
+- standalone Phase 3 workflow preview complete with CPU-lane validation
+- Writer / Slides tool coverage is ahead of Calc-specific coverage
+
 ## What Has Not Started
 
-- real provider integrations for LibreOffice
-- mode provider ports
+- live LibreOffice activation inside the unified app
 - launcher cleanup beyond the foundation test fix
 - unified-app packaging hardening beyond the tracked OpenVINO placeholder
 - Windows end-to-end validation for the unified app
 
 ## Next Workstreams
 
-The next official step after this Blender closeout docs merge is the Phase 6
-LibreOffice docs preflight branch:
+The next official step after this Blender closeout docs merge is the Phase 6A
+LibreOffice scaffolding docs branch:
 
 1. create `codex/unified-libreoffice-mode-docs`
-2. lock the shared LibreOffice provider design in docs
+2. lock the LibreOffice scaffolding scope in docs
 3. merge docs into `docs/unified-assistant-spec`
 4. merge `docs/unified-assistant-spec` into `dev/unified-assistant`
 5. create `codex/unified-libreoffice-mode`
-6. close out Phase 6 in docs
+6. close out LibreOffice scaffolding in docs
 7. continue serial merge order:
-   - LibreOffice provider port
+   - LibreOffice activation
    - Hardening and Windows packaging validation
 
 The current merged GIMP and Blender implementations leave these future phase
@@ -274,6 +281,8 @@ boundaries intact:
    plugin/server runtime
 4. Blender stays bridge-first and does not require `blender-mcp` in Phase 5
 5. no standalone app directories were taken over by the unified branch
+6. `origin/codex/libreoffice-port-track-a` remains the separate LibreOffice
+   functionality branch and is not a merge base for unified work
 
 ## Known Risks
 
@@ -283,7 +292,7 @@ boundaries intact:
 | Standalone app branch churn       | Blender and LibreOffice behavior may continue changing during the remaining ports        |
 | External GIMP runtime assumptions | Phase 4 depends on a separate GIMP install and MCP plugin/server already being available |
 | Packaging/runtime validation      | third-party runtime paths may behave differently in packaged Windows builds              |
-| LibreOffice port alignment        | the LibreOffice branch must stay aligned with the unified provider design                |
+| LibreOffice port alignment        | the LibreOffice source branch must stay aligned with the unified provider scaffold plan  |
 
 ## Merge-Safe Rules
 
@@ -296,10 +305,10 @@ boundaries intact:
 
 ## Current Success Condition
 
-The current closeout step is complete only when:
+The current next-step baseline is correct only when:
 
-1. Phase 4 GIMP implementation is merged into `dev/unified-assistant`
-2. the closeout docs are merged into `docs/unified-assistant-spec`
+1. Phase 5 Blender implementation is merged into `dev/unified-assistant`
+2. the Phase 5 closeout docs are merged into `docs/unified-assistant-spec`
 3. those docs are merged back into `dev/unified-assistant`
-4. the next branch can start from a baseline that records GIMP as the first
-   real external-provider mode
+4. the next branch starts from a baseline that records LibreOffice as a
+   scaffolding-first integration step rather than a live-mode activation

--- a/docs/unified-assistant-spec/FRONTEND_SPEC.md
+++ b/docs/unified-assistant-spec/FRONTEND_SPEC.md
@@ -292,6 +292,18 @@ During Phase 5 Blender work:
   competing live-mode request while Blender still owns the shared engine is
   blocked until the active request finishes or is cancelled.
 
+### Phase 6A LibreOffice scaffolding rule
+
+During Phase 6A LibreOffice work:
+
+- Writer, Calc, and Slides remain visible but disabled.
+- LibreOffice modes do not use `assistant_send()` yet.
+- LibreOffice mode copy should say the integration is scaffolded rather than
+  pretending document actions are live.
+- the disabled composer reason for LibreOffice modes is:
+  `LibreOffice integration is scaffolded in the unified app, but live document actions are not wired yet.`
+- Code, GIMP, and Blender execution paths remain unchanged.
+
 ## 10. Suggestion Chips
 
 Suggestion chips are mode-specific empty-state actions.
@@ -429,6 +441,14 @@ Before provider integrations land:
   is still streaming through the shared engine until the active request finishes
   or is cancelled.
 
+### Phase 6A LibreOffice scaffolding
+
+- Writer, Calc, and Slides keep mode-aware subtitles, welcome copy, and staged
+  suggestion chips.
+- Writer, Calc, and Slides keep the composer visible but disabled.
+- the shell must not show a fake send path, fake tool list, or fake document
+  execution state for LibreOffice modes.
+
 ## 14. Migration Path
 
 1. Preserve the current Codehelper shell as the shared shell.
@@ -440,8 +460,10 @@ Before provider integrations land:
    for `gimp` only.
 6. Port Blender behavior into a new Blender provider and activate
    `assistant_send` for `blender`.
-7. Port LibreOffice behavior into one provider with Writer/Calc/Slides
-   frontend configs.
+7. Land LibreOffice scaffolding into one shared provider with Writer/Calc/Slides
+   frontend configs while keeping those modes disabled.
+8. Activate live LibreOffice behavior in a later dedicated branch once the
+   separate source work is stable enough to port.
 
 The frontend should not import or embed standalone app code directly. It should
 consume new unified stores, mode configs, and Tauri command contracts.

--- a/docs/unified-assistant-spec/IMPLEMENTATION_PHASES.md
+++ b/docs/unified-assistant-spec/IMPLEMENTATION_PHASES.md
@@ -50,9 +50,12 @@
 2. merge into `docs/unified-assistant-spec`
 3. merge `docs/unified-assistant-spec` into `dev/unified-assistant`
 4. `codex/unified-libreoffice-mode`
-5. closeout docs
-6. `codex/unified-hardening-docs`
-7. `codex/unified-hardening`
+5. `codex/unified-libreoffice-mode-status-docs`
+6. `codex/unified-libreoffice-activation-docs`
+7. `codex/unified-libreoffice-activation`
+8. `codex/unified-libreoffice-activation-status-docs`
+9. `codex/unified-hardening-docs`
+10. `codex/unified-hardening`
 
 ## Phase 2: Unified Shell
 
@@ -249,19 +252,52 @@
     `Branch Chat`
   - no edits to `apps/blender-assistant/`
 
-## Phase 6: LibreOffice Modes
+## Phase 6A: LibreOffice Scaffolding
 
 **Suggested branches:** `codex/unified-libreoffice-mode-docs`, then `codex/unified-libreoffice-mode`
 
 **Scope**
 
-- port from the LibreOffice source branch into one shared provider
-- expose Writer, Calc, and Slides as separate frontend modes
+- add merge-safe LibreOffice scaffolding into the unified app
+- keep Writer, Calc, and Slides visible but disabled
+- add shared stdio MCP transport support for future provider activation
+- replace the single-file LibreOffice placeholder with a real shared-provider module tree
+- stage a tracked LibreOffice resource placeholder for the future MCP runtime sync
+
+**Locked decisions**
+
+- this phase does not activate `assistant_send` for `writer`, `calc`, or `impress`
+- this phase does not import the full LibreOffice Python MCP runtime yet
+- `origin/codex/libreoffice-port-track-a` remains a read-only reference source
+- Calc is not required to be live in this phase
+- current source-branch baseline is:
+  - Phase 1 shared-engine baseline complete
+  - Phase 2 MCP runtime port complete
+  - Phase 3 workflow preview complete with CPU-lane validation
+  - Writer / Slides coverage ahead of Calc-specific coverage
 
 **Exit criteria**
 
-- Writer, Calc, and Slides share one provider runtime and feel like distinct
-  frontend modes
+- `smolpc-mcp-client` supports stdio MCP transport
+- unified LibreOffice provider scaffolding exists under `apps/codehelper/src-tauri/src/modes/libreoffice/`
+- Writer, Calc, and Slides still share one provider family but remain honest placeholders
+- roadmap and docs explicitly defer live LibreOffice activation to a later branch
+
+## Phase 6B: LibreOffice Activation
+
+**Suggested branches:** `codex/unified-libreoffice-activation-docs`, then `codex/unified-libreoffice-activation`
+
+**Scope**
+
+- import the selected LibreOffice MCP runtime assets from the separate source branch
+- activate the shared LibreOffice provider for live mode execution
+- decide the first live Writer / Calc / Slides surface from the then-current source branch state
+
+**Exit criteria**
+
+- at least the agreed first LibreOffice submodes are live through the shared provider
+- `assistant_send` is operational for the agreed LibreOffice submodes
+- hardening can begin from a real LibreOffice integration baseline
 
 ## Phase 7: Hardening And Packaging
 

--- a/docs/unified-assistant-spec/MCP_INTEGRATION.md
+++ b/docs/unified-assistant-spec/MCP_INTEGRATION.md
@@ -297,6 +297,8 @@ Rules:
    provider processes.
 4. Shared providers still surface the requested submode back through
    `ProviderStateDto.mode` and any mode-sensitive tool list decisions.
+5. Phase 6A only lands the shared provider scaffold; live LibreOffice runtime
+   activation is deferred to a later follow-up branch.
 
 ## 5.5 `smolpc-mcp-client` scaffolding contract
 
@@ -316,6 +318,10 @@ pub trait JsonRpcClient {
 The transport call is async from the start because stdio and TCP MCP flows are
 inherently asynchronous. The foundation branch must not ship a synchronous call
 signature that later mode branches would need to break.
+
+Phase 6A extends this crate with shared stdio transport support so the unified
+LibreOffice provider can later use the same client layer as the other provider
+families instead of importing a standalone-app-specific MCP client.
 
 ## 6. DTO Contracts
 
@@ -364,12 +370,12 @@ pub struct ModeStatusDto {
 
 ### Per-provider rules
 
-| Provider    | Auto-start                                          | Disconnect behavior                                                               |
-| ----------- | --------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Code        | Not applicable                                      | No-op                                                                             |
-| GIMP        | No, depends on external app availability            | Disconnect cleanly; do not claim ownership of the external app                    |
-| Blender     | Lazy-start local bridge server on first Blender use | Cleanly stop bridge runtime on app exit; do not claim ownership of Blender itself |
-| LibreOffice | Yes, provider may own its MCP runtime               | Keep shared runtime alive across Writer/Calc/Slides switches                      |
+| Provider    | Auto-start                                          | Disconnect behavior                                                                |
+| ----------- | --------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Code        | Not applicable                                      | No-op                                                                              |
+| GIMP        | No, depends on external app availability            | Disconnect cleanly; do not claim ownership of the external app                     |
+| Blender     | Lazy-start local bridge server on first Blender use | Cleanly stop bridge runtime on app exit; do not claim ownership of Blender itself  |
+| LibreOffice | Phase 6A: no; activation deferred                   | Keep shared runtime alive across Writer/Calc/Slides switches once activation lands |
 
 ## 8. Undo Support
 
@@ -440,6 +446,20 @@ Code and GIMP behavior stable:
 - Code mode keeps the existing Codehelper inference path
 - GIMP mode keeps the current Phase 4 MCP-backed execution path
 - `assistant_send` remains scaffold-only for `writer`, `calc`, and `impress`
+
+## 9.4 Phase 6A LibreOffice scaffolding rule
+
+Phase 6A keeps LibreOffice execution non-live while landing the merge-safe
+provider scaffold:
+
+- `assistant_send` remains scaffold-only for `writer`, `calc`, and `impress`
+- `mode_status(writer|calc|impress)` returns scaffold-aware provider detail
+  rather than the original generic foundation placeholder wording
+- `mode_refresh_tools(writer|calc|impress)` validates the staged scaffold only
+  and does not launch a LibreOffice runtime
+- `available_tools` remains empty for LibreOffice modes in this phase
+- Calc is explicitly not required to be live in this phase because the current
+  source branch does not yet provide parity-level spreadsheet tooling
 
 ## 10. Planner Boundary
 

--- a/docs/unified-assistant-spec/PACKAGING.md
+++ b/docs/unified-assistant-spec/PACKAGING.md
@@ -44,13 +44,13 @@ scope of the unified frontend.
 
 ## 4. Bundled Resource Categories
 
-| Resource group          | Needed for         | Notes                                                                       |
-| ----------------------- | ------------------ | --------------------------------------------------------------------------- |
-| Engine runtime bundle   | all modes          | shared engine startup and backend runtime selection                         |
-| Models                  | all modes          | shared model discovery                                                      |
-| GIMP provider assets    | GIMP               | provider-owned configuration or helper assets only; not the GIMP app itself |
-| Blender bridge assets   | Blender            | bridge helpers and any bundled support files                                |
-| LibreOffice MCP runtime | Writer/Calc/Slides | bundled provider runtime and support assets                                 |
+| Resource group          | Needed for         | Notes                                                                          |
+| ----------------------- | ------------------ | ------------------------------------------------------------------------------ |
+| Engine runtime bundle   | all modes          | shared engine startup and backend runtime selection                            |
+| Models                  | all modes          | shared model discovery                                                         |
+| GIMP provider assets    | GIMP               | provider-owned configuration or helper assets only; not the GIMP app itself    |
+| Blender bridge assets   | Blender            | bridge helpers and any bundled support files                                   |
+| LibreOffice MCP runtime | Writer/Calc/Slides | staged placeholder in Phase 6A, bundled provider runtime only after activation |
 
 ## 5. Resource Rules
 
@@ -109,6 +109,22 @@ Phase 5 assumes:
 Phase 5 packaging validation covers connection to an external Blender setup and
 addon, not Blender installation or addon auto-provisioning.
 
+### 5.2.3 Phase 6A LibreOffice runtime rule
+
+Phase 6A does not bundle the full LibreOffice Python MCP runtime yet.
+
+Phase 6A assumes:
+
+- the unified app tracks a staged placeholder directory at
+  `apps/codehelper/src-tauri/resources/libreoffice/mcp_server/README.md`
+- the separate LibreOffice functionality branch continues evolving its runtime
+  assets independently
+- the unified app only prepares the resource boundary and future stdio transport
+  path in this phase
+
+Phase 6A packaging validation covers staged resource-path correctness only, not
+live LibreOffice runtime execution.
+
 ### 5.3 No launcher-owned runtime paths
 
 Do not require packaged resources to live under a launcher-specific directory.
@@ -162,7 +178,7 @@ Before calling the packaging plan complete, verify:
 - GIMP mode fails gracefully if GIMP is not installed or not running
 - Blender mode fails gracefully if Blender bridge is unavailable
 - Blender mode fails gracefully if port `5179` is already occupied
-- Writer/Calc/Slides can each connect through the shared LibreOffice provider
+- staged LibreOffice resource paths resolve correctly in the unified app
 
 ## 10. Deferred Packaging Questions
 
@@ -172,3 +188,4 @@ These remain for later implementation phases:
 - final model distribution approach
 - whether some provider assets ship always or are staged optionally
 - exact bundle layout for Blender supplementary tooling
+- exact bundle timing for the full LibreOffice MCP runtime import


### PR DESCRIPTION
## Summary
- re-scope the next LibreOffice step as unified scaffolding rather than live activation
- split the roadmap into Phase 6A scaffolding, Phase 6B activation, then hardening
- lock the docs around the separate `codex/libreoffice-port-track-a` branch remaining a reference source

## Validation
- `npx prettier --check docs/unified-assistant-spec/IMPLEMENTATION_PHASES.md docs/unified-assistant-spec/CURRENT_STATE.md docs/unified-assistant-spec/ARCHITECTURE.md docs/unified-assistant-spec/MCP_INTEGRATION.md docs/unified-assistant-spec/FRONTEND_SPEC.md docs/unified-assistant-spec/PACKAGING.md`
