### PR TITLE
docs: lock Phase 6B LibreOffice activation scope

### DIFF
--- a/docs/unified-assistant-spec/ARCHITECTURE.md
+++ b/docs/unified-assistant-spec/ARCHITECTURE.md
@@ -169,8 +169,9 @@ only in the command layer.
   unified app.
 - `LibreOfficeProvider` ports behavior from the LibreOffice branch into new
   unified files and serves three frontend submodes.
-- Phase 6A lands only the LibreOffice provider scaffold and shared stdio MCP
-  prep; live LibreOffice execution is deferred to a later activation branch.
+- Phase 6A lands the LibreOffice provider scaffold and shared stdio MCP prep.
+- Phase 6B activates Writer and Slides through that same shared provider while
+  Calc remains scaffold-only.
 
 ## 7. Frontend Shell
 
@@ -235,19 +236,31 @@ After Phase 5:
    - generate the tutoring answer through the shared engine
 3. Blender remains bridge-first. Supplemental MCP work stays deferred.
 
-### Phase 6A LibreOffice scaffold path
+### Phase 6B LibreOffice activation path
 
-After Phase 6A:
+After Phase 6B:
 
 1. `LibreOfficeProvider` is still shared by Writer / Calc / Slides.
-2. Writer / Calc / Slides remain disabled placeholder modes in the shell.
-3. `assistant_send` remains scaffold-only for LibreOffice modes.
-4. Shared stdio MCP transport support now exists in `smolpc-mcp-client`
-   through the same client layer used by future MCP-backed providers.
-5. The LibreOffice provider remains scaffold-only and validates resources
-   without launching a runtime.
-6. The tracked staged resource root for future LibreOffice MCP assets is:
+2. Writer and Slides are live runtime-backed modes in the shell.
+3. Calc remains a visible scaffold-only mode with disabled composer.
+4. `assistant_send` is operational for `writer` and `impress` only.
+5. `assistant_send(calc)` remains scaffold-only.
+6. Shared stdio MCP transport in `smolpc-mcp-client` now drives a real
+   LibreOffice runtime through the staged Python `main.py` entrypoint.
+7. The shared runtime contract remains:
+   - stdio MCP child process
+   - helper socket bridge on `localhost:8765`
+   - headless office socket on `localhost:2002`
+8. The imported runtime assets live under:
    `apps/codehelper/src-tauri/resources/libreoffice/mcp_server/`
+9. Live tool execution is mode-filtered at the provider boundary:
+   - Writer uses the Writer allowlist
+   - Slides uses the Slides allowlist
+   - Calc exposes no live tools in this phase
+10. The unified branch imports the runtime assets from
+    `origin/codex/libreoffice-port-track-a` commit
+    `7acad1fa0eb31e32a5485069e85c021d14284455` and continues treating that
+    branch as a read-only reference source.
 
 ## 9. Repository Boundaries
 

--- a/docs/unified-assistant-spec/CURRENT_STATE.md
+++ b/docs/unified-assistant-spec/CURRENT_STATE.md
@@ -1,7 +1,7 @@
 # Current State
 
 **Last Updated:** 2026-03-17
-**Phase:** Phase 6A LibreOffice scaffolding is merged; Phase 6B activation docs are next
+**Phase:** Phase 6A LibreOffice scaffolding is merged; Phase 6B LibreOffice activation is the current next implementation phase
 
 ## Branch Roles
 
@@ -292,22 +292,33 @@ Validation completed for the merged LibreOffice scaffolding:
 
 ## Next Workstreams
 
-The next official step after this LibreOffice scaffolding closeout docs merge
-is the Phase 6B LibreOffice activation docs branch:
+The next official step from the current merged Phase 6A baseline is the
+Phase 6B LibreOffice activation implementation flow:
 
 1. create `codex/unified-libreoffice-activation-docs`
-2. lock the first live LibreOffice activation scope in docs
+2. lock the first live LibreOffice activation scope in docs:
+   - Writer live
+   - Slides live
+   - Calc still scaffold-only
+   - imported Python runtime assets pinned to
+     `7acad1fa0eb31e32a5485069e85c021d14284455`
+   - one shared `LibreOfficeProvider`
+   - stdio MCP child process via `main.py`
+   - helper socket on `localhost:8765`
+   - headless office socket on `localhost:2002`
 3. merge docs into `docs/unified-assistant-spec`
 4. merge `docs/unified-assistant-spec` into `dev/unified-assistant`
 5. create `codex/unified-libreoffice-activation`
-6. close out LibreOffice activation in docs
-7. continue serial merge order:
+6. activate Writer and Slides only through the shared unified provider
+7. close out LibreOffice activation in docs
+8. continue serial merge order:
    - Hardening and Windows packaging validation
 
-The current merged GIMP and Blender implementations leave these future phase
-boundaries intact:
+The current merged GIMP and Blender implementations plus the merged
+LibreOffice scaffold leave these future phase boundaries intact:
 
-1. `assistant_send` remains scaffold-only for Writer / Calc / Slides
+1. `assistant_send` remains scaffold-only for Writer / Calc / Slides until the
+   dedicated Phase 6B activation branch lands
 2. Code mode still does not use the unified provider/orchestration path
 3. packaging still assumes an external GIMP install plus external MCP
    plugin/server runtime
@@ -315,6 +326,8 @@ boundaries intact:
 5. no standalone app directories were taken over by the unified branch
 6. `origin/codex/libreoffice-port-track-a` remains the separate LibreOffice
    functionality branch and is not a merge base for unified work
+7. Phase 7 hardening does not start until the Phase 6B activation closeout docs
+   are merged
 
 ## Known Risks
 
@@ -344,3 +357,5 @@ The current next-step baseline is correct only when:
 3. those docs are merged back into `dev/unified-assistant`
 4. the next branch starts from a baseline that records LibreOffice activation
    as the next official step rather than hardening
+5. the next live LibreOffice scope is explicitly Writer + Slides first while
+   Calc remains scaffold-only

--- a/docs/unified-assistant-spec/FRONTEND_SPEC.md
+++ b/docs/unified-assistant-spec/FRONTEND_SPEC.md
@@ -292,18 +292,26 @@ During Phase 5 Blender work:
   competing live-mode request while Blender still owns the shared engine is
   blocked until the active request finishes or is cancelled.
 
-### Phase 6A LibreOffice scaffolding rule
+### Phase 6B LibreOffice activation rule
 
-During Phase 6A LibreOffice work:
+During Phase 6B LibreOffice work:
 
-- Writer, Calc, and Slides remain visible but disabled.
-- LibreOffice modes do not use `assistant_send()` yet.
-- LibreOffice mode copy should say the integration is scaffolded rather than
-  pretending document actions are live.
-- the disabled composer reason for LibreOffice modes is:
+- Writer and Slides become live shell modes with enabled composers.
+- Calc remains visible but disabled.
+- Writer and Slides use `assistant_send()`.
+- Calc does not use `assistant_send()`.
+- Writer and Slides keep mode-specific live copy and live suggestion chips.
+- Calc copy should stay scaffold-honest rather than pretending spreadsheet
+  actions are live.
+- the disabled composer reason for Calc is:
   `LibreOffice integration is scaffolded in the unified app, but live document actions are not wired yet.`
 - the disabled composer placeholder remains mode-specific rather than falling
   back to a generic placeholder string
+- Writer and Slides render tool activity through the existing `toolResults`
+  metadata path.
+- Writer and Slides do not expose `Regenerate`, `Continue`, or `Branch Chat`
+  in Phase 6B because document tool calls are side-effectful.
+- Writer and Slides do not render Undo in Phase 6B.
 - Code, GIMP, and Blender execution paths remain unchanged.
 
 ## 10. Suggestion Chips
@@ -315,9 +323,9 @@ Examples:
 - Code: "Explain this error", "Write a function", "Review this snippet"
 - GIMP: "Blur the top half of the image", "Crop this image to a square", "Rotate the image 90 degrees clockwise"
 - Blender: "What is in my scene right now?", "How do I add a bevel to the selected object?", "Explain what this modifier stack is doing"
-- Writer: "Draft an introduction for this report", "Rewrite this paragraph for clarity", "Summarize these meeting notes"
-- Calc: "Explain what this formula should do", "Outline a grade tracker sheet", "Suggest a clean table layout"
-- Slides: "Turn these notes into slide bullets", "Suggest a three-slide deck outline", "Improve this presentation structure"
+- Writer: "Create a blank document called lesson-plan.odt", "Add a level 1 heading called Local AI in Schools", "Insert a two-column table for topic and notes"
+- Calc: "LibreOffice Calc activation is planned next", "Spreadsheet tools are not wired yet", "Check back after the activation follow-up"
+- Slides: "Create a blank presentation called demo-pitch.odp", "Add a title slide for Local AI in Classrooms", "Insert an image on slide 2 and scale it to fit"
 
 ## 11. Tauri Command Contracts
 
@@ -349,6 +357,8 @@ mode work begins.
   yet
 - Phase 5 note: becomes operational for `blender` as well, using token
   streaming plus structured provider events
+- Phase 6B note: becomes operational for `writer` and `impress`; `calc`
+  remains scaffold-only
 
 ### `assistant_cancel()`
 
@@ -443,13 +453,17 @@ Before provider integrations land:
   is still streaming through the shared engine until the active request finishes
   or is cancelled.
 
-### Phase 6A LibreOffice scaffolding
+### Phase 6B LibreOffice activation
 
-- Writer, Calc, and Slides keep mode-aware subtitles, welcome copy, and staged
+- Writer and Slides keep mode-aware subtitles, welcome copy, and live
   suggestion chips.
-- Writer, Calc, and Slides keep the composer visible but disabled.
+- Writer and Slides route through `assistantSend()` and may stream status,
+  tool, token, complete, and error events.
+- Calc keeps mode-aware scaffold copy and a disabled composer.
 - the shell must not show a fake send path, fake tool list, or fake document
-  execution state for LibreOffice modes.
+  execution state for Calc.
+- the shell must not show Undo, Regenerate, Continue, or Branch Chat for
+  Writer or Slides in Phase 6B.
 
 ## 14. Migration Path
 
@@ -464,8 +478,8 @@ Before provider integrations land:
    `assistant_send` for `blender`.
 7. Land LibreOffice scaffolding into one shared provider with Writer/Calc/Slides
    frontend configs while keeping those modes disabled.
-8. Activate live LibreOffice behavior in a later dedicated branch once the
-   separate source work is stable enough to port.
+8. Activate live LibreOffice behavior for Writer and Slides in a later
+   dedicated branch while keeping Calc scaffold-only.
 
 The frontend should not import or embed standalone app code directly. It should
 consume new unified stores, mode configs, and Tauri command contracts.

--- a/docs/unified-assistant-spec/IMPLEMENTATION_PHASES.md
+++ b/docs/unified-assistant-spec/IMPLEMENTATION_PHASES.md
@@ -1,7 +1,7 @@
 # Unified Assistant Implementation Phases
 
 **Last Updated:** 2026-03-17
-**Status:** Phase 6A LibreOffice scaffolding is merged; Phase 6B activation docs are next
+**Status:** Phase 6A LibreOffice scaffolding is merged; Phase 6B LibreOffice activation is the current next implementation phase
 
 ## Phase 0: Documentation Baseline
 
@@ -50,9 +50,12 @@
 2. merge into `docs/unified-assistant-spec`
 3. merge `docs/unified-assistant-spec` into `dev/unified-assistant`
 4. `codex/unified-libreoffice-activation`
-5. `codex/unified-libreoffice-activation-status-docs`
-6. `codex/unified-hardening-docs`
-7. `codex/unified-hardening`
+5. merge into `dev/unified-assistant`
+6. `codex/unified-libreoffice-activation-status-docs`
+7. merge into `docs/unified-assistant-spec`
+8. merge `docs/unified-assistant-spec` into `dev/unified-assistant`
+9. `codex/unified-hardening-docs`
+10. `codex/unified-hardening`
 
 ## Phase 2: Unified Shell
 
@@ -305,13 +308,93 @@
 **Scope**
 
 - import the selected LibreOffice MCP runtime assets from the separate source branch
-- activate the shared LibreOffice provider for live mode execution
-- decide the first live Writer / Calc / Slides surface from the then-current source branch state
+- activate the shared LibreOffice provider for live Writer and Slides execution
+- keep Calc scaffold-only while the source branch continues maturing spreadsheet coverage
+- reuse the unified app's shared stdio MCP transport rather than porting the standalone Rust MCP client
+- keep the work integration-focused and avoid porting the standalone LibreOffice UI
+
+**Locked decisions**
+
+- `origin/codex/libreoffice-port-track-a` remains a read-only reference source pinned to commit
+  `7acad1fa0eb31e32a5485069e85c021d14284455` for this phase
+- `apps/libreoffice-assistant/` remains untouched in unified activation work
+- Writer and Slides are the only live LibreOffice submodes in Phase 6B
+- Calc remains visible but scaffold-only after this branch
+- `assistant_send` becomes operational for `writer` and `impress` only
+- `assistant_send(calc)` remains scaffold-only
+- one shared `LibreOfficeProvider` still owns `writer`, `calc`, and `impress`
+- the unified app imports these Python runtime assets into
+  `apps/codehelper/src-tauri/resources/libreoffice/mcp_server/`:
+  - `main.py`
+  - `libre.py`
+  - `helper.py`
+  - `helper_utils.py`
+  - `helper_test_functions.py`
+- runtime activation uses the existing shared stdio MCP support in
+  `smolpc-mcp-client`, not the standalone `mcp_client.rs`
+- runtime contract remains:
+  - stdio MCP child process via `main.py`
+  - helper socket on `localhost:8765`
+  - headless office socket on `localhost:2002`
+- runtime remains engine-only
+- no Ollama paths, provider toggles, settings UI, or standalone MCP diagnostics
+  panels are ported
+- Writer and Slides use one tool call maximum per assistant turn
+- Writer and Slides use one summary follow-up maximum after tool execution
+- if summary generation fails, times out, or is cancelled after a successful tool
+  call, the unified app returns a deterministic local summary from the tool result
+- cancellation stops generation and follow-up summary work but does not roll back
+  an already executed LibreOffice document tool
+
+**Writer tool allowlist**
+
+- `create_blank_document`
+- `read_text_document`
+- `get_document_properties`
+- `list_documents`
+- `copy_document`
+- `add_text`
+- `add_heading`
+- `add_paragraph`
+- `add_table`
+- `insert_image`
+- `insert_page_break`
+- `format_text`
+- `search_replace_text`
+- `delete_text`
+- `format_table`
+- `delete_paragraph`
+- `apply_document_style`
+
+**Slides tool allowlist**
+
+- `create_blank_presentation`
+- `read_presentation`
+- `get_document_properties`
+- `list_documents`
+- `copy_document`
+- `add_slide`
+- `edit_slide_content`
+- `edit_slide_title`
+- `delete_slide`
+- `apply_presentation_template`
+- `format_slide_content`
+- `format_slide_title`
+- `insert_slide_image`
+
+**Calc tool allowlist**
+
+- none in Phase 6B
 
 **Exit criteria**
 
-- at least the agreed first LibreOffice submodes are live through the shared provider
-- `assistant_send` is operational for the agreed LibreOffice submodes
+- Writer and Slides are live through the shared LibreOffice provider
+- `assistant_send(writer)` and `assistant_send(impress)` are operational
+- Calc remains an honest scaffold-only mode with disabled composer and no fake
+  tool surface
+- imported Python runtime assets resolve from unified app resources
+- `mode_status(writer|impress)` and `mode_refresh_tools(writer|impress)` are
+  runtime-backed
 - hardening can begin from a real LibreOffice integration baseline
 
 ## Phase 7: Hardening And Packaging

--- a/docs/unified-assistant-spec/MCP_INTEGRATION.md
+++ b/docs/unified-assistant-spec/MCP_INTEGRATION.md
@@ -297,8 +297,12 @@ Rules:
    provider processes.
 4. Shared providers still surface the requested submode back through
    `ProviderStateDto.mode` and any mode-sensitive tool list decisions.
-5. Phase 6A only lands the shared provider scaffold; live LibreOffice runtime
-   activation is deferred to a later follow-up branch.
+5. Phase 6B activates Writer and Slides through the shared provider while Calc
+   remains scaffold-only.
+6. The unified app reuses the shared stdio MCP layer in `smolpc-mcp-client`
+   rather than importing the standalone LibreOffice Rust MCP client.
+7. Live tool discovery is filtered by submode allowlist before the frontend
+   sees it.
 
 ## 5.5 `smolpc-mcp-client` scaffolding contract
 
@@ -319,9 +323,9 @@ The transport call is async from the start because stdio and TCP MCP flows are
 inherently asynchronous. The foundation branch must not ship a synchronous call
 signature that later mode branches would need to break.
 
-Phase 6A now extends this crate with shared stdio transport support so the
-unified LibreOffice provider can later use the same client layer as the other
-provider families instead of importing a standalone-app-specific MCP client.
+Phase 6A extends this crate with shared stdio transport support, and Phase 6B
+uses that same client layer to activate the unified LibreOffice runtime instead
+of importing a standalone-app-specific MCP client.
 
 ## 6. DTO Contracts
 
@@ -375,7 +379,7 @@ pub struct ModeStatusDto {
 | Code        | Not applicable                                      | No-op                                                                              |
 | GIMP        | No, depends on external app availability            | Disconnect cleanly; do not claim ownership of the external app                     |
 | Blender     | Lazy-start local bridge server on first Blender use | Cleanly stop bridge runtime on app exit; do not claim ownership of Blender itself  |
-| LibreOffice | Phase 6A: no; activation deferred                   | Keep shared runtime alive across Writer/Calc/Slides switches once activation lands |
+| LibreOffice | Writer/Slides: yes in Phase 6B; Calc: scaffold-only | Keep shared runtime alive across Writer/Calc/Slides switches once activation lands |
 
 ## 8. Undo Support
 
@@ -384,9 +388,9 @@ pub struct ModeStatusDto {
 | Code    | Optional; not guaranteed in v1              |
 | GIMP    | Yes, first-class where provider supports it |
 | Blender | No in Phase 5                               |
-| Writer  | Optional; provider-backed if available      |
-| Calc    | Optional; provider-backed if available      |
-| Slides  | Optional; provider-backed if available      |
+| Writer  | No in Phase 6B                              |
+| Calc    | No in Phase 6A / 6B                         |
+| Slides  | No in Phase 6B                              |
 
 The frontend should only render undo affordances when:
 
@@ -447,21 +451,69 @@ Code and GIMP behavior stable:
 - GIMP mode keeps the current Phase 4 MCP-backed execution path
 - `assistant_send` remains scaffold-only for `writer`, `calc`, and `impress`
 
-## 9.4 Phase 6A LibreOffice scaffolding rule
+## 9.4 Phase 6B LibreOffice activation rule
 
-Phase 6A keeps LibreOffice execution non-live while landing the merge-safe
-provider scaffold:
+Phase 6B activates the shared LibreOffice provider for Writer and Slides while
+keeping Calc scaffold-only:
 
-- `assistant_send` remains scaffold-only for `writer`, `calc`, and `impress`
-- `mode_status(writer|calc|impress)` returns scaffold-aware provider detail
-  rather than the original generic foundation placeholder wording
-- `mode_refresh_tools(writer|calc|impress)` validates the staged scaffold only
-  and does not launch a LibreOffice runtime
-- `available_tools` remains empty for LibreOffice modes in this phase
-- the shared MCP layer now exposes `StdioJsonRpcClient` and
-  `McpSession::connect_stdio(...)` for the later activation phase
-- Calc is explicitly not required to be live in this phase because the current
-  source branch does not yet provide parity-level spreadsheet tooling
+- `assistant_send` is operational for `writer` and `impress`
+- `assistant_send(calc)` remains scaffold-only
+- `mode_status(writer|impress)` reports real runtime-backed connection state
+- `mode_status(calc)` remains scaffold-aware provider detail
+- `mode_refresh_tools(writer|impress)` starts or refreshes the shared stdio MCP
+  runtime and returns submode-filtered tool lists
+- `mode_refresh_tools(calc)` revalidates scaffold state only and does not start
+  the runtime
+- the shared runtime contract remains:
+  - stdio MCP child process via `main.py`
+  - helper socket on `localhost:8765`
+  - headless office socket on `localhost:2002`
+- imported Python runtime assets are staged under
+  `apps/codehelper/src-tauri/resources/libreoffice/mcp_server/`
+- the unified import baseline is pinned to
+  `origin/codex/libreoffice-port-track-a` commit
+  `7acad1fa0eb31e32a5485069e85c021d14284455`
+- Writer allowlist:
+  - `create_blank_document`
+  - `read_text_document`
+  - `get_document_properties`
+  - `list_documents`
+  - `copy_document`
+  - `add_text`
+  - `add_heading`
+  - `add_paragraph`
+  - `add_table`
+  - `insert_image`
+  - `insert_page_break`
+  - `format_text`
+  - `search_replace_text`
+  - `delete_text`
+  - `format_table`
+  - `delete_paragraph`
+  - `apply_document_style`
+- Slides allowlist:
+  - `create_blank_presentation`
+  - `read_presentation`
+  - `get_document_properties`
+  - `list_documents`
+  - `copy_document`
+  - `add_slide`
+  - `edit_slide_content`
+  - `edit_slide_title`
+  - `delete_slide`
+  - `apply_presentation_template`
+  - `format_slide_content`
+  - `format_slide_title`
+  - `insert_slide_image`
+- Calc allowlist: none in Phase 6B
+- execution remains intentionally narrow:
+  - one tool call maximum per assistant turn
+  - structured tool-call parsing first
+  - JSON fallback tool-call extraction retained as a compatibility path
+  - one follow-up summary turn maximum after tool execution
+  - deterministic local summary fallback when summary generation fails, times
+    out, or is cancelled after a successful tool call
+  - cancellation does not roll back an already executed document tool
 
 ## 10. Planner Boundary
 

--- a/docs/unified-assistant-spec/PACKAGING.md
+++ b/docs/unified-assistant-spec/PACKAGING.md
@@ -109,24 +109,34 @@ Phase 5 assumes:
 Phase 5 packaging validation covers connection to an external Blender setup and
 addon, not Blender installation or addon auto-provisioning.
 
-### 5.2.3 Phase 6A LibreOffice runtime rule
+### 5.2.3 Phase 6B LibreOffice runtime rule
 
-Phase 6A does not bundle the full LibreOffice Python MCP runtime yet.
+Phase 6B imports and bundles the selected LibreOffice Python MCP runtime
+assets under the unified app resource root:
 
-Phase 6A assumes:
+- `apps/codehelper/src-tauri/resources/libreoffice/mcp_server/main.py`
+- `apps/codehelper/src-tauri/resources/libreoffice/mcp_server/libre.py`
+- `apps/codehelper/src-tauri/resources/libreoffice/mcp_server/helper.py`
+- `apps/codehelper/src-tauri/resources/libreoffice/mcp_server/helper_utils.py`
+- `apps/codehelper/src-tauri/resources/libreoffice/mcp_server/helper_test_functions.py`
 
-- the unified app tracks a staged placeholder directory at
-  `apps/codehelper/src-tauri/resources/libreoffice/mcp_server/README.md`
-- the separate LibreOffice functionality branch continues evolving its runtime
-  assets independently
-- the unified app only prepares the resource boundary and future stdio transport
-  path in this phase
-- future runtime activation will use the staged Python `main.py` entrypoint plus
-  the helper socket bridge on `localhost:8765`
+Phase 6B assumes:
 
-Phase 6A packaging validation covers staged resource-path correctness only, not
-live LibreOffice runtime execution. Phase 6B is responsible for the first live
-connection validation.
+- imported runtime assets are pinned to
+  `origin/codex/libreoffice-port-track-a` commit
+  `7acad1fa0eb31e32a5485069e85c021d14284455`
+- the unified app launches the runtime through the shared stdio MCP path
+- the runtime contract remains:
+  - stdio MCP child process via `main.py`
+  - helper socket bridge on `localhost:8765`
+  - headless office socket on `localhost:2002`
+- the unified app does not bundle LibreOffice or Collabora itself
+- the unified app does not add a LibreOffice settings UI in this phase
+- runtime activation assumes an external LibreOffice or Collabora install plus
+  Python 3 available on the target system
+
+Phase 6B packaging validation covers the first real LibreOffice runtime
+connection checks for Writer and Slides while Calc remains scaffold-only.
 
 ### 5.3 No launcher-owned runtime paths
 


### PR DESCRIPTION
## Summary\n- lock the Phase 6B Writer + Slides activation scope\n- keep Calc scaffold-only in the spec\n- document the runtime import boundary, tool allowlists, and frontend/runtime rules\n\n## Testing\n- npx prettier --check docs/unified-assistant-spec/IMPLEMENTATION_PHASES.md docs/unified-assistant-spec/CURRENT_STATE.md docs/unified-assistant-spec/ARCHITECTURE.md docs/unified-assistant-spec/MCP_INTEGRATION.md docs/unified-assistant-spec/FRONTEND_SPEC.md docs/unified-assistant-spec/PACKAGING.md