### PR TITLE
feat: activate LibreOffice Writer and Slides in unified shell

### DIFF
--- a/apps/codehelper/src-tauri/resources/libreoffice/mcp_server/README.md
+++ b/apps/codehelper/src-tauri/resources/libreoffice/mcp_server/README.md
@@ -1,30 +1,28 @@
-# LibreOffice MCP Runtime Placeholder
+# MCP Server Resources
 
-This directory is intentionally staged as a tracked placeholder during unified
-Phase 6A scaffolding.
+This directory contains the Python MCP runtime assets imported into the unified
+app for Phase 6B LibreOffice activation.
 
-Reference source branch:
+Imported baseline:
 
-- `codex/libreoffice-port-track-a`
+1. source branch: `origin/codex/libreoffice-port-track-a`
+2. pinned source commit: `7acad1fa0eb31e32a5485069e85c021d14284455`
+3. imported files:
+   - `main.py`
+   - `libre.py`
+   - `helper.py`
+   - `helper_utils.py`
+   - `helper_test_functions.py`
 
-Reference source commit observed during planning:
+Runtime contract:
 
-- `7acad1fa0eb31e32a5485069e85c021d14284455`
+1. Rust launches `main.py` over stdio MCP through `smolpc-mcp-client`
+2. `libre.py` communicates with `helper.py` over `localhost:8765`
+3. headless office socket remains `localhost:2002`
 
-Expected future imported files from the standalone branch:
+Notes:
 
-- `main.py`
-- `libre.py`
-- `helper.py`
-- `helper_utils.py`
-- `helper_test_functions.py`
-
-Expected future runtime shape:
-
-- Rust child-process stdio MCP transport
-- Python `main.py` entrypoint
-- helper socket bridge on `localhost:8765`
-
-This branch does **not** import the full Python MCP runtime yet. The standalone
-LibreOffice work is still evolving on `codex/libreoffice-port-track-a`, so the
-unified app only stages the resource path and provider scaffolding here.
+1. `libre.py` currently exposes 27 active MCP tools upstream.
+2. Unified Phase 6B activates Writer and Slides only; Calc remains scaffold-only.
+3. Keep this integration engine-only in this repo; do not add Ollama runtime
+   dependencies while porting.

--- a/apps/codehelper/src-tauri/resources/libreoffice/mcp_server/helper.py
+++ b/apps/codehelper/src-tauri/resources/libreoffice/mcp_server/helper.py
@@ -1,0 +1,3462 @@
+import json
+import time
+import sys
+import os
+import traceback
+import socket
+
+from helper_utils import (
+    managed_document,
+    normalize_path,
+    ensure_directory_exists,
+    get_uno_desktop,
+    create_property_value,
+    HelperError,
+)
+
+from helper_test_functions import (
+    get_text_formatting,
+    get_table_info,
+    has_image,
+    get_page_break_info,
+    get_presentation_template_info,
+    get_presentation_text_formatting,
+    get_slide_image_info,
+)
+
+import logging
+
+print("Starting LibreOffice Helper Script...")
+logging.info("Starting LibreOffice Helper Script...")
+
+try:
+    print("Importing UNO...")
+    logging.info("Importing UNO...")
+    import uno
+    from com.sun.star.beans import PropertyValue
+    from com.sun.star.text import ControlCharacter
+    from com.sun.star.text.TextContentAnchorType import AS_CHARACTER
+    from com.sun.star.awt import Size
+    from com.sun.star.awt.FontSlant import ITALIC
+    from com.sun.star.lang import Locale
+    from com.sun.star.style.ParagraphAdjust import CENTER, LEFT, RIGHT, BLOCK
+    from com.sun.star.style.BreakType import PAGE_BEFORE
+    from com.sun.star.table import BorderLine2, TableBorder2
+    from com.sun.star.table.BorderLineStyle import SOLID
+    from com.sun.star.text.ControlCharacter import PARAGRAPH_BREAK
+    from com.sun.star.connection import NoConnectException
+
+    print("UNO imported successfully!")
+    logging.info("UNO imported successfully!")
+except ImportError as e:
+    print(f"UNO Import Error: {e}")
+    logging.error(f"UNO Import Error: {e}")
+    print("This script must be run with LibreOffice's Python.")
+    logging.error("This script must be run with LibreOffice's Python.")
+    sys.exit(1)
+
+# Create a server socket
+server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+server_socket.bind(("localhost", 8765))
+server_socket.listen(1)
+
+print("LibreOffice helper listening on port 8765")
+logging.info("LibreOffice helper listening on port 8765")
+
+print("Socket bound to localhost:8765")
+logging.info("Socket bound to localhost:8765")
+
+# General functions
+
+
+def create_document(doc_type, file_path, metadata=None):
+    """Create a new LibreOffice document with optional metadata."""
+    logging.info(f"Creating {doc_type} document at {file_path}")
+
+    # Normalize path and ensure directory exists
+    file_path = normalize_path(file_path)
+    if not ensure_directory_exists(file_path):
+        raise HelperError(f"Failed to create directory for {file_path}")
+
+    # Get desktop
+    desktop = get_uno_desktop()
+    if not desktop:
+        raise HelperError("Failed to connect to LibreOffice desktop")
+
+    # Map document types
+    type_map = {
+        "text": "private:factory/swriter",
+        "calc": "private:factory/scalc",
+        "impress": "private:factory/simpress",
+    }
+
+    if doc_type not in type_map:
+        raise HelperError(
+            f"Invalid document type. Choose from: {list(type_map.keys())}"
+        )
+
+    try:
+        # Create document
+        doc = desktop.loadComponentFromURL(type_map[doc_type], "_blank", 0, ())
+        if not doc:
+            raise HelperError(f"Failed to create {doc_type} document")
+
+        # Add metadata if provided
+        if metadata and hasattr(doc, "DocumentProperties"):
+            doc_info = doc.DocumentProperties
+            logging.info(doc_info)
+            for key, value in metadata.items():
+                logging.info(f"{key} {value} {type(value)}")
+                if hasattr(doc_info, key):
+                    setattr(doc_info, key, value)
+
+        # Save document
+        file_url = uno.systemPathToFileUrl(file_path)
+        logging.info(f"Saving to URL: {file_url}")
+
+        props = [create_property_value("Overwrite", True)]
+        doc.storeToURL(file_url, tuple(props))
+        doc.close(True)
+
+        # Verify file was created
+        time.sleep(1)  # Wait for filesystem sync
+        if os.path.exists(file_path):
+            return f"Successfully created {doc_type} document at: {file_path}"
+        else:
+            raise HelperError(
+                f"Document creation attempted, but file not found at: {file_path}"
+            )
+
+    except Exception as e:
+        logging.error(f"Error creating document: {str(e)}")
+        logging.error(traceback.format_exc())
+        raise
+
+
+def list_documents(directory):
+    """List all documents in a directory."""
+    dir_path = normalize_path(directory)
+    if not os.path.exists(dir_path) or not os.path.isdir(dir_path):
+        raise HelperError(f"Directory not found: {dir_path}")
+
+    docs = []
+    # Extensions for LibreOffice and MS Office documents
+    extensions = [
+        ".odt",
+        ".ods",
+        ".odp",
+        ".odg",  # LibreOffice/OpenOffice
+        ".doc",
+        ".docx",
+        ".xls",
+        ".xlsx",
+        ".ppt",
+        ".pptx",  # MS Office
+        ".rtf",
+        ".txt",
+        ".csv",
+        ".pdf",  # Other common document types
+    ]
+
+    for file in os.listdir(dir_path):
+        file_path = os.path.join(dir_path, file)
+        if os.path.isfile(file_path):
+            ext = os.path.splitext(file)[1].lower()
+            if ext in extensions:
+                # Get file stats
+                stats = os.stat(file_path)
+                size = stats.st_size
+
+                # Format last modified time
+                mod_time = time.strftime(
+                    "%Y-%m-%d %H:%M:%S", time.localtime(stats.st_mtime)
+                )
+
+                # Map extension to document type
+                doc_type = "unknown"
+                if ext in [".odt", ".doc", ".docx", ".rtf", ".txt"]:
+                    doc_type = "text"
+                elif ext in [".ods", ".xls", ".xlsx", ".csv"]:
+                    doc_type = "spreadsheet"
+                elif ext in [".odp", ".ppt", ".pptx"]:
+                    doc_type = "presentation"
+                elif ext in [".odg"]:
+                    doc_type = "drawing"
+                elif ext in [".pdf"]:
+                    doc_type = "pdf"
+
+                docs.append(
+                    {
+                        "name": file,
+                        "path": file_path,
+                        "size": size,
+                        "modified": mod_time,
+                        "type": doc_type,
+                        "extension": ext[1:],  # Remove leading dot
+                    }
+                )
+
+    # Sort by name
+    docs = sorted(docs, key=lambda x: x["name"])
+
+    # Format as a readable string
+    if not docs:
+        return "No documents found in the directory."
+
+    result = f"Found {len(docs)} documents in {dir_path}:\n\n"
+    for doc in docs:
+        size_kb = doc["size"] / 1024
+        size_display = (
+            f"{size_kb:.1f} KB" if size_kb < 1024 else f"{size_kb / 1024:.1f} MB"
+        )
+        result += f"Name: {doc['name']}\n"
+        result += f"Type: {doc['type']} ({doc['extension']})\n"
+        result += f"Size: {size_display}\n"
+        result += f"Modified: {doc['modified']}\n"
+        result += f"Path: {doc['path']}\n"
+        result += "---\n"
+
+    return result
+
+
+def copy_document(source_path, target_path):
+    """Create a copy of an existing document."""
+    source_path = normalize_path(source_path)
+    target_path = normalize_path(target_path)
+
+    if not os.path.exists(source_path):
+        raise HelperError(f"Source document not found: {source_path}")
+
+    if not ensure_directory_exists(target_path):
+        raise HelperError(f"Failed to create directory for target: {target_path}")
+
+    # First try to open and save through LibreOffice
+    with managed_document(source_path) as doc:
+        # Save to new location
+        target_url = uno.systemPathToFileUrl(target_path)
+        props = [create_property_value("Overwrite", True)]
+        doc.storeToURL(target_url, tuple(props))
+
+    if os.path.exists(target_path):
+        return f"Successfully copied document to: {target_path}"
+    else:
+        # If LibreOffice method failed, try direct file copy
+        import shutil
+
+        shutil.copy2(source_path, target_path)
+        return f"Successfully copied document to: {target_path}"
+
+
+def get_document_properties(file_path):
+    """Extract document properties and statistics."""
+    with managed_document(file_path) as doc:
+        props = {}
+
+        # Get basic document properties
+        if hasattr(doc, "DocumentProperties"):
+            doc_props = doc.DocumentProperties
+            for prop in [
+                "Title",
+                "Subject",
+                "Author",
+                "Description",
+                "Keywords",
+                "ModifiedBy",
+            ]:
+                if hasattr(doc_props, prop):
+                    props[prop] = getattr(doc_props, prop)
+
+            # Get dates
+            for date_prop in ["CreationDate", "ModificationDate"]:
+                if hasattr(doc_props, date_prop):
+                    date_val = getattr(doc_props, date_prop)
+                    if date_val:
+                        props[date_prop] = (
+                            date_val.isoformat()
+                            if hasattr(date_val, "isoformat")
+                            else str(date_val)
+                        )
+
+        # Get document statistics
+        if hasattr(doc, "WordCount") and hasattr(doc.WordCount, "getWordCount"):
+            props["WordCount"] = doc.WordCount.getWordCount()
+
+        if hasattr(doc, "getText"):
+            text = doc.getText()
+            props["CharacterCount"] = len(text.getString())
+
+            # Count paragraphs
+            paragraph_count = 0
+            enum = text.createEnumeration()
+            while enum.hasMoreElements():
+                paragraph_count += 1
+                enum.nextElement()
+            props["ParagraphCount"] = paragraph_count
+
+        return json.dumps(props, indent=2)
+
+
+# Writer functions
+
+
+def extract_text(file_path):
+    """Extract text from a document."""
+    with managed_document(file_path, read_only=True) as doc:
+        if hasattr(doc, "getText"):
+            return doc.getText().getString()
+        else:
+            raise HelperError("Document does not support text extraction")
+
+
+def add_text(file_path, text, position="end"):
+    """Add text to a document."""
+    with managed_document(file_path) as doc:
+        if hasattr(doc, "getText"):
+            text_obj = doc.getText()
+
+            if position == "start":
+                text_obj.insertString(text_obj.getStart(), text, False)
+            elif position == "cursor":
+                cursor = text_obj.createTextCursor()
+                text_obj.insertString(cursor, text, False)
+            else:  # default to end
+                text_obj.insertString(text_obj.getEnd(), text, False)
+
+            # Save document
+            doc.store()
+            return f"Text added to {file_path}"
+        else:
+            raise HelperError("Document does not support text insertion")
+
+
+def add_heading(file_path, text, level=1):
+    """Add a heading to a document."""
+    with managed_document(file_path) as doc:
+        if hasattr(doc, "getText"):
+            text_obj = doc.getText()
+            cursor = text_obj.createTextCursor()
+
+            # Add paragraph break
+            text_obj.insertControlCharacter(text_obj.getEnd(), PARAGRAPH_BREAK, False)
+
+            text_obj.insertString(text_obj.getEnd(), text, False)
+
+            # Move cursor to the added text
+            cursor.gotoEnd(False)
+            cursor.goLeft(len(text), True)  # Select the text
+
+            # Apply heading style
+            heading_style = f"Heading {level}"
+            if cursor.ParaStyleName != heading_style:
+                cursor.ParaStyleName = heading_style
+
+            # Add paragraph break
+            text_obj.insertControlCharacter(text_obj.getEnd(), PARAGRAPH_BREAK, False)
+
+            # Save document
+            doc.store()
+            return f"Heading added to {file_path}"
+        else:
+            raise HelperError("Document does not support headings")
+
+
+def add_paragraph(file_path, text, style=None, alignment=None):
+    """Add a paragraph with optional styling."""
+    with managed_document(file_path) as doc:
+        if hasattr(doc, "getText"):
+            text_obj = doc.getText()
+            cursor = text_obj.createTextCursor()
+
+            # Go to the end of the document
+            cursor.gotoEnd(False)
+
+            # Insert the paragraph text
+            text_obj.insertString(cursor, text, False)
+
+            # Select the inserted text
+            cursor.gotoEnd(False)
+            cursor.goLeft(len(text), True)
+
+            # Apply style if specified
+            if style:
+                try:
+                    cursor.ParaStyleName = style
+                except Exception as style_error:
+                    raise HelperError(f"Error applying style: {style_error}")
+
+            # Apply alignment if specified
+            alignment_map = {
+                "left": LEFT,
+                "center": CENTER,
+                "right": RIGHT,
+                "justify": BLOCK,
+            }
+
+            if alignment and alignment.lower() in alignment_map:
+                cursor.ParaAdjust = alignment_map[alignment.lower()]
+
+            # Add paragraph break
+            text_obj.insertControlCharacter(text_obj.getEnd(), PARAGRAPH_BREAK, False)
+
+            # Save document
+            doc.store()
+            return f"Paragraph added to {file_path}"
+        else:
+            raise HelperError("Document does not support paragraphs")
+
+
+def format_text(file_path, text_to_find, format_options):
+    """Format specific text in a document."""
+    with managed_document(file_path) as doc:
+        if hasattr(doc, "getText"):
+            search = doc.createSearchDescriptor()
+            search.SearchString = text_to_find
+            search.SearchCaseSensitive = False
+
+            found = doc.findFirst(search)
+            found_count = 0
+
+            while found:
+                found_count += 1
+                # Apply formatting
+                if format_options.get("bold"):
+                    found.CharWeight = 150
+                if format_options.get("italic"):
+                    # Try to use the proper UNO constant first
+                    try:
+                        found.CharPosture = ITALIC
+                        logging.info(f"Set CharPosture to ITALIC constant: {ITALIC}")
+                    except ImportError:
+                        # Fallback to numeric value
+                        found.CharPosture = 2
+                        logging.info("Set CharPosture to numeric value 2")
+
+                    # Log what was actually set
+                    actual_posture = getattr(found, "CharPosture", "unknown")
+                    logging.info(
+                        f"Actual CharPosture value after setting: {actual_posture} (type: {type(actual_posture)})"
+                    )
+
+                if format_options.get("underline"):
+                    found.CharUnderline = 1
+                if format_options.get("color"):
+                    color = format_options["color"]
+                    if isinstance(color, str) and color.startswith("#"):
+                        color = int(color[1:], 16)
+                    found.CharColor = color
+                if format_options.get("font"):
+                    found.CharFontName = format_options["font"]
+                if format_options.get("size"):
+                    found.CharHeight = float(format_options["size"])
+
+                # Find next occurrence
+                found = doc.findNext(found.End, search)
+
+            doc.store()
+            return f"Formatted {found_count} occurrences of '{text_to_find}' in {file_path}"
+        else:
+            raise HelperError("Document does not support text formatting")
+
+
+def search_replace_text(file_path, search_text, replace_text):
+    """Search and replace text throughout the document."""
+    with managed_document(file_path) as doc:
+        if hasattr(doc, "getText"):
+            text_obj = doc.getText()
+            document_text = text_obj.getString()
+
+            # Check if text exists in document
+            if search_text not in document_text:
+                raise HelperError(f"Text '{search_text}' not found in document")
+
+            # Create replace descriptor
+            replace_desc = doc.createReplaceDescriptor()
+            replace_desc.SearchString = search_text
+            replace_desc.ReplaceString = replace_text
+            replace_desc.SearchCaseSensitive = False
+            replace_desc.SearchWords = False
+
+            # Perform replacement
+            count = doc.replaceAll(replace_desc)
+
+            # Save document
+            doc.store()
+            return f"Replaced {count} occurrences of '{search_text}' with '{replace_text}' in {file_path}"
+        else:
+            raise HelperError("Document does not support search and replace")
+
+
+def delete_text(file_path, text_to_delete):
+    """Delete specific text from the document."""
+    return search_replace_text(file_path, text_to_delete, "")
+
+
+def add_table(file_path, rows, columns, data=None, header_row=False):
+    """Add a table to a document."""
+    with managed_document(file_path) as doc:
+        if hasattr(doc, "getText"):
+            text = doc.getText()
+            cursor = text.createTextCursor()
+            cursor.gotoEnd(False)  # Move to end of document
+
+            # Create table
+            table = doc.createInstance("com.sun.star.text.TextTable")
+            table.initialize(rows, columns)
+            text.insertTextContent(cursor, table, False)
+
+            # Populate table if data is provided
+            if data:
+                try:
+                    for row_idx, row_data in enumerate(data):
+                        if row_idx >= rows:
+                            break
+                        for col_idx, cell_value in enumerate(row_data):
+                            if col_idx >= columns:
+                                break
+                            cell_name = chr(65 + col_idx) + str(
+                                row_idx + 1
+                            )  # A1, B1, etc.
+                            cell = table.getCellByName(cell_name)
+                            cell_text = cell.getText()
+                            cell_text.setString(str(cell_value))
+                except Exception as table_error:
+                    raise HelperError(f"Error populating table: {str(table_error)}")
+
+            # Format header row if requested
+            if header_row and rows > 0:
+                try:
+                    # Format cells in first row as bold
+                    for col_idx in range(columns):
+                        cell_name = chr(65 + col_idx) + "1"  # A1, B1, etc.
+                        cell = table.getCellByName(cell_name)
+                        cursor = cell.getText().createTextCursor()
+                        cursor.gotoStart(False)
+                        cursor.gotoEnd(True)
+                        cursor.CharWeight = 150  # Bold
+                except Exception as header_error:
+                    raise HelperError(f"Error formatting header row: {header_error}")
+
+            # Save document
+            doc.store()
+            return f"Table added to {file_path}"
+
+
+def format_table(file_path, table_index, format_options):
+    """Format a table with borders, shading, etc."""
+    with managed_document(file_path) as doc:
+        if not hasattr(doc, "getTextTables"):
+            raise HelperError("Document does not support table formatting")
+
+        tables = doc.getTextTables()
+        if tables.getCount() <= table_index:
+            raise HelperError(
+                f"Table index {table_index} is out of range (document has {tables.getCount()} tables)"
+            )
+
+        table = tables.getByIndex(table_index)
+
+        # Apply table formatting options
+        if "border_width" in format_options:
+            try:
+                width = int(format_options["border_width"])
+                width_in_hundredths_mm = int(width * 35.28)
+
+                logging.info(
+                    f"Setting border width: {width} points = {width_in_hundredths_mm} 1/100mm"
+                )
+
+                # Create border line
+                border_line = BorderLine2()
+                border_line.LineWidth = width_in_hundredths_mm
+                border_line.LineStyle = SOLID
+                border_line.Color = 0  # Black color
+
+                table_border_2 = table.getPropertyValue("TableBorder2")
+                table_border_2.TopLine = border_line
+                table_border_2.BottomLine = border_line
+                table_border_2.LeftLine = border_line
+                table_border_2.RightLine = border_line
+                table_border_2.HorizontalLine = border_line
+                table_border_2.VerticalLine = border_line
+                table.setPropertyValue("TableBorder2", table_border_2)
+
+            except Exception as border_error:
+                logging.error(f"Border formatting error: {border_error}")
+                raise HelperError(f"Error applying table borders: {border_error}")
+
+        if "background_color" in format_options:
+            try:
+                color = format_options["background_color"]
+                if isinstance(color, str) and color.startswith("#"):
+                    color = int(color[1:], 16)
+                table.BackColor = color
+            except Exception as color_error:
+                raise HelperError(
+                    f"Error applying table background color: {color_error}"
+                )
+
+        # Format specific rows if requested
+        if "header_row" in format_options:
+            try:
+                if format_options["header_row"]:
+                    row = table.getRows().getByIndex(0)
+                    row.BackColor = 13421772  # Light gray
+
+                    # Format header cells
+                    for col_idx in range(table.getColumns().getCount()):
+                        cell = table.getCellByPosition(col_idx, 0)
+                        cursor = cell.getText().createTextCursor()
+                        cursor.gotoStart(False)
+                        cursor.gotoEnd(True)
+                        cursor.CharWeight = 150  # Bold
+                else:
+                    row = table.getRows().getByIndex(0)
+                    row.BackColor = 16777215  # White
+
+                    # Format header cells
+                    for col_idx in range(table.getColumns().getCount()):
+                        cell = table.getCellByPosition(col_idx, 0)
+                        cursor = cell.getText().createTextCursor()
+                        cursor.gotoStart(False)
+                        cursor.gotoEnd(True)
+                        cursor.CharWeight = 100  # Normal
+            except Exception as header_error:
+                raise HelperError(f"Error formatting header row: {header_error}")
+
+        # Save document
+        doc.store()
+        return f"Table formatted in {file_path}"
+
+
+def insert_image(file_path, image_path, width=None, height=None):
+    """Insert an image into a document using dispatch."""
+    with managed_document(file_path) as doc:
+        # Normalize image path
+        image_path = normalize_path(image_path)
+        if not image_path:
+            raise HelperError("Invalid image path provided")
+
+        if not os.path.exists(image_path):
+            raise HelperError(f"Image not found: {image_path}")
+
+        # Get component context and necessary services
+        ctx = uno.getComponentContext()
+        smgr = ctx.ServiceManager
+
+        # Create dispatch helper for UNO commands
+        dispatcher = smgr.createInstanceWithContext(
+            "com.sun.star.frame.DispatchHelper", ctx
+        )
+
+        # Get frame from document controller
+        frame = doc.getCurrentController().getFrame()
+
+        # Create properties for InsertGraphic command
+        props = []
+
+        # Add filename property - convert to URL format
+        filename_prop = PropertyValue()
+        filename_prop.Name = "FileName"
+        filename_prop.Value = uno.systemPathToFileUrl(image_path)
+        props.append(filename_prop)
+
+        # Add AsLink property
+        aslink_prop = PropertyValue()
+        aslink_prop.Name = "AsLink"
+        aslink_prop.Value = False  # Set to True if you want to link instead of embed
+        props.append(aslink_prop)
+
+        # Execute the InsertGraphic command
+        dispatcher.executeDispatch(frame, ".uno:InsertGraphic", "", 0, tuple(props))
+
+        # Optional: Resize the image if width/height provided
+        if width is not None or height is not None:
+            # Try to get the inserted image as the current selection
+            current_selection = doc.getCurrentController().getSelection()
+            if (
+                current_selection
+                and hasattr(current_selection, "getCount")
+                and current_selection.getCount() > 0
+            ):
+                shape = current_selection.getByIndex(0)
+
+                # Calculate new size preserving aspect ratio
+                if width is not None and height is not None:
+                    # Use both dimensions as provided
+                    size = Size(width, height)
+                    shape.setSize(size)
+                elif width is not None:
+                    # Maintain aspect ratio based on width
+                    ratio = shape.Size.Height / shape.Size.Width
+                    new_height = int(width * ratio)
+                    shape.setSize(Size(width, new_height))
+                elif height is not None:
+                    # Maintain aspect ratio based on height
+                    ratio = shape.Size.Width / shape.Size.Height
+                    new_width = int(height * ratio)
+                    shape.setSize(Size(new_width, height))
+            elif current_selection:
+                # Try alternative approach for Writer documents
+                try:
+                    # For Writer, the selection might be a TextGraphicObject
+                    if hasattr(current_selection, "getImplementationName"):
+                        impl_name = current_selection.getImplementationName()
+                        if (
+                            "TextGraphicObject" in impl_name
+                            or "GraphicObject" in impl_name
+                        ):
+                            shape = current_selection
+
+                            # Calculate new size preserving aspect ratio
+                            if width is not None and height is not None:
+                                size = Size(width, height)
+                                shape.setSize(size)
+                            elif width is not None:
+                                ratio = shape.Size.Height / shape.Size.Width
+                                new_height = int(width * ratio)
+                                shape.setSize(Size(width, new_height))
+                            elif height is not None:
+                                ratio = shape.Size.Width / shape.Size.Height
+                                new_width = int(height * ratio)
+                                shape.setSize(Size(new_width, height))
+                except Exception as resize_error:
+                    logging.warning(f"Could not resize image: {resize_error}")
+
+        # Save document
+        doc.store()
+        return f"Image inserted into {file_path}"
+
+
+def insert_page_break(file_path):
+    """Insert a page break at the end of the document."""
+    with managed_document(file_path) as doc:
+        if hasattr(doc, "getText"):
+            text_obj = doc.getText()
+
+            # Insert page break at the end of the document
+            text_obj.insertControlCharacter(
+                text_obj.getEnd(), ControlCharacter.PARAGRAPH_BREAK, False
+            )
+            cursor = text_obj.createTextCursor()
+            cursor.gotoEnd(False)
+            cursor.BreakType = PAGE_BEFORE
+
+            # Save document
+            doc.store()
+            return f"Page break inserted in {file_path}"
+
+
+# DISABLED - not currently functioning
+# def create_custom_style(file_path, style_name, style_properties):
+#     """Create a custom paragraph style."""
+#     with managed_document(file_path) as doc:
+#         # Check if document supports styles
+#         if not hasattr(doc, "StyleFamilies"):
+#             raise HelperError("Document does not support custom styles")
+
+#         # Get paragraph styles
+#         para_styles = doc.StyleFamilies.getByName("ParagraphStyles")
+
+#         # Create new style or modify existing style
+#         style = None
+#         if para_styles.hasByName(style_name):
+#             style = para_styles.getByName(style_name)
+#         else:
+#             style = doc.createInstance("com.sun.star.style.ParagraphStyle")
+#             para_styles.insertByName(style_name, style)
+
+#         # Apply style properties
+#         for prop, value in style_properties.items():
+#             if prop == "font_name":
+#                 style.CharFontName = value
+#             elif prop == "font_size":
+#                 style.CharHeight = float(value)
+#             elif prop == "bold":
+#                 style.CharWeight = 150 if value else 100
+#             elif prop == "italic":
+#                 style.CharPosture = uno.getConstantByName("com.sun.star.awt.FontSlant.ITALIC") if value else uno.getConstantByName("com.sun.star.awt.FontSlant.NONE")
+#             elif prop == "underline":
+#                 style.CharUnderline = 1 if value else 0
+#             elif prop == "color":
+#                 if isinstance(value, str) and value.startswith("#"):
+#                     value = int(value[1:], 16)
+#                 style.CharColor = value
+#             elif prop == "alignment":
+#                 alignment_map = {
+#                     "left": LEFT,
+#                     "center": CENTER,
+#                     "right": RIGHT,
+#                     "justify": BLOCK
+#                 }
+#                 if value.lower() in alignment_map:
+#                     style.ParaAdjust = alignment_map[value.lower()]
+
+#         # Save document
+#         doc.store()
+#         return f"Custom style '{style_name}' created/updated in {file_path}"
+
+
+def delete_paragraph(file_path, paragraph_index):
+    """Delete a paragraph at the given index."""
+    with managed_document(file_path) as doc:
+        if hasattr(doc, "getText"):
+            text = doc.getText()
+
+            # Get all paragraphs
+            paragraphs = []
+            enum = text.createEnumeration()
+            while enum.hasMoreElements():
+                paragraphs.append(enum.nextElement())
+
+            # Check if index is valid
+            if paragraph_index < 0 or paragraph_index >= len(paragraphs):
+                raise HelperError(
+                    f"Paragraph index {paragraph_index} is out of range (document has {len(paragraphs)} paragraphs)"
+                )
+
+            # Get paragraph cursor
+            paragraph = paragraphs[paragraph_index]
+            paragraph_cursor = text.createTextCursorByRange(paragraph)
+
+            # Delete paragraph
+            text.removeTextContent(paragraph)
+
+            # Save document
+            doc.store()
+            return f"Paragraph at index {paragraph_index} deleted from {file_path}"
+        else:
+            raise HelperError("Document does not support paragraph deletion")
+
+
+def apply_document_style(file_path, style):
+    """Apply consistent formatting throughout the document."""
+    with managed_document(file_path) as doc:
+        if not hasattr(doc, "getText"):
+            raise HelperError("Document does not support style application")
+
+        # Apply styles to all paragraphs
+        text = doc.getText()
+        cursor = text.createTextCursor()
+        cursor.gotoStart(False)
+        cursor.gotoEnd(True)
+
+        # Apply character formatting
+        if "font_name" in style:
+            cursor.CharFontName = style["font_name"]
+
+        if "font_size" in style:
+            cursor.CharHeight = float(style["font_size"])
+
+        if "color" in style:
+            color = style["color"]
+            if isinstance(color, str) and color.startswith("#"):
+                color = int(color[1:], 16)
+            cursor.CharColor = color
+
+        # Apply paragraph formatting
+        if "alignment" in style:
+            alignment_map = {
+                "left": LEFT,
+                "center": CENTER,
+                "right": RIGHT,
+                "justify": BLOCK,
+            }
+            if style["alignment"].lower() in alignment_map:
+                cursor.ParaAdjust = alignment_map[style["alignment"].lower()]
+
+        # Save document
+        doc.store()
+        return f"Style applied to document {file_path}"
+
+
+# Impress helper functions
+
+
+def valid_presentation(doc):
+    # Check the presentation has DrawPages
+    if not hasattr(doc, "getDrawPages"):
+        error_msg = "Document does not support slides/pages"
+        logging.error(error_msg)
+        raise HelperError(error_msg)
+    return doc
+
+
+def get_validated_slide(draw_pages, slide_index, delete=False):
+    num_slides = draw_pages.getCount()
+
+    # Validate slide index
+    if slide_index < 0 or slide_index >= num_slides:
+        error_msg = f"Slide index {slide_index} is out of range"
+        raise HelperError(error_msg)
+
+    # Prevent deletion of the last slide
+    if delete and num_slides == 1:
+        error_msg = "Cannot delete the only slide in the presentation"
+        logging.error(error_msg)
+        raise HelperError(error_msg)
+
+    target_slide = draw_pages.getByIndex(slide_index)
+    return target_slide
+
+
+def find_template_files(base_directory, template_name):
+    """Recursively search for presentation template files in a directory."""
+    found_templates = []
+
+    if not os.path.exists(base_directory) or not os.path.isdir(base_directory):
+        logging.info(f"Directory does not exist: {base_directory}")
+        return found_templates
+
+    template_extensions = [".otp"]  # Only support .otp initially
+
+    try:
+        # Walk through all subdirectories recursively
+        for root, dirs, files in os.walk(base_directory):
+            logging.info(f"Searching in directory: {root}")
+
+            for file in files:
+                file_lower = file.lower()
+                template_name_lower = template_name.lower()
+
+                # Check if file matches template name and has a valid extension
+                for ext in template_extensions:
+                    # Check for exact match with extension
+                    if file_lower == f"{template_name_lower}{ext}":
+                        full_path = os.path.join(root, file)
+                        found_templates.append(full_path)
+                        logging.info(f"Found exact match: {full_path}")
+                    # Check for partial match (template name contained in filename)
+                    elif template_name_lower in file_lower and file_lower.endswith(ext):
+                        full_path = os.path.join(root, file)
+                        found_templates.append(full_path)
+                        logging.info(f"Found partial match: {full_path}")
+
+        # Sort by preference: exact matches first, then by file extension preference
+        def sort_key(template_path):
+            filename = os.path.basename(template_path).lower()
+            template_name_lower = template_name.lower()
+
+            # Exact match gets highest priority
+            if filename.startswith(f"{template_name_lower}."):
+                return (0, template_path)
+            # Partial matches get lower priority
+            else:
+                return (1, template_path)
+
+        found_templates.sort(key=sort_key)
+
+    except Exception as e:
+        logging.error(f"Error searching for templates in {base_directory}: {e}")
+        logging.error(traceback.format_exc())
+
+    return found_templates
+
+
+def add_main_textbox(doc, target_slide):
+    """Add a main content textbox to a slide."""
+    try:
+        # Create a new main content textbox since none exists
+        logging.info("Creating new main content textbox")
+
+        try:
+            # Try to create an OutlinerShape first (preferred for presentations)
+            content_shape = None
+            try:
+                content_shape = doc.createInstance(
+                    "com.sun.star.presentation.OutlinerShape"
+                )
+                logging.info("Created OutlinerShape")
+            except Exception as outliner_error:
+                logging.warning(f"Could not create OutlinerShape: {outliner_error}")
+                # Fallback to regular TextShape
+                content_shape = doc.createInstance("com.sun.star.drawing.TextShape")
+                logging.info("Created fallback TextShape")
+
+            if not content_shape:
+                raise HelperError("Failed to create content textbox shape")
+
+            # Set size and position for main content area
+            # Standard content area positioning (below title area)
+            content_shape.setSize(Size(24000, 14000))  # Width: 24cm, Height: 14cm
+            content_shape.setPosition(uno.createUnoStruct("com.sun.star.awt.Point"))
+            content_shape.Position.X = 2000  # 2cm from left
+            content_shape.Position.Y = 6000  # 6cm from top (below title area)
+
+            # Set presentation object type for content if possible
+            try:
+                if hasattr(content_shape, "PresentationObject"):
+                    content_shape.PresentationObject = 2  # Content placeholder type
+                    logging.info("Set PresentationObject type to content")
+            except Exception as pres_obj_set_error:
+                logging.warning(
+                    f"Could not set PresentationObject: {pres_obj_set_error}"
+                )
+
+            # Add the shape to the slide
+            target_slide.add(content_shape)
+            logging.info("Added content textbox to slide")
+
+            # Set default placeholder text
+            try:
+                placeholder_text = "Click to add content"
+                content_text = content_shape.getText()
+                content_text.setString(placeholder_text)
+
+                # Apply basic formatting
+                content_cursor = content_text.createTextCursor()
+                content_cursor.gotoStart(False)
+                content_cursor.gotoEnd(True)
+                content_cursor.CharHeight = 18
+                content_cursor.ParaAdjust = LEFT
+                content_cursor.CharColor = 8421504  # Gray color for placeholder
+
+                logging.info("Set placeholder text and formatting")
+            except Exception as text_error:
+                logging.warning(f"Could not set placeholder text: {text_error}")
+
+        except Exception as create_error:
+            error_msg = f"Failed to create main content textbox: {create_error}"
+            logging.error(error_msg)
+            raise HelperError(error_msg)
+
+        success_msg = f"Successfully added main content textbox"
+        logging.info(success_msg)
+        return content_shape
+
+    except Exception as e:
+        error_msg = f"Error in add_main_textbox: {str(e)}"
+        logging.error(error_msg)
+        logging.error(traceback.format_exc())
+        try:
+            if "doc" in locals():
+                doc.close(True)
+        except:
+            pass
+        raise HelperError(error_msg)
+
+
+# Impress functions
+
+
+def extract_impress_text(file_path):
+    """Extract all text from an Impress presentation (.odp)."""
+    with managed_document(file_path, read_only=True) as doc:
+        if valid_presentation(doc):
+            draw_pages = doc.getDrawPages()
+            slide_count = draw_pages.getCount()
+            all_text = []
+
+            for i in range(slide_count):
+                slide = draw_pages.getByIndex(i)
+                slide_texts = []
+                # Iterate over all shapes on the slide
+                for shape_idx in range(slide.getCount()):
+                    shape = slide.getByIndex(shape_idx)
+                    # Some shapes have getString(), some have getText()
+                    if hasattr(shape, "getString"):
+                        text = shape.getString()
+                        if text:
+                            slide_texts.append(text)
+                    elif hasattr(shape, "getText"):
+                        text_obj = shape.getText()
+                        if hasattr(text_obj, "getString"):
+                            text = text_obj.getString()
+                            if text:
+                                slide_texts.append(text)
+                all_text.append(f"Slide {i + 1}:\n" + "\n".join(slide_texts))
+
+            return (
+                "\n\n".join(all_text) if all_text else "No text found in presentation."
+            )
+
+
+def add_slide(file_path, slide_index=None, title=None, content=None):
+    """
+    Add a new slide to an Impress presentation using a built-in layout.
+    Args:
+        file_path: Path to the presentation file.
+        slide_index: Index to insert the slide (None = append at end).
+        title: Optional title text for the slide.
+        content: Optional content text for the slide.
+    """
+    logging.info(
+        f"add_slide called with: file_path={file_path}, slide_index={slide_index}, title={title}, content={content}"
+    )
+
+    with managed_document(file_path) as doc:
+        if valid_presentation(doc):
+            draw_pages = doc.getDrawPages()
+            num_slides = draw_pages.getCount()
+            logging.info(f"Current number of slides: {num_slides}")
+
+            # Determine where to insert the slide
+            insert_index = (
+                num_slides
+                if slide_index is None
+                else max(0, min(slide_index, num_slides))
+            )
+            logging.info(f"Inserting slide at index: {insert_index}")
+
+            # Insert new slide
+            draw_pages.insertNewByIndex(insert_index)
+            new_slide = draw_pages.getByIndex(insert_index)
+            logging.info("New slide created")
+
+            # Apply slide layout first
+            layout_applied = False
+            try:
+                layout_type = 1  # TitleContent layout
+                logging.info(f"Applying layout type: {layout_type}")
+
+                # Apply the layout using different methods
+                if hasattr(new_slide, "setLayout"):
+                    new_slide.setLayout(layout_type)
+                    layout_applied = True
+                    logging.info("Layout applied using setLayout")
+                elif hasattr(new_slide, "Layout"):
+                    new_slide.Layout = layout_type
+                    layout_applied = True
+                    logging.info("Layout applied using Layout property")
+                else:
+                    logging.warning("No layout method found")
+
+            except Exception as layout_error:
+                logging.warning(f"Could not apply layout: {layout_error}")
+
+            # Give LibreOffice time to create the placeholder shapes
+            if layout_applied:
+                time.sleep(0.5)
+
+            # Now look for the actual placeholder shapes that were created by the layout
+            title_shape = None
+            content_shape = None
+
+            logging.info(f"Number of shapes on slide: {new_slide.getCount()}")
+
+            # Examine all shapes on the slide
+            for i in range(new_slide.getCount()):
+                shape = new_slide.getByIndex(i)
+                shape_type = shape.getShapeType()
+                logging.info(f"Shape {i}: {shape_type}")
+
+                # Check if this shape has text capabilities
+                if hasattr(shape, "getText"):
+                    try:
+                        # Check for LibreOffice presentation shapes by type
+                        if shape_type == "com.sun.star.presentation.TitleTextShape":
+                            title_shape = shape
+                            logging.info(f"  Found title shape at index {i}")
+                        elif shape_type == "com.sun.star.presentation.OutlinerShape":
+                            # This is a content placeholder - use the first one we find
+                            if not content_shape:
+                                content_shape = shape
+                                logging.info(f"  Found content shape at index {i}")
+                            else:
+                                logging.info(
+                                    f"  Found additional content shape at index {i} (ignoring)"
+                                )
+
+                        # Fallback: Try to get presentation object type
+                        elif hasattr(shape, "PresentationObject"):
+                            pres_obj = shape.PresentationObject
+                            logging.info(f"  PresentationObject: {pres_obj}")
+
+                            # Check for title placeholder
+                            if (
+                                pres_obj in [0, 1] and not title_shape
+                            ):  # Title placeholders
+                                title_shape = shape
+                                logging.info(f"  Found title placeholder at shape {i}")
+                            # Check for content placeholder
+                            elif (
+                                pres_obj in [2, 3, 4, 5] and not content_shape
+                            ):  # Content placeholders
+                                content_shape = shape
+                                logging.info(
+                                    f"  Found content placeholder at shape {i}"
+                                )
+
+                        # Additional fallback: check shape name or position
+                        else:
+                            if hasattr(shape, "Name"):
+                                shape_name = shape.Name.lower()
+                                logging.info(f"  Shape name: '{shape_name}'")
+                                if "title" in shape_name and not title_shape:
+                                    title_shape = shape
+                                    logging.info(
+                                        f"  Found title shape by name at shape {i}"
+                                    )
+                                elif (
+                                    any(
+                                        keyword in shape_name
+                                        for keyword in ["content", "text", "outline"]
+                                    )
+                                    and not content_shape
+                                ):
+                                    content_shape = shape
+                                    logging.info(
+                                        f"  Found content shape by name at shape {i}"
+                                    )
+
+                            # Position-based fallback (title usually at top)
+                            if (
+                                hasattr(shape, "Position")
+                                and not title_shape
+                                and not content_shape
+                            ):
+                                y_pos = shape.Position.Y
+                                if y_pos < 5000:  # Top area - likely title
+                                    title_shape = shape
+                                    logging.info(
+                                        f"  Assuming title shape by position at shape {i} (Y: {y_pos})"
+                                    )
+                                elif (
+                                    y_pos > 5000 and not content_shape
+                                ):  # Lower area - likely content
+                                    content_shape = shape
+                                    logging.info(
+                                        f"  Assuming content shape by position at shape {i} (Y: {y_pos})"
+                                    )
+
+                    except Exception as shape_error:
+                        logging.warning(f"  Error examining shape {i}: {shape_error}")
+
+            # If we still don't have placeholders and text was requested, create manual shapes
+            if title and not title_shape:
+                logging.info("Creating manual title shape")
+                title_shape = doc.createInstance("com.sun.star.drawing.TextShape")
+                title_shape.setSize(Size(24000, 3000))
+                title_shape.setPosition(uno.createUnoStruct("com.sun.star.awt.Point"))
+                title_shape.Position.X = 2000
+                title_shape.Position.Y = 2000
+                new_slide.add(title_shape)
+
+            if content and not content_shape:
+                logging.info("Creating manual content shape")
+                content_shape = doc.createInstance("com.sun.star.drawing.TextShape")
+                content_shape.setSize(Size(24000, 14000))
+                content_shape.setPosition(uno.createUnoStruct("com.sun.star.awt.Point"))
+                content_shape.Position.X = 2000
+                content_shape.Position.Y = 6000
+                new_slide.add(content_shape)
+
+            # Set title text
+            if title and title_shape:
+                logging.info(f"Setting title text: {title}")
+                try:
+                    title_text = title_shape.getText()
+                    title_text.setString(title)
+
+                    # Format title
+                    title_cursor = title_text.createTextCursor()
+                    title_cursor.gotoStart(False)
+                    title_cursor.gotoEnd(True)
+                    title_cursor.CharHeight = 28
+                    title_cursor.CharWeight = 150
+                    title_cursor.ParaAdjust = CENTER
+                    logging.info("Title text set and formatted")
+                except Exception as title_error:
+                    logging.error(f"Error setting title: {title_error}")
+
+            # Set content text
+            if content and content_shape:
+                logging.info(f"Setting content text: {content}")
+                try:
+                    content_text = content_shape.getText()
+                    content_text.setString(content)
+
+                    # Format content
+                    content_cursor = content_text.createTextCursor()
+                    content_cursor.gotoStart(False)
+                    content_cursor.gotoEnd(True)
+                    content_cursor.CharHeight = 18
+                    content_cursor.ParaAdjust = LEFT
+                    logging.info("Content text set and formatted")
+                except Exception as content_error:
+                    logging.error(f"Error setting content: {content_error}")
+
+            # Save and close
+            logging.info("Saving document...")
+            doc.store()
+
+            success_msg = f"Slide added at index {insert_index} with TitleContent layout in {file_path}"
+            logging.info(success_msg)
+            return success_msg
+
+
+def edit_slide_content(file_path, slide_index, new_content):
+    """
+    Edit the main text content of a specific slide in an Impress presentation.
+    """
+    logging.info(
+        f"edit_slide_content called with: file_path={file_path}, slide_index={slide_index}"
+    )
+
+    with managed_document(file_path) as doc:
+        if valid_presentation(doc):
+            draw_pages = doc.getDrawPages()
+
+            target_slide = get_validated_slide(draw_pages, slide_index)
+
+            logging.info(f"Editing slide at index: {slide_index}")
+
+            # Enhanced shape detection logic
+            main_content_shape = None
+            all_text_shapes = []  # Store all potential text shapes for fallback
+
+            logging.info(f"Number of shapes on slide: {target_slide.getCount()}")
+
+            # First pass: Collect all text-capable shapes and categorize them
+            for i in range(target_slide.getCount()):
+                try:
+                    shape = target_slide.getByIndex(i)
+                    shape_type = shape.getShapeType()
+                    logging.info(f"Shape {i}: {shape_type}")
+
+                    # Check if this shape has text capabilities
+                    if hasattr(shape, "getText"):
+                        shape_info = {
+                            "shape": shape,
+                            "index": i,
+                            "type": shape_type,
+                            "priority": 99,  # Default low priority
+                            "reason": "unknown",
+                        }
+
+                        # Priority 1: Standard presentation OutlinerShape (highest priority)
+                        if shape_type == "com.sun.star.presentation.OutlinerShape":
+                            shape_info["priority"] = 1
+                            shape_info["reason"] = "OutlinerShape"
+                            all_text_shapes.append(shape_info)
+                            logging.info(
+                                f"  Found OutlinerShape at index {i} (priority 1)"
+                            )
+                            continue
+
+                        # Skip title shapes explicitly
+                        if shape_type == "com.sun.star.presentation.TitleTextShape":
+                            logging.info(f"  Skipping title shape at index {i}")
+                            continue
+
+                        # Priority 2: Check PresentationObject for content placeholders
+                        try:
+                            if hasattr(shape, "PresentationObject"):
+                                pres_obj = shape.PresentationObject
+                                logging.info(f"  PresentationObject: {pres_obj}")
+
+                                # Content placeholders (exclude title placeholders 0,1)
+                                if pres_obj in [2, 3, 4, 5]:
+                                    shape_info["priority"] = 2
+                                    shape_info["reason"] = (
+                                        f"PresentationObject-{pres_obj}"
+                                    )
+                                    all_text_shapes.append(shape_info)
+                                    logging.info(
+                                        f"  Found content placeholder at index {i} (priority 2)"
+                                    )
+                                    continue
+                        except Exception as pres_obj_error:
+                            logging.warning(
+                                f"  Error checking PresentationObject: {pres_obj_error}"
+                            )
+
+                        # Priority 3: Regular TextShape (common for manual text boxes)
+                        if shape_type == "com.sun.star.drawing.TextShape":
+                            shape_info["priority"] = 3
+                            shape_info["reason"] = "TextShape"
+                            all_text_shapes.append(shape_info)
+                            logging.info(f"  Found TextShape at index {i} (priority 3)")
+                            continue
+
+                        # Priority 4: Check shape name for content indicators
+                        if hasattr(shape, "Name"):
+                            shape_name = shape.Name.lower()
+                            logging.info(f"  Shape name: '{shape_name}'")
+
+                            # Skip if name suggests it's a title
+                            if "title" in shape_name:
+                                logging.info(f"  Skipping shape with 'title' in name")
+                                continue
+
+                            # Prefer shapes with content-related names
+                            if any(
+                                keyword in shape_name
+                                for keyword in ["content", "text", "outline", "body"]
+                            ):
+                                shape_info["priority"] = 4
+                                shape_info["reason"] = f"name-{shape_name}"
+                                all_text_shapes.append(shape_info)
+                                logging.info(
+                                    f"  Found content shape by name at index {i} (priority 4)"
+                                )
+                                continue
+
+                        # Priority 5: Position and content-based detection
+                        if hasattr(shape, "Position"):
+                            y_pos = shape.Position.Y
+
+                            # Get existing text content
+                            try:
+                                text_obj = shape.getText()
+                                existing_text = (
+                                    text_obj.getString()
+                                    if hasattr(text_obj, "getString")
+                                    else ""
+                                )
+                            except:
+                                existing_text = ""
+
+                            # Content area detection (below title area)
+                            if y_pos > 3000:  # Likely content area
+                                priority = 5
+                                # Boost priority if shape has existing content
+                                if existing_text.strip():
+                                    priority = 4
+                                    shape_info["reason"] = (
+                                        f"position-with-content-Y{y_pos}"
+                                    )
+                                else:
+                                    shape_info["reason"] = f"position-Y{y_pos}"
+
+                                shape_info["priority"] = priority
+                                all_text_shapes.append(shape_info)
+                                logging.info(
+                                    f"  Found text shape by position at index {i} (priority {priority})"
+                                )
+
+                        # Priority 6: Any other text-capable shape as final fallback
+                        if not any(info["shape"] == shape for info in all_text_shapes):
+                            shape_info["priority"] = 6
+                            shape_info["reason"] = "fallback-text-capable"
+                            all_text_shapes.append(shape_info)
+                            logging.info(
+                                f"  Added fallback text shape at index {i} (priority 6)"
+                            )
+
+                except Exception as shape_error:
+                    logging.warning(f"  Error examining shape {i}: {shape_error}")
+
+            # Sort by priority (lower number = higher priority) and select the best match
+            if all_text_shapes:
+                all_text_shapes.sort(key=lambda x: (x["priority"], x["index"]))
+                best_match = all_text_shapes[0]
+                main_content_shape = best_match["shape"]
+                logging.info(
+                    f"Selected shape at index {best_match['index']} with priority {best_match['priority']} (reason: {best_match['reason']})"
+                )
+
+                # Log all candidates for debugging
+                logging.info("All text shape candidates:")
+                for info in all_text_shapes:
+                    logging.info(
+                        f"  Index {info['index']}: Priority {info['priority']}, Reason: {info['reason']}, Type: {info['type']}"
+                    )
+
+            # If still no content shape found, create one
+            if not main_content_shape:
+                logging.warning(
+                    "No suitable text shape found, creating new content textbox"
+                )
+                main_content_shape = add_main_textbox(doc, target_slide)
+
+            # Edit the selected content shape
+            try:
+                # Get current text for logging
+                current_text = (
+                    main_content_shape.getText().getString()
+                    if hasattr(main_content_shape, "getText")
+                    else ""
+                )
+                logging.info(
+                    f"Editing content shape - current text: '{current_text[:50]}...'"
+                )
+
+                # Set new content
+                text_obj = main_content_shape.getText()
+                text_obj.setString(new_content)
+
+                # Verify the text was set correctly
+                verification_text = text_obj.getString()
+                if verification_text == new_content:
+                    logging.info("Content text updated successfully")
+                    edit_result = "Content updated successfully"
+                else:
+                    error_msg = f"Text verification failed: expected '{new_content}', got '{verification_text}'"
+                    logging.error(error_msg)
+                    edit_result = "Content update failed - verification error"
+
+                # Apply basic formatting for readability
+                try:
+                    text_cursor = text_obj.createTextCursor()
+                    text_cursor.gotoStart(False)
+                    text_cursor.gotoEnd(True)
+                    text_cursor.CharHeight = 18
+                    text_cursor.ParaAdjust = LEFT
+                    logging.info("Applied formatting to content text")
+                except Exception as format_error:
+                    logging.warning(f"Could not apply formatting: {format_error}")
+
+            except Exception as edit_error:
+                error_msg = f"Failed to edit content shape: {edit_error}"
+                logging.error(error_msg)
+                raise HelperError(error_msg)
+
+            # Save and close
+            logging.info("Saving document...")
+            doc.store()
+
+            success_msg = f"Successfully edited content of slide {slide_index} in {file_path}. {edit_result}"
+            logging.info(success_msg)
+            return success_msg
+
+
+def edit_slide_title(file_path, slide_index, new_title):
+    """
+    Edit the title of a specific slide in an Impress presentation.
+    """
+    logging.info(
+        f"edit_slide_title called with: file_path={file_path}, slide_index={slide_index}"
+    )
+
+    with managed_document(file_path) as doc:
+        if valid_presentation(doc):
+            draw_pages = doc.getDrawPages()
+
+            target_slide = get_validated_slide(draw_pages, slide_index)
+            logging.info(f"Editing title of slide at index: {slide_index}")
+
+            # Enhanced shape detection logic specifically for title shapes
+            main_title_shape = None
+            all_title_shapes = []  # Store all potential title shapes for fallback
+
+            logging.info(f"Number of shapes on slide: {target_slide.getCount()}")
+
+            # First pass: Collect all text-capable shapes and categorize them for title detection
+            for i in range(target_slide.getCount()):
+                try:
+                    shape = target_slide.getByIndex(i)
+                    shape_type = shape.getShapeType()
+                    logging.info(f"Shape {i}: {shape_type}")
+
+                    # Check if this shape has text capabilities
+                    if hasattr(shape, "getText"):
+                        shape_info = {
+                            "shape": shape,
+                            "index": i,
+                            "type": shape_type,
+                            "priority": 99,  # Default low priority
+                            "reason": "unknown",
+                        }
+
+                        # Priority 1: Standard presentation TitleTextShape (highest priority)
+                        if shape_type == "com.sun.star.presentation.TitleTextShape":
+                            shape_info["priority"] = 1
+                            shape_info["reason"] = "TitleTextShape"
+                            all_title_shapes.append(shape_info)
+                            logging.info(
+                                f"  Found TitleTextShape at index {i} (priority 1)"
+                            )
+                            continue
+
+                        # Skip content shapes explicitly
+                        if shape_type == "com.sun.star.presentation.OutlinerShape":
+                            logging.info(f"  Skipping content shape at index {i}")
+                            continue
+
+                        # Priority 2: Check PresentationObject for title placeholders
+                        try:
+                            if hasattr(shape, "PresentationObject"):
+                                pres_obj = shape.PresentationObject
+                                logging.info(f"  PresentationObject: {pres_obj}")
+
+                                # Title placeholders (0 = title, 1 = subtitle)
+                                if pres_obj in [0, 1]:
+                                    shape_info["priority"] = 2
+                                    shape_info["reason"] = (
+                                        f"PresentationObject-{pres_obj}"
+                                    )
+                                    all_title_shapes.append(shape_info)
+                                    logging.info(
+                                        f"  Found title placeholder at index {i} (priority 2)"
+                                    )
+                                    continue
+                        except Exception as pres_obj_error:
+                            logging.warning(
+                                f"  Error checking PresentationObject: {pres_obj_error}"
+                            )
+
+                        # Priority 3: Regular TextShape that might be a title
+                        if shape_type == "com.sun.star.drawing.TextShape":
+                            # Check position - titles are usually at the top
+                            if hasattr(shape, "Position"):
+                                y_pos = shape.Position.Y
+                                if y_pos < 3000:  # Top area - likely title
+                                    shape_info["priority"] = 3
+                                    shape_info["reason"] = f"TextShape-top-Y{y_pos}"
+                                    all_title_shapes.append(shape_info)
+                                    logging.info(
+                                        f"  Found TextShape at top at index {i} (priority 3)"
+                                    )
+                                    continue
+
+                        # Priority 4: Check shape name for title indicators
+                        if hasattr(shape, "Name"):
+                            shape_name = shape.Name.lower()
+                            logging.info(f"  Shape name: '{shape_name}'")
+
+                            # Skip if name suggests it's content
+                            if any(
+                                keyword in shape_name
+                                for keyword in ["content", "body", "outline"]
+                            ):
+                                logging.info(
+                                    f"  Skipping shape with content-related name"
+                                )
+                                continue
+
+                            # Prefer shapes with title-related names
+                            if any(
+                                keyword in shape_name
+                                for keyword in ["title", "heading", "header"]
+                            ):
+                                shape_info["priority"] = 4
+                                shape_info["reason"] = f"name-{shape_name}"
+                                all_title_shapes.append(shape_info)
+                                logging.info(
+                                    f"  Found title shape by name at index {i} (priority 4)"
+                                )
+                                continue
+
+                        # Priority 5: Position-based detection for top area shapes
+                        if hasattr(shape, "Position"):
+                            y_pos = shape.Position.Y
+
+                            # Get existing text content
+                            try:
+                                text_obj = shape.getText()
+                                existing_text = (
+                                    text_obj.getString()
+                                    if hasattr(text_obj, "getString")
+                                    else ""
+                                )
+                            except:
+                                existing_text = ""
+
+                            # Title area detection (top area of slide)
+                            if y_pos < 3000:  # Likely title area
+                                priority = 5
+                                # Boost priority if shape has existing text that looks like a title
+                                if (
+                                    existing_text.strip()
+                                    and len(existing_text.strip()) < 100
+                                ):  # Short text, likely title
+                                    priority = 4
+                                    shape_info["reason"] = (
+                                        f"position-with-title-text-Y{y_pos}"
+                                    )
+                                else:
+                                    shape_info["reason"] = f"position-top-Y{y_pos}"
+
+                                shape_info["priority"] = priority
+                                all_title_shapes.append(shape_info)
+                                logging.info(
+                                    f"  Found title shape by position at index {i} (priority {priority})"
+                                )
+
+                        # Priority 6: Any other text-capable shape as final fallback (but only if in top half)
+                        if (
+                            hasattr(shape, "Position") and shape.Position.Y < 10000
+                        ):  # Top half of slide
+                            if not any(
+                                info["shape"] == shape for info in all_title_shapes
+                            ):
+                                shape_info["priority"] = 6
+                                shape_info["reason"] = "fallback-text-capable-top-half"
+                                all_title_shapes.append(shape_info)
+                                logging.info(
+                                    f"  Added fallback title shape at index {i} (priority 6)"
+                                )
+
+                except Exception as shape_error:
+                    logging.warning(f"  Error examining shape {i}: {shape_error}")
+
+            # Sort by priority (lower number = higher priority) and select the best match
+            if all_title_shapes:
+                all_title_shapes.sort(key=lambda x: (x["priority"], x["index"]))
+                best_match = all_title_shapes[0]
+                main_title_shape = best_match["shape"]
+                logging.info(
+                    f"Selected title shape at index {best_match['index']} with priority {best_match['priority']} (reason: {best_match['reason']})"
+                )
+
+                # Log all candidates for debugging
+                logging.info("All title shape candidates:")
+                for info in all_title_shapes:
+                    logging.info(
+                        f"  Index {info['index']}: Priority {info['priority']}, Reason: {info['reason']}, Type: {info['type']}"
+                    )
+
+            # If still no title shape found, create one
+            if not main_title_shape:
+                logging.warning(
+                    "No suitable title shape found, creating new title textbox"
+                )
+                try:
+                    # Create a new title textbox
+                    title_shape = doc.createInstance("com.sun.star.drawing.TextShape")
+                    title_shape.setSize(Size(24000, 3000))  # Width: 24cm, Height: 3cm
+                    title_shape.setPosition(
+                        uno.createUnoStruct("com.sun.star.awt.Point")
+                    )
+                    title_shape.Position.X = 2000  # 2cm from left
+                    title_shape.Position.Y = 2000  # 2cm from top
+
+                    # Set presentation object type for title if possible
+                    try:
+                        if hasattr(title_shape, "PresentationObject"):
+                            title_shape.PresentationObject = 0  # Title placeholder type
+                            logging.info("Set PresentationObject type to title")
+                    except Exception as pres_obj_set_error:
+                        logging.warning(
+                            f"Could not set PresentationObject: {pres_obj_set_error}"
+                        )
+
+                    # Add the shape to the slide
+                    target_slide.add(title_shape)
+                    main_title_shape = title_shape
+                    logging.info("Created and added new title textbox to slide")
+
+                except Exception as create_error:
+                    error_msg = f"Failed to create title textbox: {create_error}"
+                    logging.error(error_msg)
+                    raise HelperError(error_msg)
+
+            # Edit the selected title shape
+            try:
+                # Get current text for logging
+                current_text = (
+                    main_title_shape.getText().getString()
+                    if hasattr(main_title_shape, "getText")
+                    else ""
+                )
+                logging.info(
+                    f"Editing title shape - current text: '{current_text[:50]}...'"
+                )
+
+                # Set new title
+                text_obj = main_title_shape.getText()
+                text_obj.setString(new_title)
+
+                # Verify the text was set correctly
+                verification_text = text_obj.getString()
+                if verification_text == new_title:
+                    logging.info("Title text updated successfully")
+                    edit_result = "Title updated successfully"
+                else:
+                    error_msg = f"Text verification failed: expected '{new_title}', got '{verification_text}'"
+                    logging.error(error_msg)
+                    edit_result = "Title update failed - verification error"
+
+                # Apply basic formatting for title readability
+                try:
+                    text_cursor = text_obj.createTextCursor()
+                    text_cursor.gotoStart(False)
+                    text_cursor.gotoEnd(True)
+                    text_cursor.CharHeight = 28  # Larger font for title
+                    text_cursor.CharWeight = 150  # Bold
+                    text_cursor.ParaAdjust = CENTER  # Center alignment for title
+                    logging.info("Applied formatting to title text")
+                except Exception as format_error:
+                    logging.warning(f"Could not apply formatting: {format_error}")
+
+            except Exception as edit_error:
+                error_msg = f"Failed to edit title shape: {edit_error}"
+                logging.error(error_msg)
+                raise HelperError(error_msg)
+
+            # Save and close
+            logging.info("Saving document...")
+            doc.store()
+
+            success_msg = f"Successfully edited title of slide {slide_index} in {file_path}. {edit_result}"
+            logging.info(success_msg)
+            return success_msg
+
+
+def delete_slide(file_path, slide_index):
+    """
+    Delete a slide from an Impress presentation.
+    Args:
+        file_path: Path to the presentation file.
+        slide_index: Index of the slide to delete (0-based).
+    """
+    logging.info(
+        f"delete_slide called with: file_path={file_path}, slide_index={slide_index}"
+    )
+
+    with managed_document(file_path) as doc:
+        if valid_presentation(doc):
+            draw_pages = doc.getDrawPages()
+            num_slides = draw_pages.getCount()
+
+            # Get the slide to delete
+            slide_to_delete = get_validated_slide(draw_pages, slide_index, delete=True)
+            logging.info(f"Deleting slide at index: {slide_index}")
+
+            # Remove the slide
+            draw_pages.remove(slide_to_delete)
+            logging.info("Slide removed successfully")
+
+            # Verify the slide was deleted
+            new_slide_count = draw_pages.getCount()
+            if new_slide_count != num_slides - 1:
+                error_msg = f"Slide deletion verification failed: expected {num_slides - 1} slides, got {new_slide_count}"
+                logging.error(error_msg)
+                raise HelperError(error_msg)
+
+            # Save and close
+            logging.info("Saving document...")
+            doc.store()
+
+            success_msg = f"Successfully deleted slide at index {slide_index} from {file_path}. Presentation now has {new_slide_count} slides."
+            logging.info(success_msg)
+            return success_msg
+
+
+def apply_presentation_template(file_path, template_name):
+    """Apply a presentation template to an existing presentation."""
+    logging.info(f"Attempting to apply template: {template_name} to {file_path}")
+
+    home_dir = os.path.expanduser("~")
+
+    # Define search directories for templates
+    template_search_dirs = [
+        "C:/Program Files/LibreOffice/share/template/common/presnt",
+        f"{home_dir}/AppData/Roaming/LibreOffice/4/user/template",
+    ]
+
+    template_doc = None
+    found_template_path = None
+
+    # Search recursively in user directories
+    all_found_templates = []
+    for search_dir in template_search_dirs:
+        logging.info(f"Recursively searching directory: {search_dir}")
+        found_templates = find_template_files(search_dir, template_name)
+        all_found_templates.extend(found_templates)
+
+    # Try to load each found template until one works
+    for template_path in all_found_templates:
+        try:
+            logging.info(f"Trying user template: {template_path}")
+            # Convert to file URL if it's a local path
+            if not template_path.startswith(("file://", "http://", "https://")):
+                template_url = uno.systemPathToFileUrl(template_path)
+            else:
+                template_url = template_path
+
+            with managed_document(template_path, read_only=True) as template_doc:
+                if template_doc:
+                    found_template_path = template_url
+                    logging.info(
+                        f"Successfully loaded user template from: {template_path}"
+                    )
+                    break
+        except Exception as template_error:
+            logging.info(
+                f"Failed to load template from {template_path}: {template_error}"
+            )
+            continue
+
+    if not template_doc:
+        # Create a detailed error message with search information
+        search_summary = "Searched in the following locations:\n"
+        for search_dir in template_search_dirs:
+            if os.path.exists(search_dir):
+                search_summary += f"  - {search_dir} (exists)\n"
+            else:
+                search_summary += f"  - {search_dir} (not found)\n"
+
+        error_msg = f"Could not find template '{template_name}' in any location.\n{search_summary}"
+        error_msg += f"Template files searched for: {template_name}.otp, {template_name}.ott, etc."
+        raise HelperError(error_msg)
+
+    # Load target presentation using the helper
+    with managed_document(file_path) as target_doc:
+        if valid_presentation(target_doc):
+            success = False
+            new_doc = None
+
+            # Create new presentation from template and copy content
+            try:
+                logging.info("Creating new presentation from template...")
+
+                # Get desktop
+                desktop = get_uno_desktop()
+                if not desktop:
+                    raise HelperError("Failed to get UNO desktop")
+
+                # Create new document from template
+                props = [
+                    create_property_value("AsTemplate", True),
+                    create_property_value("Hidden", True),
+                ]
+
+                new_doc = desktop.loadComponentFromURL(
+                    found_template_path, "_blank", 0, tuple(props)
+                )
+                if not new_doc:
+                    raise HelperError("Failed to create new document from template")
+
+                logging.info("Created new document from template")
+
+                # Get slides from target and new document
+                target_slides = target_doc.getDrawPages()
+                new_slides = new_doc.getDrawPages()
+
+                logging.info(f"Target has {target_slides.getCount()} slides")
+                logging.info(f"New document has {new_slides.getCount()} slides")
+
+                target_slide_count = target_slides.getCount()
+                new_slide_count = new_slides.getCount()
+
+                # Validation: Ensure we have slides to work with
+                if target_slide_count == 0:
+                    raise HelperError("Target presentation has no slides")
+
+                # Analyze what layouts to use based on target slides
+                target_slide_layouts = []
+                for i in range(target_slide_count):
+                    target_slide = target_slides.getByIndex(i)
+                    has_title = False
+                    has_content = False
+
+                    for j in range(target_slide.getCount()):
+                        shape = target_slide.getByIndex(j)
+                        shape_type = shape.getShapeType()
+
+                        if shape_type == "com.sun.star.presentation.TitleTextShape":
+                            text = (
+                                shape.getText().getString()
+                                if hasattr(shape, "getText")
+                                else ""
+                            )
+                            if text.strip():
+                                has_title = True
+                        elif shape_type == "com.sun.star.presentation.OutlinerShape":
+                            text = (
+                                shape.getText().getString()
+                                if hasattr(shape, "getText")
+                                else ""
+                            )
+                            if text.strip():
+                                has_content = True
+
+                    # Determine what layout is needed
+                    if has_title and has_content:
+                        needed_layout = 1  # TitleContent layout
+                        logging.info(
+                            f"Target slide {i} needs TitleContent layout (has both title and content)"
+                        )
+                    elif has_title:
+                        needed_layout = 0  # Title only layout
+                        logging.info(
+                            f"Target slide {i} needs Title layout (has title only)"
+                        )
+                    else:
+                        needed_layout = 1  # Default to TitleContent for safety
+                        logging.info(
+                            f"Target slide {i} needs default TitleContent layout"
+                        )
+
+                    target_slide_layouts.append(needed_layout)
+
+                # Determine the template's default layout
+                template_layout = None
+                if new_slide_count > 0:
+                    try:
+                        first_template_slide = new_slides.getByIndex(0)
+                        if hasattr(first_template_slide, "Layout"):
+                            template_layout = first_template_slide.Layout
+                            logging.info(
+                                f"Template default layout detected: {template_layout}"
+                            )
+                        else:
+                            template_layout = 1  # Default to TitleContent
+                            logging.info(
+                                "Could not detect template layout, defaulting to TitleContent"
+                            )
+                    except Exception as layout_detect_error:
+                        logging.warning(
+                            f"Could not detect template layout: {layout_detect_error}"
+                        )
+                        template_layout = 1  # Default to TitleContent layout
+
+                # Add more slides to new document if needed, with appropriate layouts
+                while new_slide_count < target_slide_count:
+                    try:
+                        new_slides.insertNewByIndex(new_slide_count)
+                        added_slide = new_slides.getByIndex(new_slide_count)
+
+                        # Use the layout needed for this specific slide
+                        needed_layout = target_slide_layouts[new_slide_count]
+
+                        try:
+                            if hasattr(added_slide, "setLayout"):
+                                added_slide.setLayout(needed_layout)
+                                logging.info(
+                                    f"Applied layout {needed_layout} to added slide {new_slide_count}"
+                                )
+                            elif hasattr(added_slide, "Layout"):
+                                added_slide.Layout = needed_layout
+                                logging.info(
+                                    f"Set layout {needed_layout} on added slide {new_slide_count}"
+                                )
+
+                            # Give LibreOffice time to create the placeholder shapes
+                            time.sleep(0.3)
+
+                        except Exception as layout_error:
+                            logging.warning(
+                                f"Could not apply layout {needed_layout} to slide {new_slide_count}: {layout_error}"
+                            )
+
+                        new_slide_count += 1
+                        logging.info(
+                            f"Added slide {new_slide_count} with layout {needed_layout}"
+                        )
+
+                    except Exception as slide_add_error:
+                        raise HelperError(
+                            f"Failed to add slide {new_slide_count}: {slide_add_error}"
+                        )
+
+                # Track copying success for validation
+                copy_errors = []
+                slides_processed = 0
+
+                # Copy content from target slides to new slides
+                for i in range(target_slide_count):
+                    try:
+                        logging.info(
+                            f"Processing slide {i + 1} of {target_slide_count}"
+                        )
+
+                        target_slide = target_slides.getByIndex(i)
+                        new_slide = new_slides.getByIndex(i)
+
+                        # Find and categorize shapes on both slides
+                        target_title_shape = None
+                        target_content_shape = None
+                        target_other_shapes = []
+
+                        new_title_shape = None
+                        new_content_shape = None
+
+                        # Analyze target slide shapes
+                        target_shape_count = target_slide.getCount()
+                        logging.info(
+                            f"Target slide {i} has {target_shape_count} shapes"
+                        )
+
+                        for j in range(target_shape_count):
+                            try:
+                                shape = target_slide.getByIndex(j)
+                                shape_type = shape.getShapeType()
+
+                                if (
+                                    shape_type
+                                    == "com.sun.star.presentation.TitleTextShape"
+                                ):
+                                    target_title_shape = shape
+                                    logging.info(
+                                        f"Found target title shape on slide {i}"
+                                    )
+                                elif (
+                                    shape_type
+                                    == "com.sun.star.presentation.OutlinerShape"
+                                ):
+                                    if not target_content_shape:
+                                        target_content_shape = shape
+                                        logging.info(
+                                            f"Found target content shape on slide {i}"
+                                        )
+                                else:
+                                    target_other_shapes.append(shape)
+                                    logging.info(
+                                        f"Found target other shape: {shape_type}"
+                                    )
+                            except Exception as shape_error:
+                                error_msg = f"Failed to analyze target shape {j} on slide {i}: {shape_error}"
+                                logging.error(error_msg)
+                                copy_errors.append(error_msg)
+
+                        # Analyze new slide shapes
+                        new_shape_count = new_slide.getCount()
+                        logging.info(f"New slide {i} has {new_shape_count} shapes")
+
+                        for j in range(new_shape_count):
+                            try:
+                                shape = new_slide.getByIndex(j)
+                                shape_type = shape.getShapeType()
+
+                                if (
+                                    shape_type
+                                    == "com.sun.star.presentation.TitleTextShape"
+                                ):
+                                    new_title_shape = shape
+                                    logging.info(
+                                        f"Found new slide title shape on slide {i}"
+                                    )
+                                elif (
+                                    shape_type
+                                    == "com.sun.star.presentation.OutlinerShape"
+                                ):
+                                    if not new_content_shape:
+                                        new_content_shape = shape
+                                        logging.info(
+                                            f"Found new slide content shape on slide {i}"
+                                        )
+                            except Exception as shape_error:
+                                error_msg = f"Failed to analyze new slide shape {j} on slide {i}: {shape_error}"
+                                logging.error(error_msg)
+                                copy_errors.append(error_msg)
+
+                        # Copy title text (critical operation)
+                        if target_title_shape:
+                            target_title_text = (
+                                target_title_shape.getText().getString()
+                                if hasattr(target_title_shape, "getText")
+                                else ""
+                            )
+                            if (
+                                target_title_text.strip()
+                            ):  # Only if there's actual text to copy
+                                if not new_title_shape:
+                                    error_msg = f"Target slide {i} has title text but new slide has no title placeholder"
+                                    logging.error(error_msg)
+                                    copy_errors.append(error_msg)
+                                else:
+                                    try:
+                                        new_title_shape.getText().setString(
+                                            target_title_text
+                                        )
+                                        logging.info(
+                                            f"Copied title text: '{target_title_text[:50]}...'"
+                                        )
+
+                                        # Verify the text was actually set
+                                        verification_text = (
+                                            new_title_shape.getText().getString()
+                                        )
+                                        if verification_text != target_title_text:
+                                            error_msg = f"Title text verification failed on slide {i}: expected '{target_title_text}', got '{verification_text}'"
+                                            logging.error(error_msg)
+                                            copy_errors.append(error_msg)
+                                    except Exception as title_error:
+                                        error_msg = f"Failed to copy title text on slide {i}: {title_error}"
+                                        logging.error(error_msg)
+                                        copy_errors.append(error_msg)
+                            else:
+                                logging.info(f"No title text to copy on slide {i}")
+
+                        # Copy content text (critical operation)
+                        if target_content_shape:
+                            target_content_text = (
+                                target_content_shape.getText().getString()
+                                if hasattr(target_content_shape, "getText")
+                                else ""
+                            )
+                            if (
+                                target_content_text.strip()
+                            ):  # Only if there's actual text to copy
+                                if not new_content_shape:
+                                    error_msg = f"Target slide {i} has content text but new slide has no content placeholder"
+                                    logging.error(error_msg)
+                                    copy_errors.append(error_msg)
+                                else:
+                                    try:
+                                        new_content_shape.getText().setString(
+                                            target_content_text
+                                        )
+                                        logging.info(
+                                            f"Copied content text: '{target_content_text[:50]}...'"
+                                        )
+
+                                        # Verify the text was actually set
+                                        verification_text = (
+                                            new_content_shape.getText().getString()
+                                        )
+                                        if verification_text != target_content_text:
+                                            error_msg = f"Content text verification failed on slide {i}: expected '{target_content_text}', got '{verification_text}'"
+                                            logging.error(error_msg)
+                                            copy_errors.append(error_msg)
+                                    except Exception as content_error:
+                                        error_msg = f"Failed to copy content text on slide {i}: {content_error}"
+                                        logging.error(error_msg)
+                                        copy_errors.append(error_msg)
+                            else:
+                                logging.info(f"No content text to copy on slide {i}")
+
+                        # Copy other shapes (non-critical, but track errors)
+                        other_shapes_copied = 0
+                        for k, source_shape in enumerate(target_other_shapes):
+                            try:
+                                # Create a new shape of the same type
+                                shape_type = source_shape.getShapeType()
+                                cloned_shape = new_doc.createInstance(shape_type)
+
+                                # Copy basic properties
+                                if hasattr(source_shape, "Position"):
+                                    cloned_shape.Position = source_shape.Position
+                                if hasattr(source_shape, "Size"):
+                                    cloned_shape.Size = source_shape.Size
+
+                                # Copy style properties
+                                style_properties = [
+                                    "FillColor",
+                                    "FillStyle",
+                                    "LineColor",
+                                    "LineStyle",
+                                    "LineWidth",
+                                ]
+                                for prop in style_properties:
+                                    if hasattr(source_shape, prop) and hasattr(
+                                        cloned_shape, prop
+                                    ):
+                                        try:
+                                            setattr(
+                                                cloned_shape,
+                                                prop,
+                                                getattr(source_shape, prop),
+                                            )
+                                        except:
+                                            pass  # Non-critical property copy failure
+
+                                # Copy text content if it's a text shape
+                                if hasattr(source_shape, "getText") and hasattr(
+                                    cloned_shape, "getText"
+                                ):
+                                    source_text = source_shape.getText().getString()
+                                    if source_text:
+                                        cloned_shape.getText().setString(source_text)
+                                        logging.info(
+                                            f"Copied text to other shape: '{source_text[:30]}...'"
+                                        )
+
+                                # Add the cloned shape to the new slide
+                                new_slide.add(cloned_shape)
+                                other_shapes_copied += 1
+                                logging.info(
+                                    f"Successfully copied other shape {k}: {shape_type}"
+                                )
+
+                            except Exception as clone_error:
+                                error_msg = f"Failed to copy other shape {k} on slide {i}: {clone_error}"
+                                logging.warning(error_msg)
+                                copy_errors.append(error_msg)
+
+                        logging.info(
+                            f"Copied {other_shapes_copied} of {len(target_other_shapes)} other shapes on slide {i}"
+                        )
+                        slides_processed += 1
+
+                    except Exception as slide_error:
+                        error_msg = (
+                            f"Critical error processing slide {i}: {slide_error}"
+                        )
+                        logging.error(error_msg)
+                        copy_errors.append(error_msg)
+
+                # Remove any extra slides from new document
+                extra_slides_removed = 0
+                while new_slides.getCount() > target_slide_count:
+                    try:
+                        last_slide = new_slides.getByIndex(new_slides.getCount() - 1)
+                        new_slides.remove(last_slide)
+                        extra_slides_removed += 1
+                        logging.info(f"Removed extra slide")
+                    except Exception as remove_slide_error:
+                        error_msg = (
+                            f"Failed to remove extra slide: {remove_slide_error}"
+                        )
+                        logging.error(error_msg)
+                        copy_errors.append(error_msg)
+                        break
+
+                # CRITICAL VALIDATION: Check if all operations succeeded
+                if copy_errors:
+                    error_summary = f"Content copying failed with {len(copy_errors)} errors. No changes will be applied to preserve data integrity."
+                    logging.error(error_summary)
+                    for error in copy_errors:
+                        logging.error(f"  - {error}")
+                    raise HelperError(f"{error_summary} First error: {copy_errors[0]}")
+
+                if slides_processed != target_slide_count:
+                    raise HelperError(
+                        f"Only processed {slides_processed} of {target_slide_count} slides. Aborting to prevent data loss."
+                    )
+
+                # Verify final slide count matches
+                if new_slides.getCount() != target_slide_count:
+                    raise HelperError(
+                        f"Final slide count mismatch: expected {target_slide_count}, got {new_slides.getCount()}"
+                    )
+
+                logging.info(
+                    "All content copied successfully. Proceeding with file replacement."
+                )
+
+                # Only now that everything is verified, save new document over the target
+                file_url = uno.systemPathToFileUrl(normalize_path(file_path))
+                save_props = [create_property_value("Overwrite", True)]
+
+                try:
+                    new_doc.storeToURL(file_url, tuple(save_props))
+                    logging.info("Successfully saved new document over target file")
+                except Exception as save_error:
+                    raise HelperError(
+                        f"Failed to save templated document: {save_error}"
+                    )
+
+                success = True
+                logging.info("Template applied successfully with all content preserved")
+
+            except Exception as process_error:
+                logging.error(f"Template application failed: {process_error}")
+                logging.error(traceback.format_exc())
+                # Don't set success = True, so no changes are applied
+                raise process_error
+
+            finally:
+                # Clean up documents
+                try:
+                    if new_doc:
+                        new_doc.close(True)
+                        logging.info("Closed new document")
+                except:
+                    pass
+
+            if success:
+                logging.info(
+                    f"Successfully applied template '{template_name}' to {file_path}"
+                )
+                return f"Successfully applied template '{template_name}' to presentation with all content preserved"
+            else:
+                logging.warning("Template application failed - original file unchanged")
+                return f"Failed to apply template '{template_name}' to presentation - original file preserved"
+
+
+def format_slide_content(file_path, slide_index, format_options):
+    """
+    Format the content text of a specific slide in an Impress presentation.
+
+    Args:
+        file_path: Path to the presentation file.
+        slide_index: Index of the slide to format (0-based).
+        format_options: Dictionary containing formatting options:
+            - font_name: Font family name (e.g., "Arial", "Times New Roman")
+            - font_size: Font size in points (e.g., 18, 24)
+            - bold: Boolean to apply bold formatting
+            - italic: Boolean to apply italic formatting
+            - underline: Boolean to apply underline formatting
+            - color: Text color as hex string (e.g., "#FF0000") or RGB integer
+            - alignment: Text alignment ("left", "center", "right", "justify")
+            - line_spacing: Line spacing multiplier (e.g., 1.5, 2.0)
+            - background_color: Background color as hex string or RGB integer
+    """
+    logging.info(
+        f"format_slide_content called with: file_path={file_path}, slide_index={slide_index}"
+    )
+
+    with managed_document(file_path) as doc:
+        if valid_presentation(doc):
+            draw_pages = doc.getDrawPages()
+
+            target_slide = get_validated_slide(draw_pages, slide_index)
+            logging.info(f"Formatting content of slide at index: {slide_index}")
+
+            # Find the main content shape using similar logic as edit_slide_content
+            main_content_shape = None
+            all_text_shapes = []
+
+            logging.info(f"Number of shapes on slide: {target_slide.getCount()}")
+
+            # Collect all text-capable shapes and categorize them
+            for i in range(target_slide.getCount()):
+                try:
+                    shape = target_slide.getByIndex(i)
+                    shape_type = shape.getShapeType()
+                    logging.info(f"Shape {i}: {shape_type}")
+
+                    if hasattr(shape, "getText"):
+                        shape_info = {
+                            "shape": shape,
+                            "index": i,
+                            "type": shape_type,
+                            "priority": 99,
+                            "reason": "unknown",
+                        }
+
+                        # Priority 1: Standard presentation OutlinerShape (highest priority)
+                        if shape_type == "com.sun.star.presentation.OutlinerShape":
+                            shape_info["priority"] = 1
+                            shape_info["reason"] = "OutlinerShape"
+                            all_text_shapes.append(shape_info)
+                            logging.info(
+                                f"  Found OutlinerShape at index {i} (priority 1)"
+                            )
+                            continue
+
+                        # Skip title shapes explicitly
+                        if shape_type == "com.sun.star.presentation.TitleTextShape":
+                            logging.info(f"  Skipping title shape at index {i}")
+                            continue
+
+                        # Priority 2: Check PresentationObject for content placeholders
+                        try:
+                            if hasattr(shape, "PresentationObject"):
+                                pres_obj = shape.PresentationObject
+                                if pres_obj in [2, 3, 4, 5]:  # Content placeholders
+                                    shape_info["priority"] = 2
+                                    shape_info["reason"] = (
+                                        f"PresentationObject-{pres_obj}"
+                                    )
+                                    all_text_shapes.append(shape_info)
+                                    logging.info(
+                                        f"  Found content placeholder at index {i} (priority 2)"
+                                    )
+                                    continue
+                        except Exception as pres_obj_error:
+                            logging.warning(
+                                f"  Error checking PresentationObject: {pres_obj_error}"
+                            )
+
+                        # Priority 3: Regular TextShape
+                        if shape_type == "com.sun.star.drawing.TextShape":
+                            shape_info["priority"] = 3
+                            shape_info["reason"] = "TextShape"
+                            all_text_shapes.append(shape_info)
+                            logging.info(f"  Found TextShape at index {i} (priority 3)")
+                            continue
+
+                        # Priority 4: Check shape name for content indicators
+                        if hasattr(shape, "Name"):
+                            shape_name = shape.Name.lower()
+                            if "title" not in shape_name and any(
+                                keyword in shape_name
+                                for keyword in ["content", "text", "outline", "body"]
+                            ):
+                                shape_info["priority"] = 4
+                                shape_info["reason"] = f"name-{shape_name}"
+                                all_text_shapes.append(shape_info)
+                                logging.info(
+                                    f"  Found content shape by name at index {i} (priority 4)"
+                                )
+                                continue
+
+                        # Priority 5: Position-based detection (below title area)
+                        if hasattr(shape, "Position") and shape.Position.Y > 3000:
+                            shape_info["priority"] = 5
+                            shape_info["reason"] = f"position-Y{shape.Position.Y}"
+                            all_text_shapes.append(shape_info)
+                            logging.info(
+                                f"  Found text shape by position at index {i} (priority 5)"
+                            )
+
+                except Exception as shape_error:
+                    logging.warning(f"  Error examining shape {i}: {shape_error}")
+
+            # Select the best content shape
+            if all_text_shapes:
+                all_text_shapes.sort(key=lambda x: (x["priority"], x["index"]))
+                best_match = all_text_shapes[0]
+                main_content_shape = best_match["shape"]
+                logging.info(
+                    f"Selected content shape at index {best_match['index']} with priority {best_match['priority']}"
+                )
+
+            if not main_content_shape:
+                error_msg = f"No content shape found on slide {slide_index}"
+                raise HelperError(error_msg)
+
+            # Apply formatting to the content shape
+            try:
+                text_obj = main_content_shape.getText()
+
+                # Check if there's text to format
+                if not text_obj.getString().strip():
+                    logging.warning("No text content found to format")
+
+                # Create text cursor to apply formatting
+                text_cursor = text_obj.createTextCursor()
+                text_cursor.gotoStart(False)
+                text_cursor.gotoEnd(True)  # Select all text
+
+                # Apply font formatting
+                if format_options.get("font_name"):
+                    text_cursor.CharFontName = format_options["font_name"]
+                    logging.info(f"Applied font: {format_options['font_name']}")
+
+                if format_options.get("font_size"):
+                    text_cursor.CharHeight = float(format_options["font_size"])
+                    logging.info(f"Applied font size: {format_options['font_size']}")
+
+                if format_options.get("bold") is not None:
+                    text_cursor.CharWeight = 150 if format_options["bold"] else 100
+                    logging.info(f"Applied bold: {format_options['bold']}")
+
+                if format_options.get("italic") is not None:
+                    text_cursor.CharPosture = 2 if format_options["italic"] else 0
+                    logging.info(f"Applied italic: {format_options['italic']}")
+
+                if format_options.get("underline") is not None:
+                    text_cursor.CharUnderline = 1 if format_options["underline"] else 0
+                    logging.info(f"Applied underline: {format_options['underline']}")
+
+                # Apply color formatting
+                if format_options.get("color"):
+                    try:
+                        color = format_options["color"]
+                        if isinstance(color, str) and color.startswith("#"):
+                            color = int(color[1:], 16)
+                        text_cursor.CharColor = color
+                        logging.info(f"Applied text color: {format_options['color']}")
+                    except Exception as color_error:
+                        logging.error(f"Error applying text color: {color_error}")
+
+                # Apply paragraph formatting
+                if format_options.get("alignment"):
+                    alignment_map = {
+                        "left": LEFT,
+                        "center": CENTER,
+                        "right": RIGHT,
+                        "justify": BLOCK,
+                    }
+                    alignment = format_options["alignment"].lower()
+                    if alignment in alignment_map:
+                        text_cursor.ParaAdjust = alignment_map[alignment]
+                        logging.info(f"Applied alignment: {alignment}")
+
+                # Apply line spacing
+                if format_options.get("line_spacing"):
+                    try:
+                        line_spacing = float(format_options["line_spacing"])
+                        # Set line spacing mode and value
+                        text_cursor.ParaLineSpacing = uno.createUnoStruct(
+                            "com.sun.star.style.LineSpacing"
+                        )
+                        text_cursor.ParaLineSpacing.Mode = 1  # PROP mode (proportional)
+                        text_cursor.ParaLineSpacing.Height = int(
+                            line_spacing * 100
+                        )  # Convert to percentage
+                        logging.info(f"Applied line spacing: {line_spacing}")
+                    except Exception as spacing_error:
+                        logging.error(f"Error applying line spacing: {spacing_error}")
+
+                # Apply background color to the shape if specified
+                if format_options.get("background_color"):
+                    try:
+                        bg_color = format_options["background_color"]
+                        if isinstance(bg_color, str) and bg_color.startswith("#"):
+                            bg_color = int(bg_color[1:], 16)
+
+                        # Set fill style and color for the shape
+                        main_content_shape.FillStyle = 1  # SOLID fill
+                        main_content_shape.FillColor = bg_color
+                        logging.info(
+                            f"Applied background color: {format_options['background_color']}"
+                        )
+                    except Exception as bg_error:
+                        logging.error(f"Error applying background color: {bg_error}")
+
+            except Exception as format_error:
+                error_msg = (
+                    f"Failed to apply formatting to content shape: {format_error}"
+                )
+                logging.error(error_msg)
+                raise HelperError(error_msg)
+
+            # Save document
+            logging.info("Saving document...")
+            doc.store()
+
+            # Build success message with applied formatting details
+            applied_formats = []
+            for key, value in format_options.items():
+                if value is not None:
+                    applied_formats.append(f"{key}: {value}")
+
+            success_msg = f"Successfully formatted content of slide {slide_index} in {file_path}. Applied: {', '.join(applied_formats)}"
+            logging.info(success_msg)
+            return success_msg
+
+
+def format_slide_title(file_path, slide_index, format_options):
+    """
+    Format the title text of a specific slide in an Impress presentation.
+
+    Args:
+        file_path: Path to the presentation file.
+        slide_index: Index of the slide to format (0-based).
+        format_options: Dictionary containing formatting options:
+            - font_name: Font family name (e.g., "Arial", "Times New Roman")
+            - font_size: Font size in points (e.g., 28, 36)
+            - bold: Boolean to apply bold formatting
+            - italic: Boolean to apply italic formatting
+            - underline: Boolean to apply underline formatting
+            - color: Text color as hex string (e.g., "#FF0000") or RGB integer
+            - alignment: Text alignment ("left", "center", "right", "justify")
+            - line_spacing: Line spacing multiplier (e.g., 1.5, 2.0)
+            - background_color: Background color as hex string or RGB integer
+    """
+    logging.info(
+        f"format_slide_title called with: file_path={file_path}, slide_index={slide_index}, format_options={format_options}"
+    )
+
+    with managed_document(file_path) as doc:
+        if valid_presentation(doc):
+            draw_pages = doc.getDrawPages()
+
+            target_slide = get_validated_slide(draw_pages, slide_index)
+            logging.info(f"Formatting title of slide at index: {slide_index}")
+
+            # Find the main title shape using similar logic as edit_slide_title
+            main_title_shape = None
+            all_title_shapes = []
+
+            logging.info(f"Number of shapes on slide: {target_slide.getCount()}")
+
+            # Collect all text-capable shapes and categorize them for title detection
+            for i in range(target_slide.getCount()):
+                try:
+                    shape = target_slide.getByIndex(i)
+                    shape_type = shape.getShapeType()
+                    logging.info(f"Shape {i}: {shape_type}")
+
+                    if hasattr(shape, "getText"):
+                        shape_info = {
+                            "shape": shape,
+                            "index": i,
+                            "type": shape_type,
+                            "priority": 99,
+                            "reason": "unknown",
+                        }
+
+                        # Priority 1: Standard presentation TitleTextShape (highest priority)
+                        if shape_type == "com.sun.star.presentation.TitleTextShape":
+                            shape_info["priority"] = 1
+                            shape_info["reason"] = "TitleTextShape"
+                            all_title_shapes.append(shape_info)
+                            logging.info(
+                                f"  Found TitleTextShape at index {i} (priority 1)"
+                            )
+                            continue
+
+                        # Skip content shapes explicitly
+                        if shape_type == "com.sun.star.presentation.OutlinerShape":
+                            logging.info(f"  Skipping content shape at index {i}")
+                            continue
+
+                        # Priority 2: Check PresentationObject for title placeholders
+                        try:
+                            if hasattr(shape, "PresentationObject"):
+                                pres_obj = shape.PresentationObject
+                                if pres_obj in [0, 1]:  # Title placeholders
+                                    shape_info["priority"] = 2
+                                    shape_info["reason"] = (
+                                        f"PresentationObject-{pres_obj}"
+                                    )
+                                    all_title_shapes.append(shape_info)
+                                    logging.info(
+                                        f"  Found title placeholder at index {i} (priority 2)"
+                                    )
+                                    continue
+                        except Exception as pres_obj_error:
+                            logging.warning(
+                                f"  Error checking PresentationObject: {pres_obj_error}"
+                            )
+
+                        # Priority 3: Regular TextShape in top area
+                        if shape_type == "com.sun.star.drawing.TextShape":
+                            if (
+                                hasattr(shape, "Position") and shape.Position.Y < 3000
+                            ):  # Top area
+                                shape_info["priority"] = 3
+                                shape_info["reason"] = (
+                                    f"TextShape-top-Y{shape.Position.Y}"
+                                )
+                                all_title_shapes.append(shape_info)
+                                logging.info(
+                                    f"  Found TextShape at top at index {i} (priority 3)"
+                                )
+                                continue
+
+                        # Priority 4: Check shape name for title indicators
+                        if hasattr(shape, "Name"):
+                            shape_name = shape.Name.lower()
+                            if any(
+                                keyword in shape_name
+                                for keyword in ["title", "heading", "header"]
+                            ):
+                                shape_info["priority"] = 4
+                                shape_info["reason"] = f"name-{shape_name}"
+                                all_title_shapes.append(shape_info)
+                                logging.info(
+                                    f"  Found title shape by name at index {i} (priority 4)"
+                                )
+                                continue
+
+                        # Priority 5: Position-based detection for top area shapes
+                        if hasattr(shape, "Position") and shape.Position.Y < 3000:
+                            shape_info["priority"] = 5
+                            shape_info["reason"] = f"position-top-Y{shape.Position.Y}"
+                            all_title_shapes.append(shape_info)
+                            logging.info(
+                                f"  Found title shape by position at index {i} (priority 5)"
+                            )
+
+                except Exception as shape_error:
+                    logging.warning(f"  Error examining shape {i}: {shape_error}")
+
+            # Select the best title shape
+            if all_title_shapes:
+                all_title_shapes.sort(key=lambda x: (x["priority"], x["index"]))
+                best_match = all_title_shapes[0]
+                main_title_shape = best_match["shape"]
+                logging.info(
+                    f"Selected title shape at index {best_match['index']} with priority {best_match['priority']}"
+                )
+
+            if not main_title_shape:
+                error_msg = f"No title shape found on slide {slide_index}"
+                raise HelperError(error_msg)
+
+            # Apply formatting to the title shape
+            try:
+                text_obj = main_title_shape.getText()
+
+                # Check if there's text to format
+                if not text_obj.getString().strip():
+                    logging.warning("No title text found to format")
+
+                # Create text cursor to apply formatting
+                text_cursor = text_obj.createTextCursor()
+                text_cursor.gotoStart(False)
+                text_cursor.gotoEnd(True)  # Select all text
+
+                # Apply font formatting
+                if format_options.get("font_name"):
+                    text_cursor.CharFontName = format_options["font_name"]
+                    logging.info(f"Applied font: {format_options['font_name']}")
+
+                if format_options.get("font_size"):
+                    text_cursor.CharHeight = float(format_options["font_size"])
+                    logging.info(f"Applied font size: {format_options['font_size']}")
+
+                if format_options.get("bold") is not None:
+                    text_cursor.CharWeight = 150 if format_options["bold"] else 100
+                    logging.info(f"Applied bold: {format_options['bold']}")
+
+                if format_options.get("italic") is not None:
+                    text_cursor.CharPosture = 2 if format_options["italic"] else 0
+                    logging.info(f"Applied italic: {format_options['italic']}")
+
+                if format_options.get("underline") is not None:
+                    text_cursor.CharUnderline = 1 if format_options["underline"] else 0
+                    logging.info(f"Applied underline: {format_options['underline']}")
+
+                # Apply color formatting
+                if format_options.get("color"):
+                    try:
+                        color = format_options["color"]
+                        if isinstance(color, str) and color.startswith("#"):
+                            color = int(color[1:], 16)
+                        text_cursor.CharColor = color
+                        logging.info(f"Applied text color: {format_options['color']}")
+                    except Exception as color_error:
+                        logging.error(f"Error applying text color: {color_error}")
+
+                # Apply paragraph formatting
+                if format_options.get("alignment"):
+                    alignment_map = {
+                        "left": LEFT,
+                        "center": CENTER,
+                        "right": RIGHT,
+                        "justify": BLOCK,
+                    }
+                    alignment = format_options["alignment"].lower()
+                    if alignment in alignment_map:
+                        text_cursor.ParaAdjust = alignment_map[alignment]
+                        logging.info(f"Applied alignment: {alignment}")
+
+                # Apply line spacing
+                if format_options.get("line_spacing"):
+                    try:
+                        line_spacing = float(format_options["line_spacing"])
+                        # Set line spacing mode and value
+                        text_cursor.ParaLineSpacing = uno.createUnoStruct(
+                            "com.sun.star.style.LineSpacing"
+                        )
+                        text_cursor.ParaLineSpacing.Mode = 1  # PROP mode (proportional)
+                        text_cursor.ParaLineSpacing.Height = int(
+                            line_spacing * 100
+                        )  # Convert to percentage
+                        logging.info(f"Applied line spacing: {line_spacing}")
+                    except Exception as spacing_error:
+                        logging.error(f"Error applying line spacing: {spacing_error}")
+
+                # Apply background color to the shape if specified
+                if format_options.get("background_color"):
+                    try:
+                        bg_color = format_options["background_color"]
+                        if isinstance(bg_color, str) and bg_color.startswith("#"):
+                            bg_color = int(bg_color[1:], 16)
+
+                        # Set fill style and color for the shape
+                        main_title_shape.FillStyle = 1  # SOLID fill
+                        main_title_shape.FillColor = bg_color
+                        logging.info(
+                            f"Applied background color: {format_options['background_color']}"
+                        )
+                    except Exception as bg_error:
+                        logging.error(f"Error applying background color: {bg_error}")
+
+            except Exception as format_error:
+                error_msg = f"Failed to apply formatting to title shape: {format_error}"
+                logging.error(error_msg)
+                raise HelperError(error_msg)
+
+            # Save document
+            logging.info("Saving document...")
+            doc.store()
+
+            # Build success message with applied formatting details
+            applied_formats = []
+            for key, value in format_options.items():
+                if value is not None:
+                    applied_formats.append(f"{key}: {value}")
+
+            success_msg = f"Successfully formatted title of slide {slide_index} in {file_path}. Applied: {', '.join(applied_formats)}"
+            logging.info(success_msg)
+            return success_msg
+
+
+def insert_slide_image(
+    file_path,
+    slide_index,
+    image_path,
+    max_width=None,
+    max_height=None,
+    img_width_px=None,
+    img_height_px=None,
+    dpi=96,
+):
+    """
+    Insert an image into a specific slide of an Impress presentation.
+    The image will be centered on the slide using proper positioning.
+
+    Args:
+        file_path: Path to the presentation file.
+        slide_index: Index of the slide to insert the image into (0-based).
+        image_path: Path to the image file to insert.
+        max_width: Maximum width in 1/100mm (defaults to slide width minus margins).
+        max_height: Maximum height in 1/100mm (defaults to slide height minus margins).
+        img_width_px: Image width in pixels (for proper scaling calculation).
+        img_height_px: Image height in pixels (for proper scaling calculation).
+        dpi: Image DPI (for proper scaling calculation).
+    """
+    logging.info(
+        f"insert_slide_image called with: file_path={file_path}, slide_index={slide_index}, image_path={image_path}"
+    )
+
+    with managed_document(file_path) as doc:
+        if valid_presentation(doc):
+            draw_pages = doc.getDrawPages()
+
+            # Normalize and validate image path
+            image_path = normalize_path(image_path)
+            if not os.path.exists(image_path):
+                raise HelperError(f"Image not found: {image_path}")
+
+            target_slide = get_validated_slide(draw_pages, slide_index)
+            logging.info(f"Inserting image into slide at index: {slide_index}")
+
+            # Get slide dimensions (LibreOffice uses 1/100mm units internally)
+            slide_width = 25400  # Standard slide width in 1/100mm (254mm = 10 inches)
+            slide_height = (
+                19050  # Standard slide height in 1/100mm (190.5mm = 7.5 inches)
+            )
+
+            # Try to get actual slide dimensions from the slide master or page setup
+            try:
+                # Method 1: Try to get slide dimensions from the master page
+                if hasattr(target_slide, "getMasterPage"):
+                    master_page = target_slide.getMasterPage()
+                    if hasattr(master_page, "Width") and hasattr(master_page, "Height"):
+                        slide_width = master_page.Width
+                        slide_height = master_page.Height
+                        logging.info(
+                            f"Got slide dimensions from master page: {slide_width}x{slide_height} (1/100mm)"
+                        )
+
+                # Method 2: Try to get from the document's draw page size
+                elif hasattr(doc, "getDrawPageSize"):
+                    page_size = doc.getDrawPageSize()
+                    slide_width = page_size.Width
+                    slide_height = page_size.Height
+                    logging.info(
+                        f"Got slide dimensions from draw page size: {slide_width}x{slide_height} (1/100mm)"
+                    )
+
+            except Exception as size_error:
+                logging.warning(
+                    f"Could not get slide dimensions, using defaults: {size_error}"
+                )
+
+            # Log the parameters we received
+            logging.info(
+                f"Input parameters: max_width={max_width}, max_height={max_height}"
+            )
+
+            # Set maximum dimensions with reasonable defaults (75% of slide for good visual balance)
+            if max_width is None:
+                max_width = int(slide_width * 0.75)
+            else:
+                # Ensure provided max_width doesn't exceed slide
+                max_width = min(max_width, int(slide_width * 0.9))
+
+            if max_height is None:
+                max_height = int(slide_height * 0.75)
+            else:
+                # Ensure provided max_height doesn't exceed slide
+                max_height = min(max_height, int(slide_height * 0.9))
+
+            logging.info(f"Slide dimensions: {slide_width}x{slide_height} (1/100mm)")
+            logging.info(
+                f"Maximum image dimensions: {max_width}x{max_height} (1/100mm)"
+            )
+
+            if img_width_px and img_height_px and dpi:
+                # Convert pixels to LibreOffice units (1/100mm)
+                mm_per_inch = 25.4
+                conversion_factor = (mm_per_inch * 100) / dpi  # 1/100mm per pixel
+
+                original_width = int(img_width_px * conversion_factor)
+                original_height = int(img_height_px * conversion_factor)
+
+                logging.info(
+                    f"Calculated image size: {original_width}x{original_height} (1/100mm) from {img_width_px}x{img_height_px} pixels at {dpi} DPI"
+                )
+            else:
+                # Fallback: use reasonable default size
+                logging.warning(
+                    "Could not get image size/DPI, using fallback dimensions"
+                )
+                original_width = max_width // 2
+                original_height = max_height // 2
+                logging.info(
+                    f"Using fallback size: {original_width}x{original_height} (1/100mm)"
+                )
+
+            try:
+                # Create a graphics shape to hold the image
+                image_shape = doc.createInstance(
+                    "com.sun.star.drawing.GraphicObjectShape"
+                )
+                if not image_shape:
+                    raise HelperError("Failed to create graphics shape")
+
+                # Convert image path to file URL
+                image_url = uno.systemPathToFileUrl(image_path)
+                logging.info(f"Image URL: {image_url}")
+
+                # Set the image URL
+                image_shape.GraphicURL = image_url
+
+                # Calculate scaling to fit within maximum dimensions while preserving aspect ratio
+                width_scale = max_width / original_width
+                height_scale = max_height / original_height
+                scale_factor = min(
+                    width_scale, height_scale, 1.0
+                )  # Don't scale up, only down
+
+                new_width = int(original_width * scale_factor)
+                new_height = int(original_height * scale_factor)
+
+                # Ensure minimum size (at least 10mm x 10mm)
+                min_size = 1000  # 10mm in 1/100mm
+                if new_width < min_size:
+                    new_width = min_size
+                if new_height < min_size:
+                    new_height = min_size
+
+                logging.info(
+                    f"Width scale: {width_scale:.3f}, Height scale: {height_scale:.3f}"
+                )
+                logging.info(f"Final scale factor: {scale_factor:.3f}")
+                logging.info(f"Final image size: {new_width}x{new_height} (1/100mm)")
+
+                # Set the size
+                new_size = Size(new_width, new_height)
+                image_shape.setSize(new_size)
+
+                # PROPER CENTERING FOR DRAWING SHAPES
+                # Calculate center position relative to slide
+                slide_center_x = slide_width // 2
+                slide_center_y = slide_height // 2
+
+                # Calculate top-left position to center the image
+                pos_x = slide_center_x - (new_width // 2)
+                pos_y = slide_center_y - (new_height // 2)
+
+                logging.info(f"Slide center: ({slide_center_x}, {slide_center_y})")
+                logging.info(f"Image half-size: ({new_width // 2}, {new_height // 2})")
+                logging.info(f"Calculated centered position: ({pos_x}, {pos_y})")
+
+                # Set the position using the Point structure
+                image_position = uno.createUnoStruct("com.sun.star.awt.Point")
+                image_position.X = pos_x
+                image_position.Y = pos_y
+                image_shape.setPosition(image_position)
+
+                # Verify positioning
+                actual_position = image_shape.getPosition()
+                logging.info(
+                    f"Actual position after setting: ({actual_position.X}, {actual_position.Y})"
+                )
+
+                # Add the shape to the slide
+                target_slide.add(image_shape)
+
+                # Set additional properties for better image handling
+                try:
+                    if hasattr(image_shape, "KeepAspectRatio"):
+                        image_shape.KeepAspectRatio = True
+                        logging.info("Set KeepAspectRatio property")
+
+                    # For drawing shapes, we can also try to set transformation matrix for perfect centering
+                    if hasattr(image_shape, "Transformation"):
+                        # The transformation matrix can be used for more precise positioning
+                        # This is an advanced feature but might help with centering
+                        logging.info("Shape has Transformation property available")
+
+                except Exception as prop_error:
+                    logging.warning(
+                        f"Could not set additional image properties: {prop_error}"
+                    )
+
+                # Final verification of image bounds
+                final_position = image_shape.getPosition()
+                final_size = image_shape.getSize()
+                image_right = final_position.X + final_size.Width
+                image_bottom = final_position.Y + final_size.Height
+
+                logging.info("Final verification:")
+                logging.info(
+                    f"Image position: ({final_position.X}, {final_position.Y})"
+                )
+                logging.info(f"Image size: {final_size.Width}x{final_size.Height}")
+                logging.info(
+                    f"Image bounds: X({final_position.X} to {image_right}), Y({final_position.Y} to {image_bottom})"
+                )
+                logging.info(
+                    f"Slide bounds: X(0 to {slide_width}), Y(0 to {slide_height})"
+                )
+
+                # Check if image is properly contained within slide
+                if (
+                    final_position.X >= 0
+                    and final_position.Y >= 0
+                    and image_right <= slide_width
+                    and image_bottom <= slide_height
+                ):
+                    logging.info("Image is properly contained within slide boundaries")
+                else:
+                    logging.warning("Image may extend beyond slide boundaries")
+
+            except Exception as image_error:
+                error_msg = f"Failed to create and configure image shape: {image_error}"
+                logging.error(error_msg)
+                raise HelperError(error_msg)
+
+            # Save document
+            logging.info("Saving document...")
+            doc.store()
+
+            success_msg = f"Successfully inserted image '{os.path.basename(image_path)}' into slide {slide_index} of {file_path}"
+            success_msg += f" (resized to {new_width // 100}x{new_height // 100}mm, centered on slide)"
+            logging.info(success_msg)
+            return success_msg
+
+
+def safe_execute(operation_name, handler_func, command):
+    """Execute a function with consistent error handling and logging."""
+    try:
+        logging.info(f"Starting {operation_name}")
+        result = handler_func(command)
+        logging.info(f"Successfully completed {operation_name}")
+        return result
+    except HelperError as e:
+        # Pass through HelperError messages directly
+        logging.error(str(e))
+        logging.error(traceback.format_exc())
+        raise
+    except Exception as e:
+        error_msg = f"Error in {operation_name}: {str(e)}"
+        logging.error(error_msg)
+        logging.error(traceback.format_exc())
+        raise HelperError(error_msg)
+
+
+# Command handler mapping
+COMMAND_HANDLERS = {
+    # Document creation and management
+    "create_document": lambda cmd: create_document(
+        cmd.get("doc_type", "text"), cmd.get("file_path", ""), cmd.get("metadata", None)
+    ),
+    "read_text_document": lambda cmd: extract_text(cmd.get("file_path", "")),
+    "get_document_properties": lambda cmd: get_document_properties(
+        cmd.get("file_path", "")
+    ),
+    "list_documents": lambda cmd: list_documents(cmd.get("directory", "")),
+    "copy_document": lambda cmd: copy_document(
+        cmd.get("source_path", ""), cmd.get("target_path", "")
+    ),
+    # Impress presentation creation and management
+    "add_slide": lambda cmd: add_slide(
+        cmd.get("file_path", ""),
+        cmd.get("slide_index", None),
+        cmd.get("title", None),
+        cmd.get("content", None),
+    ),
+    "edit_slide_content": lambda cmd: edit_slide_content(
+        cmd.get("file_path", ""), cmd.get("slide_index", 0), cmd.get("new_content", "")
+    ),
+    "edit_slide_title": lambda cmd: edit_slide_title(
+        cmd.get("file_path", ""), cmd.get("slide_index", 0), cmd.get("new_title", "")
+    ),
+    "delete_slide": lambda cmd: delete_slide(
+        cmd.get("file_path", ""), cmd.get("slide_index", 0)
+    ),
+    "read_presentation": lambda cmd: extract_impress_text(cmd.get("file_path", "")),
+    "apply_presentation_template": lambda cmd: apply_presentation_template(
+        cmd.get("file_path", ""), cmd.get("template_name", "")
+    ),
+    "format_slide_content": lambda cmd: format_slide_content(
+        cmd.get("file_path", ""),
+        cmd.get("slide_index", 0),
+        cmd.get("format_options", {}),
+    ),
+    "format_slide_title": lambda cmd: format_slide_title(
+        cmd.get("file_path", ""),
+        cmd.get("slide_index", 0),
+        cmd.get("format_options", {}),
+    ),
+    "insert_slide_image": lambda cmd: insert_slide_image(
+        cmd.get("file_path", ""),
+        cmd.get("slide_index", 0),
+        cmd.get("image_path", ""),
+        cmd.get("max_width", None),
+        cmd.get("max_height", None),
+        cmd.get("img_width_px", None),
+        cmd.get("img_height_px", None),
+        cmd.get("dpi", 96),
+    ),
+    # Writer content creation
+    "add_text": lambda cmd: add_text(
+        cmd.get("file_path", ""), cmd.get("text", ""), cmd.get("position", "end")
+    ),
+    "add_heading": lambda cmd: add_heading(
+        cmd.get("file_path", ""), cmd.get("text", ""), cmd.get("level", 1)
+    ),
+    "add_paragraph": lambda cmd: add_paragraph(
+        cmd.get("file_path", ""),
+        cmd.get("text", ""),
+        cmd.get("style", None),
+        cmd.get("alignment", None),
+    ),
+    "add_table": lambda cmd: add_table(
+        cmd.get("file_path", ""),
+        cmd.get("rows", 2),
+        cmd.get("columns", 2),
+        cmd.get("data", None),
+        cmd.get("header_row", False),
+    ),
+    "insert_image": lambda cmd: insert_image(
+        cmd.get("file_path", ""),
+        cmd.get("image_path", ""),
+        cmd.get("width", None),
+        cmd.get("height", None),
+    ),
+    "insert_page_break": lambda cmd: insert_page_break(cmd.get("file_path", "")),
+    # Text formatting
+    "format_text": lambda cmd: format_text(
+        cmd.get("file_path", ""),
+        cmd.get("text_to_find", ""),
+        {
+            "bold": cmd.get("bold", False),
+            "italic": cmd.get("italic", False),
+            "underline": cmd.get("underline", False),
+            "color": cmd.get("color", None),
+            "font": cmd.get("font", None),
+            "size": cmd.get("size", None),
+        },
+    ),
+    "search_replace_text": lambda cmd: search_replace_text(
+        cmd.get("file_path", ""),
+        cmd.get("search_text", ""),
+        cmd.get("replace_text", ""),
+    ),
+    "delete_text": lambda cmd: delete_text(
+        cmd.get("file_path", ""), cmd.get("text_to_delete", "")
+    ),
+    # Table formatting
+    "format_table": lambda cmd: format_table(
+        cmd.get("file_path", ""),
+        cmd.get("table_index", 0),
+        cmd.get("format_options", {}),
+    ),
+    # Advanced document manipulation
+    # "create_custom_style": lambda cmd: create_custom_style(
+    #     cmd.get("file_path", ""),
+    #     cmd.get("style_name", "CustomStyle"),
+    #     cmd.get("style_properties", {})
+    # ),
+    "delete_paragraph": lambda cmd: delete_paragraph(
+        cmd.get("file_path", ""), cmd.get("paragraph_index", 0)
+    ),
+    "apply_document_style": lambda cmd: apply_document_style(
+        cmd.get("file_path", ""), cmd.get("style", {})
+    ),
+    # Testing functions
+    "get_text_formatting": lambda cmd: get_text_formatting(
+        cmd.get("file_path", ""), cmd.get("text_to_find", "")
+    ),
+    "get_table_info": lambda cmd: get_table_info(
+        cmd.get("file_path", ""), cmd.get("table_index", 0)
+    ),
+    "has_image": lambda cmd: has_image(cmd.get("file_path", "")),
+    "get_page_break_info": lambda cmd: get_page_break_info(cmd.get("file_path", "")),
+    "get_presentation_template_info": lambda cmd: get_presentation_template_info(
+        cmd.get("file_path", "")
+    ),
+    "get_presentation_text_formatting": lambda cmd: get_presentation_text_formatting(
+        cmd.get("file_path", ""),
+        cmd.get("text_to_find", ""),
+        cmd.get("slide_index", None),
+    ),
+    "get_slide_image_info": lambda cmd: get_slide_image_info(
+        cmd.get("file_path", ""), cmd.get("slide_index", 0)
+    ),
+    # System commands
+    "ping": lambda cmd: "LibreOffice helper is running",
+}
+
+
+def handle_command(command):
+    """Process commands from the MCP server using dictionary dispatch."""
+    try:
+        logging.info("handle_command called")
+        action = command.get("action", "")
+        logging.info(f"action: {action}")
+
+        # Look up the handler function
+        handler = COMMAND_HANDLERS.get(action)
+        if handler:
+            return safe_execute(action, handler, command)
+        else:
+            raise HelperError(f"Unknown action: {action}")
+
+    except Exception as e:
+        print(f"Error handling command: {str(e)}")
+        print(traceback.format_exc())
+        raise
+
+
+# Main server loop
+print("Starting command processing loop...")
+try:
+    while True:
+        client_socket = None
+        try:
+            print("Waiting for connection...")
+            logging.info("Waiting for connection...")
+
+            # This can raise OSError if server socket is invalid
+            client_socket, address = server_socket.accept()
+            print(f"Connection from {address}")
+            logging.info(f"Connection from {address}")
+
+            # Set timeout for client operations
+            client_socket.settimeout(30)
+
+            # Receive data in chunks to handle large messages
+            received_data = b""
+            while True:
+                try:
+                    chunk = client_socket.recv(4096)  # Smaller chunk size
+                    if not chunk:
+                        break
+                    received_data += chunk
+
+                    # Check if we have a complete JSON message
+                    try:
+                        data_str = received_data.decode("utf-8")
+                        json.loads(
+                            data_str
+                        )  # Try to parse - if successful, we have complete message
+                        break
+                    except (json.JSONDecodeError, UnicodeDecodeError):
+                        # Not complete yet, continue receiving
+                        if len(received_data) > 65536:  # Prevent memory issues
+                            raise Exception("Message too large")
+                        continue
+
+                except socket.timeout:
+                    print("Timeout while receiving data")
+                    logging.warning("Timeout while receiving data")
+                    break
+                except ConnectionResetError:
+                    print("Client disconnected during receive")
+                    logging.info("Client disconnected during receive")
+                    break
+                except Exception as recv_error:
+                    print(f"Error receiving data: {recv_error}")
+                    logging.error(f"Error receiving data: {recv_error}")
+                    break
+
+            if not received_data:
+                print("No data received, closing connection")
+                continue
+
+            try:
+                data_str = received_data.decode("utf-8")
+                print(f"Received data: {data_str[:100]}...")
+                logging.info(f"Received data: {data_str[:100]}...")
+            except UnicodeDecodeError as decode_error:
+                error_msg = f"Failed to decode received data: {decode_error}"
+                print(error_msg)
+                logging.error(error_msg)
+                response = {"status": "error", "message": error_msg}
+                try:
+                    client_socket.send(json.dumps(response).encode("utf-8"))
+                except:
+                    pass
+                continue
+
+            # Parse and execute command
+            try:
+                command = json.loads(data_str)
+                result = handle_command(command)
+                response = {"status": "success", "message": result}
+
+            except json.JSONDecodeError as json_error:
+                error_msg = f"Invalid JSON received: {str(json_error)}"
+                print(error_msg)
+                logging.error(error_msg)
+                response = {"status": "error", "message": error_msg}
+
+            except HelperError as helper_error:
+                error_msg = str(helper_error)
+                print(f"Helper error: {error_msg}")
+                logging.error(f"Helper error: {error_msg}")
+                response = {"status": "error", "message": error_msg}
+
+            except Exception as unexpected_error:
+                error_msg = f"Unexpected error: {str(unexpected_error)}"
+                print(error_msg)
+                print(traceback.format_exc())
+                logging.error(error_msg)
+                logging.error(traceback.format_exc())
+                response = {"status": "error", "message": error_msg}
+
+            # Send response
+            try:
+                response_json = json.dumps(response)
+                response_bytes = response_json.encode("utf-8")
+
+                # Send response length first, then data
+                length_header = len(response_bytes).to_bytes(4, byteorder="big")
+                client_socket.send(length_header + response_bytes)
+                print("Response sent")
+                logging.info("Response sent")
+
+            except ConnectionResetError:
+                print("Client disconnected before response could be sent")
+                logging.warning("Client disconnected before response could be sent")
+            except BrokenPipeError:
+                print("Broken pipe - client disconnected")
+                logging.warning("Broken pipe - client disconnected")
+            except Exception as send_error:
+                print(f"Failed to send response: {send_error}")
+                logging.error(f"Failed to send response: {send_error}")
+
+        except socket.timeout:
+            print("Server socket timeout")
+            logging.warning("Server socket timeout")
+
+        except ConnectionAbortedError:
+            print("Connection aborted by client")
+            logging.info("Connection aborted by client")
+
+        except OSError as os_error:
+            # Handle socket-related OS errors
+            if os_error.errno == 22:  # Invalid argument
+                print(f"Socket error (Invalid argument): {os_error}")
+                logging.error(f"Socket error: {os_error}")
+                # Try to recreate the server socket
+                try:
+                    server_socket.close()
+                    print("Attempting to recreate server socket...")
+                    logging.info("Attempting to recreate server socket...")
+
+                    server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                    server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                    server_socket.bind(("localhost", 8765))
+                    server_socket.listen(1)
+
+                    print("Server socket recreated successfully")
+                    logging.info("Server socket recreated successfully")
+                    continue
+
+                except Exception as recreate_error:
+                    print(f"Failed to recreate server socket: {recreate_error}")
+                    logging.fatal(f"Failed to recreate server socket: {recreate_error}")
+                    break
+            else:
+                print(f"OS error in server loop: {os_error}")
+                logging.error(f"OS error in server loop: {os_error}")
+
+        except Exception as client_error:
+            error_msg = f"Client connection error: {str(client_error)}"
+            print(error_msg)
+            logging.error(error_msg)
+            logging.error(traceback.format_exc())
+
+        finally:
+            # Always close the client socket
+            if client_socket:
+                try:
+                    client_socket.close()
+                    print("Client connection closed")
+                except Exception as close_error:
+                    print(f"Error closing client socket: {close_error}")
+
+except KeyboardInterrupt:
+    print("Helper server shutting down...")
+    logging.info("Helper server shutting down...")
+except Exception as fatal_error:
+    print(f"Fatal server error: {str(fatal_error)}")
+    logging.fatal(f"Fatal server error: {str(fatal_error)}")
+    print(traceback.format_exc())
+    logging.fatal(traceback.format_exc())
+finally:
+    try:
+        server_socket.close()
+        print("Server socket closed")
+        logging.info("Server socket closed")
+    except Exception as final_close_error:
+        print(f"Error closing server socket: {final_close_error}")
+        logging.error(f"Error closing server socket: {final_close_error}")

--- a/apps/codehelper/src-tauri/resources/libreoffice/mcp_server/helper_test_functions.py
+++ b/apps/codehelper/src-tauri/resources/libreoffice/mcp_server/helper_test_functions.py
@@ -1,0 +1,989 @@
+import logging
+import json
+import os
+from helper_utils import managed_document, HelperError
+from com.sun.star.awt.FontSlant import ITALIC
+from com.sun.star.table import BorderLine2, TableBorder2
+from com.sun.star.table.BorderLineStyle import SOLID
+
+
+# Functions for testing
+def get_text_formatting(file_path, text_to_find):
+    """Get formatting information for specific text in a document."""
+    with managed_document(file_path, read_only=True) as doc:
+        if hasattr(doc, "getText"):
+            search = doc.createSearchDescriptor()
+            search.SearchString = text_to_find
+            search.SearchCaseSensitive = False
+
+            found = doc.findFirst(search)
+            if not found:
+                raise HelperError(f"Text '{text_to_find}' not found in document")
+
+            # Extract formatting properties from the found text
+            formatting_info = {}
+
+            # Character formatting
+            try:
+                formatting_info["font_name"] = getattr(found, "CharFontName", "Unknown")
+                formatting_info["font_size"] = getattr(found, "CharHeight", 0)
+
+                # Bold (CharWeight: 100=normal, 150=bold)
+                char_weight = getattr(found, "CharWeight", 100)
+                formatting_info["bold"] = char_weight >= 150
+
+                # Italic (CharPosture: 0=none, 2=italic)
+                char_posture = getattr(found, "CharPosture", 0)
+                # Compare directly with the ITALIC constant
+                formatting_info["italic"] = char_posture == ITALIC
+
+                # Underline (CharUnderline: 0=none, 1=single, etc.)
+                char_underline = getattr(found, "CharUnderline", 0)
+                formatting_info["underline"] = char_underline > 0
+
+                # Text color
+                char_color = getattr(found, "CharColor", 0)
+                formatting_info["color"] = (
+                    f"#{char_color:06X}" if char_color > 0 else "#000000"
+                )
+
+                # Background color
+                char_back_color = getattr(found, "CharBackColor", -1)
+                if char_back_color != -1:
+                    formatting_info["background_color"] = f"#{char_back_color:06X}"
+                else:
+                    formatting_info["background_color"] = "transparent"
+
+            except Exception as char_error:
+                logging.warning(f"Error reading character formatting: {char_error}")
+
+            # Paragraph formatting
+            try:
+                # Alignment - convert enum to string
+                para_adjust = getattr(found, "ParaAdjust", None)
+                if para_adjust is not None:
+                    # Convert the enum value to its numeric value first, then to string
+                    try:
+                        adjust_value = int(para_adjust)
+                        alignment_map = {
+                            0: "left",  # LEFT
+                            1: "right",  # RIGHT
+                            2: "block",  # BLOCK
+                            3: "center",  # CENTER
+                            4: "stretch",  # STRETCH
+                        }
+                        formatting_info["alignment"] = alignment_map.get(
+                            adjust_value, f"unknown({adjust_value})"
+                        )
+                    except (ValueError, TypeError):
+                        formatting_info["alignment"] = "unknown"
+
+                # Line spacing
+                para_line_spacing = getattr(found, "ParaLineSpacing", None)
+                if para_line_spacing and hasattr(para_line_spacing, "Height"):
+                    # Height is in percentage (100 = single spacing)
+                    spacing_value = para_line_spacing.Height / 100.0
+                    formatting_info["line_spacing"] = spacing_value
+                else:
+                    formatting_info["line_spacing"] = 1.0
+
+                # Paragraph margins
+                formatting_info["left_margin"] = getattr(found, "ParaLeftMargin", 0)
+                formatting_info["right_margin"] = getattr(found, "ParaRightMargin", 0)
+                formatting_info["top_margin"] = getattr(found, "ParaTopMargin", 0)
+                formatting_info["bottom_margin"] = getattr(found, "ParaBottomMargin", 0)
+
+                # First line indent
+                formatting_info["first_line_indent"] = getattr(
+                    found, "ParaFirstLineIndent", 0
+                )
+
+            except Exception as para_error:
+                logging.warning(f"Error reading paragraph formatting: {para_error}")
+
+            # Style information
+            try:
+                formatting_info["paragraph_style"] = getattr(
+                    found, "ParaStyleName", "Standard"
+                )
+                formatting_info["character_style"] = getattr(found, "CharStyleName", "")
+
+            except Exception as style_error:
+                logging.warning(f"Error reading style information: {style_error}")
+
+            # Additional properties
+            try:
+                # Strikethrough
+                char_strikeout = getattr(found, "CharStrikeout", 0)
+                formatting_info["strikethrough"] = char_strikeout > 0
+
+                # Superscript/Subscript
+                char_escapement = getattr(found, "CharEscapement", 0)
+                if char_escapement > 0:
+                    formatting_info["script"] = "superscript"
+                elif char_escapement < 0:
+                    formatting_info["script"] = "subscript"
+                else:
+                    formatting_info["script"] = "normal"
+
+                # Font style (italic alternative) - convert to numeric value
+                font_slant = getattr(found, "CharPosture", 0)
+                try:
+                    formatting_info["font_slant"] = int(font_slant)
+                except (ValueError, TypeError):
+                    formatting_info["font_slant"] = 0
+
+                # Character scaling
+                formatting_info["char_scale_width"] = getattr(
+                    found, "CharScaleWidth", 100
+                )
+
+            except Exception as additional_error:
+                logging.warning(
+                    f"Error reading additional formatting: {additional_error}"
+                )
+
+            # Count occurrences
+            occurrence_count = 0
+            current_found = found
+            while current_found:
+                occurrence_count += 1
+                current_found = doc.findNext(current_found.End, search)
+
+            formatting_info["occurrences_found"] = occurrence_count
+            formatting_info["search_text"] = text_to_find
+
+            return json.dumps(formatting_info, indent=2)
+
+        else:
+            raise HelperError("Document does not support text formatting retrieval")
+
+
+def get_table_info(file_path, table_index=0):
+    """Get detailed information about a table in a document."""
+    with managed_document(file_path, read_only=True) as doc:
+        if not hasattr(doc, "getTextTables"):
+            raise HelperError("Document does not support tables")
+
+        tables = doc.getTextTables()
+        table_count = tables.getCount()
+
+        if table_count == 0:
+            raise HelperError("No tables found in document")
+
+        if table_index < 0 or table_index >= table_count:
+            raise HelperError(
+                f"Table index {table_index} is out of range (document has {table_count} tables)"
+            )
+
+        table = tables.getByIndex(table_index)
+
+        # Get table dimensions
+        rows = table.getRows()
+        columns = table.getColumns()
+        row_count = rows.getCount()
+        column_count = columns.getCount()
+
+        # Extract table data
+        table_data = []
+        for row_idx in range(row_count):
+            row_data = []
+            for col_idx in range(column_count):
+                try:
+                    cell_name = chr(65 + col_idx) + str(row_idx + 1)  # A1, B1, etc.
+                    cell = table.getCellByName(cell_name)
+                    cell_text = (
+                        cell.getText().getString() if hasattr(cell, "getText") else ""
+                    )
+                    row_data.append(cell_text)
+                except Exception as cell_error:
+                    logging.warning(f"Error reading cell: {cell_error}")
+                    row_data.append("")
+            table_data.append(row_data)
+
+        # Get table formatting information
+        table_info = {
+            "table_index": table_index,
+            "rows": row_count,
+            "columns": column_count,
+            "data": table_data,
+            "total_tables": table_count,
+        }
+
+        # Get table border information with enhanced debugging
+        try:
+            # Check both TableBorder2 and TableBorder properties for comparison
+            border_info = None
+            border_source = "none"
+
+            if hasattr(table, "TableBorder2"):
+                border_info = table.TableBorder2
+                border_source = "TableBorder2"
+                logging.info("Reading borders from TableBorder2 property")
+            elif hasattr(table, "TableBorder"):
+                border_info = table.TableBorder
+                border_source = "TableBorder"
+                logging.info("Reading borders from TableBorder property")
+
+            table_info["border_source"] = border_source
+
+            if border_info:
+                # Extract border line widths with detailed logging
+                border_widths = {}
+
+                # Log the border_info object for debugging
+                logging.info(f"Border info object: {border_info}")
+
+                # Check each border line with detailed logging
+                if hasattr(border_info, "TopLine") and border_info.TopLine:
+                    top_width = border_info.TopLine.LineWidth
+                    logging.info(f"TopLine.LineWidth: {top_width}")
+                    border_widths["top"] = top_width
+                else:
+                    logging.info("TopLine is None or missing")
+                    border_widths["top"] = 0
+
+                if hasattr(border_info, "BottomLine") and border_info.BottomLine:
+                    bottom_width = border_info.BottomLine.LineWidth
+                    logging.info(f"BottomLine.LineWidth: {bottom_width}")
+                    border_widths["bottom"] = bottom_width
+                else:
+                    logging.info("BottomLine is None or missing")
+                    border_widths["bottom"] = 0
+
+                if hasattr(border_info, "LeftLine") and border_info.LeftLine:
+                    left_width = border_info.LeftLine.LineWidth
+                    logging.info(f"LeftLine.LineWidth: {left_width}")
+                    border_widths["left"] = left_width
+                else:
+                    logging.info("LeftLine is None or missing")
+                    border_widths["left"] = 0
+
+                if hasattr(border_info, "RightLine") and border_info.RightLine:
+                    right_width = border_info.RightLine.LineWidth
+                    logging.info(f"RightLine.LineWidth: {right_width}")
+                    border_widths["right"] = right_width
+                else:
+                    logging.info("RightLine is None or missing")
+                    border_widths["right"] = 0
+
+                if (
+                    hasattr(border_info, "HorizontalLine")
+                    and border_info.HorizontalLine
+                ):
+                    horizontal_width = border_info.HorizontalLine.LineWidth
+                    logging.info(f"HorizontalLine.LineWidth: {horizontal_width}")
+                    border_widths["horizontal"] = horizontal_width
+                else:
+                    logging.info("HorizontalLine is None or missing")
+                    border_widths["horizontal"] = 0
+
+                if hasattr(border_info, "VerticalLine") and border_info.VerticalLine:
+                    vertical_width = border_info.VerticalLine.LineWidth
+                    logging.info(f"VerticalLine.LineWidth: {vertical_width}")
+                    border_widths["vertical"] = vertical_width
+                else:
+                    logging.info("VerticalLine is None or missing")
+                    border_widths["vertical"] = 0
+
+                table_info["border_widths"] = border_widths
+
+                # Log the final border_widths for debugging
+                logging.info(f"Final border_widths: {border_widths}")
+
+                # Check if table has any borders
+                has_borders = any(width > 0 for width in border_widths.values())
+                table_info["has_borders"] = has_borders
+
+                # Get maximum border width
+                table_info["max_border_width"] = (
+                    max(border_widths.values()) if border_widths.values() else 0
+                )
+
+                # Get border styles if available
+                border_styles = {}
+                if hasattr(border_info, "TopLine") and border_info.TopLine:
+                    border_styles["top"] = getattr(
+                        border_info.TopLine, "LineStyle", "unknown"
+                    )
+                if hasattr(border_info, "BottomLine") and border_info.BottomLine:
+                    border_styles["bottom"] = getattr(
+                        border_info.BottomLine, "LineStyle", "unknown"
+                    )
+                if hasattr(border_info, "LeftLine") and border_info.LeftLine:
+                    border_styles["left"] = getattr(
+                        border_info.LeftLine, "LineStyle", "unknown"
+                    )
+                if hasattr(border_info, "RightLine") and border_info.RightLine:
+                    border_styles["right"] = getattr(
+                        border_info.RightLine, "LineStyle", "unknown"
+                    )
+
+                table_info["border_styles"] = border_styles
+
+            else:
+                table_info["has_borders"] = False
+                table_info["border_widths"] = {
+                    "top": 0,
+                    "bottom": 0,
+                    "left": 0,
+                    "right": 0,
+                    "horizontal": 0,
+                    "vertical": 0,
+                }
+                table_info["max_border_width"] = 0
+
+        except Exception as border_error:
+            logging.warning(f"Error reading table border properties: {border_error}")
+            table_info["border_error"] = str(border_error)
+            table_info["has_borders"] = False
+
+        # Get other table properties
+        try:
+            if hasattr(table, "BackColor"):
+                table_info["background_color"] = (
+                    f"#{table.BackColor:06X}"
+                    if table.BackColor != -1
+                    else "transparent"
+                )
+
+            if hasattr(table, "Width"):
+                table_info["width"] = table.Width
+
+        except Exception as prop_error:
+            logging.warning(f"Error reading table properties: {prop_error}")
+
+        return json.dumps(table_info, indent=2)
+
+
+def has_image(file_path):
+    """Check if a document contains at least one image and get dimensions of the first image."""
+    with managed_document(file_path, read_only=True) as doc:
+        if not hasattr(doc, "getGraphicObjects"):
+            raise HelperError("Document does not support graphics/images")
+
+        graphic_objects = doc.getGraphicObjects()
+        image_count = graphic_objects.getCount()
+
+        result = {"has_image": image_count > 0, "image_count": image_count}
+
+        # If there's at least one image, get dimensions of the first one
+        if image_count > 0:
+            try:
+                first_image = graphic_objects.getByIndex(0)
+                if hasattr(first_image, "Size"):
+                    size = first_image.Size
+                    result["first_image_width"] = size.Width
+                    result["first_image_height"] = size.Height
+                    # Also provide dimensions in mm for convenience
+                    result["first_image_width_mm"] = size.Width / 100.0
+                    result["first_image_height_mm"] = size.Height / 100.0
+                else:
+                    result["first_image_width"] = None
+                    result["first_image_height"] = None
+            except Exception as e:
+                logging.warning(f"Error reading first image dimensions: {e}")
+                result["first_image_width"] = None
+                result["first_image_height"] = None
+
+        return json.dumps(result, indent=2)
+
+
+def get_page_break_info(file_path):
+    """Get information about page breaks in a document."""
+    with managed_document(file_path, read_only=True) as doc:
+        if not hasattr(doc, "getText"):
+            raise HelperError("Document does not support text content")
+
+        text = doc.getText()
+
+        # Method 1: Check paragraphs for BreakType property
+        text_enum = text.createEnumeration()
+        page_break_count = 0
+        paragraph_details = []
+
+        paragraph_index = 0
+        while text_enum.hasMoreElements():
+            paragraph = text_enum.nextElement()
+            paragraph_info = {
+                "index": paragraph_index,
+                "has_break": False,
+                "break_type": None,
+            }
+
+            try:
+                if hasattr(paragraph, "BreakType"):
+                    break_type = paragraph.BreakType
+                    paragraph_info["break_type"] = str(break_type)
+
+                    # Handle different ways the enum might be represented
+                    if hasattr(break_type, "value"):
+                        break_value = break_type.value
+                    else:
+                        # Convert string representation to check for page break types
+                        break_str = str(break_type).upper()
+                        if "PAGE_BEFORE" in break_str:
+                            break_value = "PAGE_BEFORE"
+                        elif "PAGE_AFTER" in break_str:
+                            break_value = "PAGE_AFTER"
+                        elif "PAGE_BOTH" in break_str:
+                            break_value = "PAGE_BOTH"
+                        else:
+                            break_value = "NONE"
+
+                    paragraph_info["break_value"] = break_value
+
+                    # Check for any page break type
+                    if break_value in ["PAGE_BEFORE", "PAGE_AFTER", "PAGE_BOTH"]:
+                        page_break_count += 1
+                        paragraph_info["has_break"] = True
+
+                # Also check the paragraph text content
+                if hasattr(paragraph, "getString"):
+                    para_text = paragraph.getString()
+                    paragraph_info["text"] = (
+                        para_text[:50] + "..." if len(para_text) > 50 else para_text
+                    )
+                    paragraph_info["length"] = len(para_text)
+
+            except Exception as e:
+                paragraph_info["error"] = str(e)
+                logging.debug(f"Error checking paragraph {paragraph_index}: {e}")
+
+            paragraph_details.append(paragraph_info)
+            paragraph_index += 1
+
+        # Method 2: Check for manual page breaks (form feed characters)
+        text_content = text.getString()
+        manual_breaks = text_content.count("\x0c")  # Form feed character
+
+        # Method 3: Try to get actual page count from view
+        estimated_pages = None
+        try:
+            if hasattr(doc, "getCurrentController"):
+                controller = doc.getCurrentController()
+                if hasattr(controller, "getPageCount"):
+                    estimated_pages = controller.getPageCount()
+        except Exception as e:
+            logging.debug(f"Could not get page count: {e}")
+
+        result = {
+            "paragraph_page_breaks": page_break_count,
+            "manual_page_breaks": manual_breaks,
+            "total_page_breaks": page_break_count + manual_breaks,
+            "estimated_page_count": estimated_pages,
+            "total_paragraphs": len(paragraph_details),
+            "paragraph_details": paragraph_details,
+            "text_length": len(text_content),
+            "contains_form_feed": "\x0c" in text_content,
+            "debug_text_sample": text_content[:200] + "..."
+            if len(text_content) > 200
+            else text_content,
+        }
+
+        return json.dumps(result, indent=2)
+
+
+def get_presentation_template_info(file_path):
+    """Get the name of the template used by a presentation."""
+    with managed_document(file_path, read_only=True) as doc:
+        if not hasattr(doc, "getDrawPages"):
+            raise HelperError("Document does not support slides/pages")
+
+        template_info = {
+            "template_name": None,
+            "master_slide_name": None,
+            "template_path": None,
+        }
+
+        # Check document properties for template info
+        try:
+            if hasattr(doc, "DocumentProperties"):
+                doc_props = doc.DocumentProperties
+                if hasattr(doc_props, "TemplateName") and doc_props.TemplateName:
+                    template_info["template_name"] = doc_props.TemplateName
+                if hasattr(doc_props, "TemplateURL") and doc_props.TemplateURL:
+                    template_info["template_path"] = doc_props.TemplateURL
+        except Exception as e:
+            logging.warning(f"Error reading document properties: {e}")
+
+        # Get master slide name as potential template indicator
+        try:
+            if hasattr(doc, "getMasterPages"):
+                master_pages = doc.getMasterPages()
+                if master_pages.getCount() > 0:
+                    master_slide = master_pages.getByIndex(0)
+                    if hasattr(master_slide, "Name") and master_slide.Name:
+                        template_info["master_slide_name"] = master_slide.Name
+        except Exception as e:
+            logging.warning(f"Error reading master slide: {e}")
+
+        # Return the most likely template name
+        template_name = (
+            template_info["template_name"]
+            or template_info["master_slide_name"]
+            or "Default"
+        )
+
+        return f"Template: {template_name}"
+
+
+def get_presentation_text_formatting(file_path, text_to_find, slide_index=None):
+    """Get formatting information for specific text in a presentation."""
+    with managed_document(file_path, read_only=True) as doc:
+        if not hasattr(doc, "getDrawPages"):
+            raise HelperError("Document does not support slides/pages")
+
+        draw_pages = doc.getDrawPages()
+        slide_count = draw_pages.getCount()
+
+        if slide_count == 0:
+            raise HelperError("No slides found in presentation")
+
+        # If slide_index is specified, search only that slide
+        if slide_index is not None:
+            if slide_index < 0 or slide_index >= slide_count:
+                raise HelperError(
+                    f"Slide index {slide_index} is out of range (presentation has {slide_count} slides)"
+                )
+            slides_to_search = [slide_index]
+        else:
+            # Search all slides
+            slides_to_search = range(slide_count)
+
+        # Search for text across specified slides
+        found_text_object = None
+        found_slide_index = None
+        found_shape_index = None
+        found_shape_type = None
+
+        for slide_idx in slides_to_search:
+            slide = draw_pages.getByIndex(slide_idx)
+
+            # Check each shape on the slide
+            if hasattr(slide, "getCount"):
+                shape_count = slide.getCount()
+
+                for shape_idx in range(shape_count):
+                    try:
+                        shape = slide.getByIndex(shape_idx)
+                        shape_type = shape.getShapeType()
+
+                        # Check if shape contains text
+                        if hasattr(shape, "getText"):
+                            text_obj = shape.getText()
+                            if text_obj:
+                                # Get the full text content as string
+                                text_content = text_obj.getString()
+
+                                # Check if our search text is in this shape's content
+                                if text_to_find.lower() in text_content.lower():
+                                    found_text_object = text_obj
+                                    found_slide_index = slide_idx
+                                    found_shape_index = shape_idx
+                                    found_shape_type = shape_type
+                                    break
+
+                    except Exception as shape_error:
+                        logging.warning(
+                            f"Error searching shape {shape_idx} on slide {slide_idx}: {shape_error}"
+                        )
+                        continue
+
+                if found_text_object:
+                    break
+
+        if not found_text_object:
+            raise HelperError(
+                f"Text '{text_to_find}' not found in presentation"
+                + (f" slide {slide_index}" if slide_index is not None else "")
+            )
+
+        # Extract formatting properties from the found text object
+        formatting_info = {
+            "search_text": text_to_find,
+            "found_on_slide": found_slide_index,
+            "found_in_shape": found_shape_index,
+            "shape_type": found_shape_type,
+        }
+
+        # Determine if this is likely a title or content shape
+        shape_category = "unknown"
+        if found_shape_type and "Title" in found_shape_type:
+            shape_category = "title"
+        elif found_shape_type and (
+            "Outliner" in found_shape_type or "Text" in found_shape_type
+        ):
+            shape_category = "content"
+        formatting_info["shape_category"] = shape_category
+
+        # Try to get formatting from the text object using the same method as format_slide_content
+        text_to_format = found_text_object
+
+        # Try to create a text cursor like format_slide_content does
+        try:
+            if hasattr(found_text_object, "createTextCursor"):
+                text_cursor = found_text_object.createTextCursor()
+                text_cursor.gotoStart(False)
+                text_cursor.gotoEnd(
+                    True
+                )  # Select all text like format_slide_content does
+                text_to_format = text_cursor
+                logging.info(
+                    "Using text cursor for formatting detection (matching format_slide_content method)"
+                )
+        except Exception as cursor_error:
+            logging.warning(f"Could not create text cursor: {cursor_error}")
+
+            # Fallback: Try to get the first paragraph for more specific formatting
+            try:
+                if hasattr(found_text_object, "createEnumeration"):
+                    text_enum = found_text_object.createEnumeration()
+                    if text_enum.hasMoreElements():
+                        first_paragraph = text_enum.nextElement()
+                        if first_paragraph:
+                            # Try to get text portions within the paragraph for more specific formatting
+                            if hasattr(first_paragraph, "createEnumeration"):
+                                portion_enum = first_paragraph.createEnumeration()
+                                if portion_enum.hasMoreElements():
+                                    first_portion = portion_enum.nextElement()
+                                    if first_portion:
+                                        text_to_format = first_portion
+                            else:
+                                text_to_format = first_paragraph
+            except Exception as enum_error:
+                logging.warning(f"Could not get paragraph enumeration: {enum_error}")
+
+        # Character formatting
+        try:
+            formatting_info["font_name"] = getattr(
+                text_to_format, "CharFontName", "Unknown"
+            )
+            formatting_info["font_size"] = getattr(text_to_format, "CharHeight", 0)
+
+            # Bold (CharWeight: 100=normal, 150=bold)
+            char_weight = getattr(text_to_format, "CharWeight", 100)
+            formatting_info["bold"] = char_weight >= 150
+
+            # Italic (CharPosture: 0=none, 2=italic)
+            char_posture = getattr(text_to_format, "CharPosture", 0)
+            formatting_info["italic"] = (
+                char_posture == 2
+            )  # Use numeric value like in format functions
+
+            # Underline (CharUnderline: 0=none, 1=single, etc.)
+            char_underline = getattr(text_to_format, "CharUnderline", 0)
+            formatting_info["underline"] = char_underline > 0
+
+            # Text color
+            char_color = getattr(text_to_format, "CharColor", 0)
+            formatting_info["color"] = (
+                f"#{char_color:06X}" if char_color > 0 else "#000000"
+            )
+
+            # Background color
+            char_back_color = getattr(text_to_format, "CharBackColor", -1)
+            if char_back_color != -1:
+                formatting_info["background_color"] = f"#{char_back_color:06X}"
+            else:
+                formatting_info["background_color"] = "transparent"
+
+        except Exception as char_error:
+            logging.warning(f"Error reading character formatting: {char_error}")
+
+        # Paragraph formatting
+        try:
+            # Alignment - convert enum to string (matching format functions)
+            para_adjust = getattr(text_to_format, "ParaAdjust", None)
+            if para_adjust is not None:
+                try:
+                    adjust_value = int(para_adjust)
+                    alignment_map = {
+                        0: "left",  # LEFT
+                        1: "right",  # RIGHT
+                        2: "block",  # BLOCK
+                        3: "center",  # CENTER
+                        4: "stretch",  # STRETCH
+                    }
+                    formatting_info["alignment"] = alignment_map.get(
+                        adjust_value, f"unknown({adjust_value})"
+                    )
+                except (ValueError, TypeError):
+                    formatting_info["alignment"] = "unknown"
+
+            # Line spacing
+            para_line_spacing = getattr(text_to_format, "ParaLineSpacing", None)
+            if para_line_spacing and hasattr(para_line_spacing, "Height"):
+                spacing_value = para_line_spacing.Height / 100.0
+                formatting_info["line_spacing"] = spacing_value
+            else:
+                formatting_info["line_spacing"] = 1.0
+
+            # Paragraph margins/indents
+            formatting_info["left_margin"] = getattr(
+                text_to_format, "ParaLeftMargin", 0
+            )
+            formatting_info["right_margin"] = getattr(
+                text_to_format, "ParaRightMargin", 0
+            )
+            formatting_info["top_margin"] = getattr(text_to_format, "ParaTopMargin", 0)
+            formatting_info["bottom_margin"] = getattr(
+                text_to_format, "ParaBottomMargin", 0
+            )
+            formatting_info["first_line_indent"] = getattr(
+                text_to_format, "ParaFirstLineIndent", 0
+            )
+
+        except Exception as para_error:
+            logging.warning(f"Error reading paragraph formatting: {para_error}")
+
+        # Style information
+        try:
+            formatting_info["paragraph_style"] = getattr(
+                text_to_format, "ParaStyleName", "Standard"
+            )
+            formatting_info["character_style"] = getattr(
+                text_to_format, "CharStyleName", ""
+            )
+
+        except Exception as style_error:
+            logging.warning(f"Error reading style information: {style_error}")
+
+        # Additional presentation-specific properties
+        try:
+            # Strikethrough
+            char_strikeout = getattr(text_to_format, "CharStrikeout", 0)
+            formatting_info["strikethrough"] = char_strikeout > 0
+
+            # Superscript/Subscript
+            char_escapement = getattr(text_to_format, "CharEscapement", 0)
+            if char_escapement > 0:
+                formatting_info["script"] = "superscript"
+            elif char_escapement < 0:
+                formatting_info["script"] = "subscript"
+            else:
+                formatting_info["script"] = "normal"
+
+            # Character scaling
+            formatting_info["char_scale_width"] = getattr(
+                text_to_format, "CharScaleWidth", 100
+            )
+
+        except Exception as additional_error:
+            logging.warning(f"Error reading additional formatting: {additional_error}")
+
+        # Count total occurrences across all slides
+        try:
+            total_occurrences = 0
+            for slide_idx in range(slide_count):
+                slide = draw_pages.getByIndex(slide_idx)
+                if hasattr(slide, "getCount"):
+                    shape_count = slide.getCount()
+                    for shape_idx in range(shape_count):
+                        try:
+                            shape = slide.getByIndex(shape_idx)
+                            if hasattr(shape, "getText"):
+                                text_obj = shape.getText()
+                                if text_obj:
+                                    text_content = text_obj.getString()
+                                    total_occurrences += text_content.lower().count(
+                                        text_to_find.lower()
+                                    )
+                        except Exception:
+                            continue
+
+            formatting_info["total_occurrences"] = total_occurrences
+
+        except Exception as count_error:
+            logging.warning(f"Error counting occurrences: {count_error}")
+            formatting_info["total_occurrences"] = 1
+
+        # Add the actual text content found for debugging
+        try:
+            formatting_info["full_text_content"] = found_text_object.getString()
+        except Exception:
+            formatting_info["full_text_content"] = "Could not retrieve text content"
+
+        return json.dumps(formatting_info, indent=2)
+
+
+def get_slide_image_info(file_path, slide_index):
+    """Check if a specific slide contains images and get information about them."""
+    with managed_document(file_path, read_only=True) as doc:
+        if not hasattr(doc, "getDrawPages"):
+            raise HelperError("Document does not support slides/pages")
+
+        draw_pages = doc.getDrawPages()
+        slide_count = draw_pages.getCount()
+
+        if slide_count == 0:
+            raise HelperError("No slides found in presentation")
+
+        if slide_index < 0 or slide_index >= slide_count:
+            raise HelperError(
+                f"Slide index {slide_index} is out of range (presentation has {slide_count} slides)"
+            )
+
+        target_slide = draw_pages.getByIndex(slide_index)
+
+        result = {
+            "slide_index": slide_index,
+            "has_images": False,
+            "image_count": 0,
+            "images": [],
+            "total_slides": slide_count,
+        }
+
+        # Check all shapes on the slide for images
+        shape_count = target_slide.getCount()
+
+        for shape_idx in range(shape_count):
+            try:
+                shape = target_slide.getByIndex(shape_idx)
+                shape_type = shape.getShapeType()
+
+                # Check if this is a graphic/image shape (same check as insert_slide_image)
+                if shape_type == "com.sun.star.drawing.GraphicObjectShape":
+                    image_info = {
+                        "shape_index": shape_idx,
+                        "shape_type": shape_type,
+                        "width": None,
+                        "height": None,
+                        "width_mm": None,
+                        "height_mm": None,
+                        "position_x": None,
+                        "position_y": None,
+                        "position_x_mm": None,
+                        "position_y_mm": None,
+                        "graphic_url": None,
+                        "filename": None,
+                    }
+
+                    # Get image dimensions (same method as insert_slide_image)
+                    try:
+                        if hasattr(shape, "getSize"):
+                            size = shape.getSize()
+                            image_info["width"] = size.Width  # 1/100mm units
+                            image_info["height"] = size.Height  # 1/100mm units
+                            # Convert to mm for convenience
+                            image_info["width_mm"] = size.Width / 100.0
+                            image_info["height_mm"] = size.Height / 100.0
+                    except Exception as size_error:
+                        logging.warning(f"Error reading image size: {size_error}")
+
+                    # Get image position (same method as insert_slide_image)
+                    try:
+                        if hasattr(shape, "getPosition"):
+                            position = shape.getPosition()
+                            image_info["position_x"] = position.X  # 1/100mm units
+                            image_info["position_y"] = position.Y  # 1/100mm units
+                            # Convert to mm for convenience
+                            image_info["position_x_mm"] = position.X / 100.0
+                            image_info["position_y_mm"] = position.Y / 100.0
+                    except Exception as pos_error:
+                        logging.warning(f"Error reading image position: {pos_error}")
+
+                    # Get graphic URL/source if available (fixed to handle None values)
+                    try:
+                        if hasattr(shape, "GraphicURL"):
+                            graphic_url = shape.GraphicURL
+                            if graphic_url and isinstance(graphic_url, str):
+                                image_info["graphic_url"] = graphic_url
+                                # Try to extract just the filename for readability
+                                if graphic_url.startswith("file://"):
+                                    try:
+                                        import urllib.parse
+
+                                        file_path_from_url = urllib.parse.unquote(
+                                            graphic_url[7:]
+                                        )
+                                        image_info["filename"] = os.path.basename(
+                                            file_path_from_url
+                                        )
+                                    except Exception as parse_error:
+                                        logging.warning(
+                                            f"Error parsing file URL: {parse_error}"
+                                        )
+                                        image_info["filename"] = "unknown"
+                                else:
+                                    # For non-file URLs or embedded images
+                                    image_info["filename"] = "embedded_or_unknown"
+                    except Exception as url_error:
+                        logging.warning(f"Error reading graphic URL: {url_error}")
+
+                    # Check if image is centered on slide (same logic as insert_slide_image)
+                    try:
+                        if (
+                            image_info["position_x"] is not None
+                            and image_info["position_y"] is not None
+                            and image_info["width"] is not None
+                            and image_info["height"] is not None
+                        ):
+                            # Get slide dimensions (using same defaults and methods as insert_slide_image)
+                            slide_width = 25400  # Standard slide width in 1/100mm
+                            slide_height = 19050  # Standard slide height in 1/100mm
+
+                            try:
+                                # Method 1: Try to get slide dimensions from the master page
+                                if hasattr(target_slide, "getMasterPage"):
+                                    master_page = target_slide.getMasterPage()
+                                    if hasattr(master_page, "Width") and hasattr(
+                                        master_page, "Height"
+                                    ):
+                                        slide_width = master_page.Width
+                                        slide_height = master_page.Height
+
+                                # Method 2: Try to get from the document's draw page size
+                                elif hasattr(doc, "getDrawPageSize"):
+                                    page_size = doc.getDrawPageSize()
+                                    slide_width = page_size.Width
+                                    slide_height = page_size.Height
+
+                            except Exception as slide_dim_error:
+                                logging.warning(
+                                    f"Could not get slide dimensions, using defaults: {slide_dim_error}"
+                                )
+
+                            # Calculate if image is centered (same calculation as insert_slide_image)
+                            slide_center_x = slide_width // 2
+                            slide_center_y = slide_height // 2
+                            image_center_x = image_info["position_x"] + (
+                                image_info["width"] // 2
+                            )
+                            image_center_y = image_info["position_y"] + (
+                                image_info["height"] // 2
+                            )
+
+                            # Allow some tolerance for "centered" (within 5mm)
+                            center_tolerance = 500  # 5mm in 1/100mm units
+                            is_centered_x = (
+                                abs(image_center_x - slide_center_x) <= center_tolerance
+                            )
+                            is_centered_y = (
+                                abs(image_center_y - slide_center_y) <= center_tolerance
+                            )
+
+                            image_info["is_centered"] = is_centered_x and is_centered_y
+                            image_info["is_centered_horizontally"] = is_centered_x
+                            image_info["is_centered_vertically"] = is_centered_y
+
+                            # Add slide dimensions for reference
+                            image_info["slide_width"] = slide_width
+                            image_info["slide_height"] = slide_height
+                            image_info["slide_width_mm"] = slide_width / 100.0
+                            image_info["slide_height_mm"] = slide_height / 100.0
+
+                    except Exception as center_error:
+                        logging.warning(
+                            f"Error calculating image centering: {center_error}"
+                        )
+
+                    result["images"].append(image_info)
+                    result["image_count"] += 1
+                    result["has_images"] = True
+
+            except Exception as shape_error:
+                logging.warning(f"Error examining shape {shape_idx}: {shape_error}")
+                continue
+
+        return json.dumps(result, indent=2)

--- a/apps/codehelper/src-tauri/resources/libreoffice/mcp_server/helper_utils.py
+++ b/apps/codehelper/src-tauri/resources/libreoffice/mcp_server/helper_utils.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python
+import os
+import time
+import traceback
+import logging
+import sys
+from contextlib import contextmanager
+
+
+# Set up logging immediately when this module is imported
+def _resolve_log_path(filename):
+    """Resolve log file location, preferring SMOLPC_MCP_LOG_DIR when provided."""
+    log_dir = os.getenv("SMOLPC_MCP_LOG_DIR")
+    if log_dir:
+        os.makedirs(log_dir, exist_ok=True)
+        return os.path.join(log_dir, filename)
+    module_dir = os.path.dirname(__file__)
+    return os.path.join(module_dir, filename)
+
+
+def _setup_module_logging():
+    """Internal function to set up logging for this module."""
+    try:
+        log_path = _resolve_log_path("helper.log")
+
+        # Clear existing handlers
+        for handler in logging.root.handlers[:]:
+            logging.root.removeHandler(handler)
+
+        # Configure logging
+        logging.basicConfig(
+            filename=log_path,
+            level=logging.INFO,
+            format="%(asctime)s %(levelname)s %(message)s",
+            force=True,
+            filemode="a",
+        )
+
+        # Test logging
+        logging.info("=" * 50)
+        logging.info(f"helper_utils module loaded - logging to: {log_path}")
+
+    except Exception as e:
+        print(f"Failed to set up logging in helper_utils: {e}")
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s %(levelname)s %(message)s",
+            stream=sys.stdout,
+        )
+
+
+# Call the setup function
+_setup_module_logging()
+
+try:
+    print("Importing UNO...")
+    logging.info("Importing UNO...")
+    import uno
+    from com.sun.star.beans import PropertyValue
+    from com.sun.star.connection import NoConnectException
+
+    print("UNO imported successfully!")
+    logging.info("UNO imported successfully!")
+except ImportError as e:
+    print(f"UNO Import Error: {e}")
+    logging.error(f"UNO Import Error: {e}")
+    print("This script must be run with LibreOffice's Python.")
+    logging.error("This script must be run with LibreOffice's Python.")
+    sys.exit(1)
+
+
+class HelperError(Exception):
+    pass
+
+
+@contextmanager
+def managed_document(file_path, read_only=False):
+    doc, message = open_document(file_path, read_only)
+    if not doc:
+        raise HelperError(message)
+    try:
+        yield doc
+    finally:
+        try:
+            doc.close(True)
+        except Exception:
+            pass
+
+
+# Helper functions
+
+
+def ensure_directory_exists(file_path):
+    """Ensure the directory for a file exists, creating it if necessary."""
+    directory = os.path.dirname(file_path)
+    if directory and not os.path.exists(directory):
+        try:
+            os.makedirs(directory, exist_ok=True)
+            print(f"Created directory: {directory}")
+        except Exception as e:
+            print(f"Failed to create directory {directory}: {str(e)}")
+            return False
+    return True
+
+
+def normalize_path(file_path):
+    """Convert a relative path to an absolute path."""
+    if not file_path:
+        raise HelperError("File path cannot be empty or None")
+
+    if not isinstance(file_path, str):
+        raise HelperError(f"File path must be a string, got {type(file_path).__name__}")
+
+    # If file path is already complete, return it
+    if file_path.startswith(("file://", "http://", "https://", "ftp://")):
+        return file_path
+
+    # Expand user directory if path starts with ~
+    if file_path.startswith("~"):
+        file_path = os.path.expanduser(file_path)
+
+    # Make absolute if relative
+    if not os.path.isabs(file_path):
+        file_path = os.path.abspath(file_path)
+
+    print(f"Normalized path: {file_path}")
+    return file_path
+
+
+def get_uno_desktop():
+    """Get LibreOffice desktop object."""
+    try:
+        local_context = uno.getComponentContext()
+        resolver = local_context.ServiceManager.createInstanceWithContext(
+            "com.sun.star.bridge.UnoUrlResolver", local_context
+        )
+
+        # Try both localhost and 127.0.0.1
+        try:
+            context = resolver.resolve(
+                "uno:socket,host=localhost,port=2002;urp;StarOffice.ComponentContext"
+            )
+        except NoConnectException:
+            context = resolver.resolve(
+                "uno:socket,host=127.0.0.1,port=2002;urp;StarOffice.ComponentContext"
+            )
+
+        desktop = context.ServiceManager.createInstanceWithContext(
+            "com.sun.star.frame.Desktop", context
+        )
+        return desktop
+    except Exception as e:
+        print(f"Failed to get UNO desktop: {str(e)}")
+        print(traceback.format_exc())
+        return None
+
+
+def create_property_value(name, value):
+    """Create a PropertyValue with given name and value."""
+    prop = PropertyValue()
+    prop.Name = name
+
+    # Convert Python boolean to UNO boolean if needed
+    if isinstance(value, bool):
+        prop.Value = uno.Bool(value)
+    else:
+        prop.Value = value
+
+    return prop
+
+
+def open_document(file_path, read_only=False, retries=3, delay=0.5):
+    print(f"Opening document: {file_path} (read_only: {read_only})")
+    normalized_path = normalize_path(file_path)
+    if not normalized_path.startswith(("file://", "http://", "https://", "ftp://")):
+        if not os.path.exists(normalized_path):
+            raise HelperError(f"Document not found: {normalized_path}")
+        file_url = uno.systemPathToFileUrl(normalized_path)
+    else:
+        file_url = normalized_path
+
+    desktop = get_uno_desktop()
+    if not desktop:
+        raise HelperError("Failed to connect to LibreOffice desktop")
+
+    last_exception = None
+    for attempt in range(retries):
+        try:
+            props = [
+                create_property_value("Hidden", True),
+                create_property_value("ReadOnly", read_only),
+            ]
+            doc = desktop.loadComponentFromURL(file_url, "_blank", 0, tuple(props))
+            if not doc:
+                raise HelperError(f"Failed to load document: {file_path}")
+            return doc, "Success"
+        except Exception as e:
+            last_exception = e
+            print(f"Attempt {attempt + 1} failed: {e}")
+            time.sleep(delay)
+
+    if last_exception:
+        raise last_exception
+    else:
+        raise HelperError(
+            f"Failed to load document after {retries} attempts: {file_path}"
+        )

--- a/apps/codehelper/src-tauri/resources/libreoffice/mcp_server/libre.py
+++ b/apps/codehelper/src-tauri/resources/libreoffice/mcp_server/libre.py
@@ -1,0 +1,1639 @@
+#!/usr/bin/env python3
+import os
+import sys
+from typing import Optional, List
+import socket
+import json
+import logging
+import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from queue import Queue, Empty
+import time
+import builtins
+
+# Redirect all print() to stderr — stdout is reserved for MCP JSON-RPC protocol
+_original_print = builtins.print
+def _print_to_stderr(*args, **kwargs):
+    kwargs.setdefault('file', sys.stderr)
+    _original_print(*args, **kwargs)
+builtins.print = _print_to_stderr
+
+def _resolve_log_path(filename: str) -> str:
+    log_dir = os.getenv("SMOLPC_MCP_LOG_DIR")
+    if log_dir:
+        os.makedirs(log_dir, exist_ok=True)
+        return os.path.join(log_dir, filename)
+    return os.path.join(os.path.dirname(__file__), filename)
+
+log_path = _resolve_log_path("libre.log")
+logging.basicConfig(
+    filename=log_path,
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+
+# Extensions
+writer_extensions = (
+    ".odt",
+    ".docx",
+    ".dotx",
+    ".xml",
+    ".doc",
+    ".dot",
+    ".rtf",
+    ".wpd",
+)
+
+impress_extensions = (
+    ".odp",
+    ".pptx",
+    ".ppsx",
+    ".ppmx",
+    ".potx",
+    ".pomx",
+    ".ppt",
+    ".pps",
+    ".ppm",
+    ".pot",
+    ".pom",
+)
+
+# Global Queue and Thread Pool
+request_queue = Queue()
+response_dict = {}
+response_lock = threading.Lock()
+thread_pool = ThreadPoolExecutor(max_workers=1)
+
+
+def queue_worker():
+    """Worker function that processes requests from the queue sequentially"""
+    while True:
+        try:
+            request_id, command = request_queue.get(timeout=1)
+
+            # Process the request
+            try:
+                client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                client_socket.settimeout(30)  # 30 second timeout
+                client_socket.connect(("localhost", 8765))
+
+                logging.info(client_socket)
+
+                # Send command
+                request_data = json.dumps(command).encode("utf-8")
+                client_socket.send(request_data)
+
+                logging.info(request_data)
+
+                # Receive response (helper.py sends 4-byte big-endian length header + JSON)
+                length_data = client_socket.recv(4)
+                if len(length_data) < 4:
+                    client_socket.close()
+                    response = {
+                        "status": "error",
+                        "message": "Incomplete length header from helper",
+                    }
+                else:
+                    msg_length = int.from_bytes(length_data, byteorder="big")
+
+                    # Read exactly msg_length bytes
+                    chunks = []
+                    bytes_remaining = msg_length
+                    while bytes_remaining > 0:
+                        chunk = client_socket.recv(min(bytes_remaining, 16384))
+                        if not chunk:
+                            break
+                        chunks.append(chunk)
+                        bytes_remaining -= len(chunk)
+
+                    client_socket.close()
+                    response_data = b"".join(chunks).decode("utf-8")
+                    logging.info(response_data)
+
+                    if not response_data:
+                        response = {
+                            "status": "error",
+                            "message": "Empty response from helper",
+                        }
+                    else:
+                        response = json.loads(response_data)
+
+            except socket.timeout:
+                response = {
+                    "status": "error",
+                    "message": "Connection to helper timed out",
+                }
+            except ConnectionRefusedError:
+                response = {
+                    "status": "error",
+                    "message": "Connection refused. Is the helper script running?",
+                }
+            except Exception as e:
+                response = {
+                    "status": "error",
+                    "message": f"Error communicating with helper: {str(e)}",
+                }
+
+            # Store the response
+            with response_lock:
+                response_dict[request_id] = response
+
+            request_queue.task_done()
+        except Empty:
+            continue
+        except Exception as e:
+            logging.error(f"Queue worker error: {e}")
+
+
+# Start the queue worker thread
+queue_worker_thread = threading.Thread(target=queue_worker, daemon=True)
+queue_worker_thread.start()
+
+
+def get_image_size(image_path):
+    """Get image size and DPI using PIL/Pillow."""
+    try:
+        from PIL import Image
+
+        with Image.open(image_path) as img:
+            width, height = img.size
+
+            # Get DPI information
+            dpi = 96  # Default DPI
+            try:
+                if hasattr(img, "info") and "dpi" in img.info:
+                    dpi_info = img.info["dpi"]
+                    if isinstance(dpi_info, tuple):
+                        dpi = dpi_info[0]  # Use horizontal DPI
+                    else:
+                        dpi = dpi_info
+                    logging.info(f"Found image DPI: {dpi}")
+                else:
+                    logging.info(f"No DPI info found in image, using default: {dpi}")
+            except Exception as dpi_error:
+                logging.warning(f"Could not extract DPI info: {dpi_error}")
+                dpi = 96  # Fallback to default
+
+            return width, height, dpi  # Returns (width_px, height_px, dpi)
+
+    except ImportError:
+        logging.warning("PIL/Pillow not available")
+        return None, None, None
+    except Exception as e:
+        logging.warning(f"Could not get image size using PIL: {e}")
+        return None, None, None
+
+
+# Helper function for directory management
+def ensure_directory_exists(file_path: str) -> None:
+    """Ensure the directory for a file exists, creating it if necessary."""
+    directory = os.path.dirname(file_path)
+    if directory and not os.path.exists(directory):
+        try:
+            os.makedirs(directory, exist_ok=True)
+            print(f"Created directory: {directory}")
+        except Exception as e:
+            print(f"Failed to create directory {directory}: {str(e)}")
+            raise
+
+
+# Helper function to normalize file paths
+def normalize_path(file_path: str) -> str:
+    """Convert a relative path to an absolute path."""
+    if not file_path:
+        raise ValueError("Empty file path provided")
+
+    # Expand user directory if path starts with ~
+    if file_path.startswith("~"):
+        file_path = os.path.expanduser(file_path)
+
+    # Make absolute if relative
+    if not os.path.isabs(file_path):
+        file_path = os.path.abspath(file_path)
+
+    print(f"Normalized path: {file_path}")
+    return file_path
+
+
+# Function to communicate with the LibreOffice helper
+async def call_libreoffice_helper(command: dict) -> dict:
+    """
+    Send a command to the LibreOffice helper process.
+
+    Args:
+        command: Dictionary with command details
+
+    Returns:
+        Dictionary with response from helper
+    """
+    try:
+        logging.info("call_libreoffice_helper function called")
+
+        # Generate unique request ID
+        request_id = f"{time.time()}_{threading.get_ident()}"
+
+        # Add request to queue
+        request_queue.put((request_id, command))
+
+        # Wait for response with timeout
+        max_wait_time = 60
+        wait_interval = 0.1
+        waited_time = 0
+
+        while waited_time < max_wait_time:
+            with response_lock:
+                if request_id in response_dict:
+                    response = response_dict.pop(request_id)
+                    logging.info(f"Got response for request {request_id}: {response}")
+                    return response
+
+            await asyncio.sleep(wait_interval)
+            waited_time += wait_interval
+
+        # Timeout occurred
+        return {"status": "error", "message": "Request timed out in queue"}
+
+    except Exception as e:
+        return {
+            "status": "error",
+            "message": f"Error queuing request: {str(e)}",
+        }
+
+
+# Now import MCP dependencies
+try:
+    from mcp.server.fastmcp import FastMCP
+except ImportError as e:
+    print(f"Dependency Import Error: {e}")
+    print("Ensure you have installed:")
+    print("- mcp[cli]")
+    sys.exit(1)
+
+# Initialize MCP server
+mcp = FastMCP("libreoffice-server")
+
+
+def get_default_document_path(filename: str) -> str:
+    """Get the path to user's default Documents folder path on Windows plus the filename passed in"""
+    if sys.platform == "win32":
+        try:
+            import ctypes
+            from ctypes import wintypes
+
+            # Use the actual GUID structure
+            from uuid import UUID
+
+            class GUID(ctypes.Structure):
+                _fields_ = [
+                    ("Data1", ctypes.c_ulong),
+                    ("Data2", ctypes.c_ushort),
+                    ("Data3", ctypes.c_ushort),
+                    ("Data4", ctypes.c_ubyte * 8),
+                ]
+
+                def __init__(self, uuidstr):
+                    uuid = UUID(uuidstr)
+                    ctypes.Structure.__init__(self)
+                    self.Data1 = uuid.time_low
+                    self.Data2 = uuid.time_mid
+                    self.Data3 = uuid.time_hi_version
+                    self.Data4[:] = uuid.bytes[8:]
+
+            SHGetKnownFolderPath = ctypes.windll.shell32.SHGetKnownFolderPath
+            SHGetKnownFolderPath.argtypes = [
+                ctypes.POINTER(GUID),
+                wintypes.DWORD,
+                wintypes.HANDLE,
+                ctypes.POINTER(ctypes.c_wchar_p),
+            ]
+            SHGetKnownFolderPath.restype = ctypes.HRESULT
+
+            path_ptr = ctypes.c_wchar_p()
+            guid = GUID("FDD39AD0-238F-46AF-ADB4-6C85480369C7")
+            result = SHGetKnownFolderPath(
+                ctypes.byref(guid), 0, 0, ctypes.byref(path_ptr)
+            )
+            if result == 0 and path_ptr.value:
+                docs_path = path_ptr.value
+                logging.info(f"Found default document path: {docs_path}")
+                ctypes.windll.ole32.CoTaskMemFree(path_ptr)
+                return os.path.join(docs_path, filename)
+        except Exception as e:
+            logging.error(f"Could not get Windows Documents folder: {e}")
+    # Fallback for non-Windows or error
+    docs_path = os.path.join(os.path.expanduser("~"), "Documents")
+    return os.path.join(docs_path, filename)
+
+
+# Document Management Tools
+
+
+@mcp.tool()
+async def create_blank_document(
+    filename: str,
+    title: str = "",
+    author: str = "",
+    subject: str = "",
+    keywords: str = "",
+) -> str:
+    """
+    Create a new LibreOffice Writer document.
+
+    Args:
+        filename: Name of the document to create
+        title: Document title metadata
+        author: Document author metadata
+        subject: Document subject metadata
+        keywords: Document keywords metadata (comma-separated)
+    """
+    try:
+        # Check for supported file extensions
+        if not filename.lower().endswith(writer_extensions):
+            filename += ".odt"
+
+        # If filename doesn't include a path, add default path
+        if os.path.basename(filename) == filename:
+            save_path = get_default_document_path(filename)
+        else:
+            save_path = filename
+
+        # Normalize path
+        save_path = normalize_path(save_path)
+        print(f"Creating document at: {save_path}")
+
+        # Prepare metadata if provided
+        metadata = {}
+        if title:
+            metadata["Title"] = title
+        if author:
+            metadata["Author"] = author
+        if subject:
+            metadata["Subject"] = subject
+        if keywords:
+            # Split by comma and strip whitespace
+            keywords_list = [k.strip() for k in keywords.split(",")]
+            metadata["Keywords"] = keywords_list
+
+        logging.info(save_path)
+        logging.info(metadata)
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {
+                "action": "create_document",
+                "doc_type": "text",
+                "file_path": save_path,
+                "metadata": metadata,
+            }
+        )
+
+        logging.info(response["status"])
+        logging.info(response["message"])
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+
+    except Exception as e:
+        logging.error(f"Error in create_document: {str(e)}")
+        return f"Failed to create document: {str(e)}"
+
+
+@mcp.tool()
+async def read_text_document(file_path: str) -> str:
+    """
+    Open and read a text document.
+
+    Args:
+        file_path: Path to the document
+    """
+    try:
+        # Normalize path
+        file_path = normalize_path(file_path)
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {"action": "read_text_document", "file_path": file_path}
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in open_text_document: {str(e)}")
+        return f"Failed to open document: {str(e)}"
+
+
+@mcp.tool()
+async def get_document_properties(file_path: str) -> str:
+    """
+    Get document properties and statistics, including author, description, keywords, word count, etc.
+
+    Args:
+        file_path: Path to the document
+    """
+    try:
+        # Normalize path
+        file_path = normalize_path(file_path)
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {"action": "get_document_properties", "file_path": file_path}
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in get_document_properties: {str(e)}")
+        return f"Failed to get document properties: {str(e)}"
+
+
+@mcp.tool()
+async def list_documents(directory: str) -> str:
+    """
+    List all documents in a directory.
+
+    Args:
+        directory: Path to the directory to scan
+    """
+    try:
+        # Normalize path
+        directory = normalize_path(directory)
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {"action": "list_documents", "directory": directory}
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in list_documents: {str(e)}")
+        return f"Failed to list documents: {str(e)}"
+
+
+@mcp.tool()
+async def copy_document(source_path: str, target_path: str) -> str:
+    """
+    Create a copy of an existing document.
+
+    Args:
+        source_path: Path to the document to copy
+        target_path: Path where to save the copy
+    """
+    try:
+        # Normalize paths
+        source_path = normalize_path(source_path)
+        target_path = normalize_path(target_path)
+
+        if source_path is target_path:
+            raise Exception("Cannot copy a document to itself")
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {
+                "action": "copy_document",
+                "source_path": source_path,
+                "target_path": target_path,
+            }
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in copy_document: {str(e)}")
+        return f"Failed to copy document: {str(e)}"
+
+
+# Content Creation Tools
+
+
+@mcp.tool()
+async def add_text(file_path: str, text: str, position: Optional[str] = "end") -> str:
+    """
+    Add text to a LibreOffice document.
+
+    Args:
+        file_path: Path to the document
+        text: Text to add
+        position: Where to add text (start, end, or cursor)
+    """
+    try:
+        # Normalize path
+        file_path = normalize_path(file_path)
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {
+                "action": "add_text",
+                "file_path": file_path,
+                "text": text,
+                "position": position,
+            }
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in add_text: {str(e)}")
+        return f"Failed to add text: {str(e)}"
+
+
+@mcp.tool()
+async def add_heading(file_path: str, text: str, level: int = 1) -> str:
+    """
+    Add a heading to a document.
+
+    Args:
+        file_path: Path to the document
+        text: Heading text
+        level: Heading level (1-6, where 1 is the highest level)
+    """
+    try:
+        # Normalize path
+        file_path = normalize_path(file_path)
+
+        # Validate heading level
+        if level < 1 or level > 6:
+            return f"Invalid heading level: {level}. Choose a level between 1 and 6."
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {
+                "action": "add_heading",
+                "file_path": file_path,
+                "text": text,
+                "level": level,
+            }
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in add_heading: {str(e)}")
+        return f"Failed to add heading: {str(e)}"
+
+
+@mcp.tool()
+async def add_paragraph(
+    file_path: str,
+    text: str,
+    style: Optional[str] = None,
+    alignment: Optional[str] = None,
+) -> str:
+    """
+    Add a paragraph with optional styling.
+
+    Args:
+        file_path: Path to the document
+        text: Paragraph text
+        style: Paragraph style name (if available in document)
+        alignment: Text alignment (left, center, right, justify)
+    """
+    try:
+        # Normalize path
+        file_path = normalize_path(file_path)
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {
+                "action": "add_paragraph",
+                "file_path": file_path,
+                "text": text,
+                "style": style,
+                "alignment": alignment,
+            }
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in add_paragraph: {str(e)}")
+        return f"Failed to add paragraph: {str(e)}"
+
+
+@mcp.tool()
+async def add_table(
+    file_path: str,
+    rows: int,
+    columns: int,
+    data: Optional[List[List[str]]] = None,
+    header_row: bool = False,
+) -> str:
+    """
+    Add a table to a LibreOffice text document.
+
+    Args:
+        file_path: Path to the document
+        rows: Number of rows
+        columns: Number of columns
+        data: Optional 2D list of data to populate the table
+        header_row: Whether to format the first row as a header
+    """
+    try:
+        # Normalize path
+        file_path = normalize_path(file_path)
+
+        # Check dimensions of table match data
+        if data:
+            if len(data) != rows:
+                raise Exception("Data does not match dimensions provided")
+            else:
+                for row in data:
+                    if len(row) != columns:
+                        raise Exception("Data does not match dimensions provided")
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {
+                "action": "add_table",
+                "file_path": file_path,
+                "rows": rows,
+                "columns": columns,
+                "data": data,
+                "header_row": header_row,
+            }
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in add_table: {str(e)}")
+        return f"Failed to add table: {str(e)}"
+
+
+@mcp.tool()
+async def insert_image(
+    file_path: str,
+    image_path: str,
+    width: Optional[int] = None,
+    height: Optional[int] = None,
+) -> str:
+    """
+    Insert an image into a LibreOffice document with optional resizing.
+
+    Args:
+        file_path: Path to the target document
+        image_path: Path to the image file to insert
+        width: Optional width in 100ths of mm (maintains aspect ratio if only width is specified)
+        height: Optional height in 100ths of mm (maintains aspect ratio if only height is specified)
+    """
+    try:
+        # Normalize paths
+        file_path = normalize_path(file_path)
+        image_path = normalize_path(image_path)
+
+        if width and width <= 0:
+            raise Exception("Invalid dimensions")
+        if height and height <= 0:
+            raise Exception("Invalid dimensions")
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {
+                "action": "insert_image",
+                "file_path": file_path,
+                "image_path": image_path,
+                "width": width,
+                "height": height,
+            }
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in insert_image: {str(e)}")
+        return f"Failed to insert image: {str(e)}"
+
+
+@mcp.tool()
+async def insert_page_break(file_path: str) -> str:
+    """
+    Insert a page break at the end of a document.
+
+    Args:
+        file_path: Path to the document
+    """
+    try:
+        # Normalize path
+        file_path = normalize_path(file_path)
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {"action": "insert_page_break", "file_path": file_path}
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in insert_page_break: {str(e)}")
+        return f"Failed to insert page break: {str(e)}"
+
+
+# Text Formatting Tools
+
+
+@mcp.tool()
+async def format_text(
+    file_path: str,
+    text_to_find: str,
+    bold: bool = False,
+    italic: bool = False,
+    underline: bool = False,
+    color: Optional[str] = None,
+    font: Optional[str] = None,
+    size: Optional[float] = None,
+) -> str:
+    """
+    Format specific text in a document.
+
+    Args:
+        file_path: Path to the document to modify.
+        text_to_find: The exact text string to search for and format.
+        bold: If True, apply bold formatting to the found text.
+        italic: If True, apply italic formatting to the found text.
+        underline: If True, apply underline formatting to the found text.
+        color: Optional text color in hex format (e.g., "#FF0000" for red).
+        font: Optional font family name to apply (e.g., "Arial").
+        size: Optional font size in points (e.g., 12.0).
+    """
+    try:
+        # Normalize path
+        file_path = normalize_path(file_path)
+
+        # Send command to helper with all parameters using the correct names
+        response = await call_libreoffice_helper(
+            {
+                "action": "format_text",
+                "file_path": file_path,  # Note: using file_path, not filepath
+                "text_to_find": text_to_find,
+                "bold": bold,
+                "italic": italic,
+                "underline": underline,
+                "color": color,
+                "font": font,
+                "size": size,
+            }
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in format_text: {str(e)}")
+        return f"Failed to format text: {str(e)}"
+
+
+@mcp.tool()
+async def search_replace_text(
+    file_path: str, search_text: str, replace_text: str
+) -> str:
+    """
+    Search and replace text throughout the document.
+
+    Args:
+        file_path: Path to the document
+        search_text: Text to search for
+        replace_text: Text to replace with
+    """
+    try:
+        # Normalize path
+        file_path = normalize_path(file_path)
+
+        if not search_text:
+            raise Exception("No search text provided")
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {
+                "action": "search_replace_text",
+                "file_path": file_path,
+                "search_text": search_text,
+                "replace_text": replace_text,
+            }
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in search_replace_text: {str(e)}")
+        return f"Failed to search and replace text: {str(e)}"
+
+
+@mcp.tool()
+async def delete_text(file_path: str, text_to_delete: str) -> str:
+    """
+    Delete specific text from the document.
+
+    Args:
+        file_path: Path to the document
+        text_to_delete: Text to search for and delete
+    """
+    try:
+        # Normalize path
+        file_path = normalize_path(file_path)
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {
+                "action": "delete_text",
+                "file_path": file_path,
+                "text_to_delete": text_to_delete,
+            }
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in delete_text: {str(e)}")
+        return f"Failed to delete text: {str(e)}"
+
+
+# Table Formatting Tools
+
+
+@mcp.tool()
+async def format_table(
+    file_path: str,
+    table_index: int = 0,
+    border_width: Optional[int] = None,
+    background_color: Optional[str] = None,
+    header_row: bool = False,
+) -> str:
+    """
+    Format a table with borders, background color, and a header row
+
+    Args:
+        file_path: Path to the document
+        table_index: Index of the table to format (0 = first table)
+        border_width: Border width in points
+        background_color: Background color (hex format, e.g., "#F0F0F0")
+        header_row: Whether to format the first row as a header
+    """
+    try:
+        # Normalize path
+        file_path = normalize_path(file_path)
+
+        # Prepare format options
+        format_options = {}
+
+        if border_width is not None:
+            format_options["border_width"] = border_width
+
+        if background_color:
+            format_options["background_color"] = background_color
+
+        format_options["header_row"] = header_row
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {
+                "action": "format_table",
+                "file_path": file_path,
+                "table_index": table_index,
+                "format_options": format_options,
+            }
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in format_table: {str(e)}")
+        return f"Failed to format table: {str(e)}"
+
+
+# Advanced Document Manipulation Tools
+
+# DISABLED - not currently functional
+# @mcp.tool()
+# async def create_custom_style(file_path: str, style_name: str, font_name: Optional[str] = None,
+#                              font_size: Optional[float] = None, bold: bool = False, italic: bool = False,
+#                              underline: bool = False, color: Optional[str] = None,
+#                              alignment: Optional[str] = None) -> str:
+#     """
+#     Create a custom paragraph style.
+
+#     Args:
+#         file_path: Path to the document
+#         style_name: Name for the style
+#         font_name: Font name
+#         font_size: Font size in points
+#         bold: Apply bold formatting
+#         italic: Apply italic formatting
+#         underline: Apply underline formatting
+#         color: Text color (hex format, e.g., "#000000")
+#         alignment: Paragraph alignment (left, center, right, justify)
+#     """
+#     try:
+#         # Normalize path
+#         file_path = normalize_path(file_path)
+
+#         # Prepare style properties
+#         style_properties = {}
+
+#         if font_name:
+#             style_properties["font_name"] = font_name
+
+#         if font_size is not None:
+#             style_properties["font_size"] = font_size
+
+#         if bold:
+#             style_properties["bold"] = True
+
+#         if italic:
+#             style_properties["italic"] = True
+
+#         if underline:
+#             style_properties["underline"] = True
+
+#         if color:
+#             style_properties["color"] = color
+
+#         if alignment:
+#             style_properties["alignment"] = alignment
+
+#         # Send command to helper
+#         response = await call_libreoffice_helper({
+#             "action": "create_custom_style",
+#             "file_path": file_path,
+#             "style_name": style_name,
+#             "style_properties": style_properties
+#         })
+
+#         if response["status"] == "success":
+#             return response["message"]
+#         else:
+#             return f"Error: {response['message']}"
+#     except Exception as e:
+#         print(f"Error in create_custom_style: {str(e)}")
+#         return f"Failed to create custom style: {str(e)}"
+
+
+@mcp.tool()
+async def delete_paragraph(file_path: str, paragraph_index: int) -> str:
+    """
+    Delete a paragraph at the given index.
+    If the user has not specified an index, you may need to call the read_text_document function first to find the correct index.
+
+    Args:
+        file_path: Path to the document
+        paragraph_index: Index of the paragraph to delete (0 = first paragraph)
+    """
+    try:
+        # Normalize path
+        file_path = normalize_path(file_path)
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {
+                "action": "delete_paragraph",
+                "file_path": file_path,
+                "paragraph_index": paragraph_index,
+            }
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in delete_paragraph: {str(e)}")
+        return f"Failed to delete paragraph: {str(e)}"
+
+
+@mcp.tool()
+async def apply_document_style(
+    file_path: str,
+    font_name: Optional[str] = None,
+    font_size: Optional[float] = None,
+    color: Optional[str] = None,
+    alignment: Optional[str] = None,
+) -> str:
+    """
+    Apply consistent formatting throughout the document.
+
+    Args:
+        file_path: Path to the document
+        font_name: Font name
+        font_size: Font size in points
+        color: Text color (hex format, e.g., "#000000")
+        alignment: Alignment (left, center, right, justify)
+    """
+    try:
+        # Normalize path
+        file_path = normalize_path(file_path)
+
+        # Prepare style
+        style = {}
+
+        if font_name:
+            style["font_name"] = font_name
+
+        if font_size:
+            style["font_size"] = font_size
+
+        if color:
+            style["color"] = color
+
+        if alignment:
+            style["alignment"] = alignment
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {"action": "apply_document_style", "file_path": file_path, "style": style}
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in apply_document_style: {str(e)}")
+        return f"Failed to apply document style: {str(e)}"
+
+
+# Impress Presentation functions
+@mcp.tool()
+async def create_blank_presentation(
+    filename: str,
+    title: str = "",
+    author: str = "",
+    subject: str = "",
+    keywords: str = "",
+) -> str:
+    """
+    Create a new LibreOffice Impress presentation.
+
+    Args:
+        filename: Name of the presentation
+        title: Presentation title metadata
+        author: Presentation author metadata
+        subject: Presentation subject metadata
+        keywords: Presentation keywords metadata (comma-separated)
+    """
+    try:
+        # Check for supported file extensions
+        if not filename.lower().endswith(impress_extensions):
+            filename += ".odp"
+
+        # If filename doesn't include a path, add default path
+        if os.path.basename(filename) == filename:
+            save_path = get_default_document_path(filename)
+        else:
+            save_path = filename
+
+        # Normalize path
+        save_path = normalize_path(save_path)
+        print(f"Creating document at: {save_path}")
+
+        # Prepare metadata if provided
+        metadata = {}
+        if title:
+            metadata["Title"] = title
+        if author:
+            metadata["Author"] = author
+        if subject:
+            metadata["Subject"] = subject
+        if keywords:
+            # Split by comma and strip whitespace
+            keywords_list = [k.strip() for k in keywords.split(",")]
+            metadata["Keywords"] = keywords_list
+
+        logging.info(save_path)
+        logging.info(metadata)
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {
+                "action": "create_document",
+                "doc_type": "impress",
+                "file_path": save_path,
+                "metadata": metadata,
+            }
+        )
+
+        logging.info(response["status"])
+        logging.info(response["message"])
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+
+    except Exception as e:
+        logging.error(f"Error in create_document: {str(e)}")
+        return f"Failed to create document: {str(e)}"
+
+
+@mcp.tool()
+async def read_presentation(file_path: str) -> str:
+    """
+    Open and read the text of an Impress presentation.
+
+    Args:
+        file_path: Path to the presentation
+    """
+    try:
+        # Normalize path
+        file_path = normalize_path(file_path)
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {"action": "read_presentation", "file_path": file_path}
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in open_presentation: {str(e)}")
+        return f"Failed to open presentation: {str(e)}"
+
+
+@mcp.tool()
+async def add_slide(
+    file_path: str,
+    slide_index: Optional[int] = None,
+    title: Optional[str] = None,
+    content: Optional[str] = None,
+) -> str:
+    """
+    Add a new slide to an Impress presentation using the built-in layout.
+
+    Args:
+        file_path: Path to the presentation file.
+        slide_index: Index at which to insert the new slide (0-based). If None, the slide is appended at the end.
+        title: Optional title text for the new slide.
+        content: Optional content text for the new slide.
+    """
+    try:
+        if not file_path.endswith(impress_extensions):
+            return "Error: file_path is not a presentation."
+
+        file_path = normalize_path(file_path)
+
+        response = await call_libreoffice_helper(
+            {
+                "action": "add_slide",
+                "file_path": file_path,
+                "slide_index": slide_index,
+                "title": title,
+                "content": content,
+            }
+        )
+
+        print(f"add_slide: response={response}")
+
+        if not response:
+            return "Error: No response from helper."
+        if response.get("status") == "success":
+            return response.get("message", "")
+        else:
+            return f"Error: {response.get('message', 'Unknown error')}"
+    except Exception as e:
+        print(f"Error in add_slide: {str(e)}")
+        return f"Failed to add slide: {str(e)}"
+
+
+@mcp.tool()
+async def edit_slide_content(file_path: str, slide_index: int, new_content: str) -> str:
+    """
+    Edit the main text content of a specific slide in an Impress presentation.
+
+    Args:
+        file_path: Path to the presentation file
+        slide_index: Index of the slide to edit (0-based, where 0 is the first slide)
+        new_content: New text content to set in the main content area
+    """
+    try:
+        # Validate file extension
+        if not file_path.lower().endswith(impress_extensions):
+            return "Error: file_path is not a presentation file."
+
+        # Normalize path
+        file_path = normalize_path(file_path)
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {
+                "action": "edit_slide_content",
+                "file_path": file_path,
+                "slide_index": slide_index,
+                "new_content": new_content,
+            }
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in edit_slide_content: {str(e)}")
+        return f"Failed to edit slide content: {str(e)}"
+
+
+@mcp.tool()
+async def edit_slide_title(file_path: str, slide_index: int, new_title: str) -> str:
+    """
+    Edit the title of a specific slide in an Impress presentation.
+
+    Args:
+        file_path: Path to the presentation file
+        slide_index: Index of the slide to edit (0-based, where 0 is the first slide)
+        new_title: New title text to set in the title area
+    """
+    try:
+        # Validate file extension
+        if not file_path.lower().endswith(impress_extensions):
+            return "Error: file_path is not a presentation file."
+
+        # Normalize path
+        file_path = normalize_path(file_path)
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {
+                "action": "edit_slide_title",
+                "file_path": file_path,
+                "slide_index": slide_index,
+                "new_title": new_title,
+            }
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in edit_slide_title: {str(e)}")
+        return f"Failed to edit slide title: {str(e)}"
+
+
+@mcp.tool()
+async def delete_slide(file_path: str, slide_index: int) -> str:
+    """
+    Delete a slide from an Impress presentation.
+
+    Args:
+        file_path: Path to the presentation file
+        slide_index: Index of the slide to delete (0-based, where 0 is the first slide)
+    """
+    try:
+        # Validate file extension
+        if not file_path.lower().endswith(impress_extensions):
+            return "Error: file_path is not a presentation file."
+
+        # Normalize path
+        file_path = normalize_path(file_path)
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {
+                "action": "delete_slide",
+                "file_path": file_path,
+                "slide_index": slide_index,
+            }
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in delete_slide: {str(e)}")
+        return f"Failed to delete slide: {str(e)}"
+
+
+@mcp.tool()
+async def apply_presentation_template(file_path: str, template_name: str) -> str:
+    """
+    Apply a built-in LibreOffice presentation template/master slide to a presentation.
+
+    Args:
+        file_path: Path to the presentation file
+        template_name: Name of the built-in template to apply (can be exact name, partial match, or numeric index)
+    """
+    try:
+        # Validate file extension
+        if not file_path.lower().endswith(impress_extensions):
+            return "Error: file_path is not a presentation file."
+
+        # Normalize path
+        file_path = normalize_path(file_path)
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {
+                "action": "apply_presentation_template",
+                "file_path": file_path,
+                "template_name": template_name,
+            }
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in apply_presentation_template: {str(e)}")
+        return f"Failed to apply presentation template: {str(e)}"
+
+
+@mcp.tool()
+async def format_slide_content(
+    file_path: str,
+    slide_index: int,
+    font_name: Optional[str] = None,
+    font_size: Optional[float] = None,
+    bold: Optional[bool] = None,
+    italic: Optional[bool] = None,
+    underline: Optional[bool] = None,
+    color: Optional[str] = None,
+    alignment: Optional[str] = None,
+    line_spacing: Optional[float] = None,
+    background_color: Optional[str] = None,
+) -> str:
+    """
+    Format the content text of a specific slide in an Impress presentation.
+
+    Args:
+        file_path: Path to the presentation file
+        slide_index: Index of the slide to format (0-based, where 0 is the first slide)
+        font_name: Font family name (e.g., "Arial", "Times New Roman")
+        font_size: Font size in points (e.g., 18, 24)
+        bold: Apply bold formatting (True/False)
+        italic: Apply italic formatting (True/False)
+        underline: Apply underline formatting (True/False)
+        color: Text color as hex string (e.g., "#FF0000") or RGB integer
+        alignment: Text alignment ("left", "center", "right", "justify")
+        line_spacing: Line spacing multiplier (e.g., 1.5, 2.0)
+        background_color: Background color as hex string (e.g., "#F0F0F0") or RGB integer
+    """
+    try:
+        # Validate file extension
+        if not file_path.lower().endswith(impress_extensions):
+            return "Error: file_path is not a presentation file."
+
+        # Normalize path
+        file_path = normalize_path(file_path)
+
+        # Prepare format options
+        format_options = {}
+
+        if font_name is not None:
+            format_options["font_name"] = font_name
+        if font_size is not None:
+            format_options["font_size"] = font_size
+        if bold is not None:
+            format_options["bold"] = bold
+        if italic is not None:
+            format_options["italic"] = italic
+        if underline is not None:
+            format_options["underline"] = underline
+        if color is not None:
+            format_options["color"] = color
+        if alignment is not None:
+            format_options["alignment"] = alignment
+        if line_spacing is not None:
+            format_options["line_spacing"] = line_spacing
+        if background_color is not None:
+            format_options["background_color"] = background_color
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {
+                "action": "format_slide_content",
+                "file_path": file_path,
+                "slide_index": slide_index,
+                "format_options": format_options,
+            }
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in format_slide_content: {str(e)}")
+        return f"Failed to format slide content: {str(e)}"
+
+
+@mcp.tool()
+async def format_slide_title(
+    file_path: str,
+    slide_index: int,
+    font_name: Optional[str] = None,
+    font_size: Optional[float] = None,
+    bold: Optional[bool] = None,
+    italic: Optional[bool] = None,
+    underline: Optional[bool] = None,
+    color: Optional[str] = None,
+    alignment: Optional[str] = None,
+    line_spacing: Optional[float] = None,
+    background_color: Optional[str] = None,
+) -> str:
+    """
+    Format the title text of a specific slide in an Impress presentation.
+
+    Args:
+        file_path: Path to the presentation file
+        slide_index: Index of the slide to format (0-based, where 0 is the first slide)
+        font_name: Font family name (e.g., "Arial", "Times New Roman")
+        font_size: Font size in points (e.g., 28, 36)
+        bold: Apply bold formatting (True/False)
+        italic: Apply italic formatting (True/False)
+        underline: Apply underline formatting (True/False)
+        color: Text color as hex string (e.g., "#FF0000") or RGB integer
+        alignment: Text alignment ("left", "center", "right", "justify")
+        line_spacing: Line spacing multiplier (e.g., 1.5, 2.0)
+        background_color: Background color as hex string (e.g., "#F0F0F0") or RGB integer
+    """
+    try:
+        # Validate file extension
+        if not file_path.lower().endswith(impress_extensions):
+            return "Error: file_path is not a presentation file."
+
+        # Normalize path
+        file_path = normalize_path(file_path)
+
+        # Prepare format options
+        format_options = {}
+
+        if font_name is not None:
+            format_options["font_name"] = font_name
+        if font_size is not None:
+            format_options["font_size"] = font_size
+        if bold is not None:
+            format_options["bold"] = bold
+        if italic is not None:
+            format_options["italic"] = italic
+        if underline is not None:
+            format_options["underline"] = underline
+        if color is not None:
+            format_options["color"] = color
+        if alignment is not None:
+            format_options["alignment"] = alignment
+        if line_spacing is not None:
+            format_options["line_spacing"] = line_spacing
+        if background_color is not None:
+            format_options["background_color"] = background_color
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {
+                "action": "format_slide_title",
+                "file_path": file_path,
+                "slide_index": slide_index,
+                "format_options": format_options,
+            }
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in format_slide_title: {str(e)}")
+        return f"Failed to format slide title: {str(e)}"
+
+
+@mcp.tool()
+async def insert_slide_image(
+    file_path: str,
+    slide_index: int,
+    image_path: str,
+    max_width: Optional[int] = None,
+    max_height: Optional[int] = None,
+) -> str:
+    """
+    Insert an image into a specific slide of an Impress presentation.
+    The image will be centered on the slide and resized if necessary to fit.
+
+    Args:
+        file_path: Path to the presentation file
+        slide_index: Index of the slide to insert the image into (0-based, where 0 is the first slide)
+        image_path: Path to the image file to insert
+        max_width: Maximum width in 1/100mm units (defaults to slide width minus margins)
+        max_height: Maximum height in 1/100mm units (defaults to slide height minus margins)
+    """
+    try:
+        # Validate file extension
+        if not file_path.lower().endswith(impress_extensions):
+            return "Error: file_path is not a presentation file."
+
+        # Get image dimensions and DPI
+        img_width_px, img_height_px, dpi = get_image_size(image_path)
+
+        # Normalize paths
+        file_path = normalize_path(file_path)
+        image_path = normalize_path(image_path)
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {
+                "action": "insert_slide_image",
+                "file_path": file_path,
+                "slide_index": slide_index,
+                "image_path": image_path,
+                "max_width": max_width,
+                "max_height": max_height,
+                "img_width_px": img_width_px,
+                "img_height_px": img_height_px,
+                "dpi": dpi,
+            }
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Error: {response['message']}"
+    except Exception as e:
+        print(f"Error in insert_slide_image: {str(e)}")
+        return f"Failed to insert slide image: {str(e)}"
+
+
+# Resource for document access
+@mcp.resource("libreoffice:{path}")
+async def document_resource(path: str) -> str:
+    """
+    Resource for accessing LibreOffice document content.
+
+    Args:
+        path: Path to the document
+
+    Returns:
+        Document content as text
+    """
+    try:
+        normalized_path = normalize_path(path)
+
+        # Send command to helper
+        response = await call_libreoffice_helper(
+            {"action": "open_text_document", "file_path": normalized_path}
+        )
+
+        if response["status"] == "success":
+            return response["message"]
+        else:
+            return f"Failed to access document resource: {response['message']}"
+    except Exception as e:
+        print(f"Error in document_resource: {str(e)}")
+        return f"Failed to access document resource: {str(e)}"
+
+
+async def main():
+    """
+    Main entry point for the LibreOffice MCP server.
+    """
+    print("Starting LibreOffice MCP server with stdio transport")
+
+    # Check if helper is running
+    try:
+        response = await call_libreoffice_helper({"action": "ping"})
+        if (
+            response["status"] == "error"
+            and "Connection refused" in response["message"]
+        ):
+            print("⚠️ WARNING: LibreOffice helper is not running!")
+            print("Please start the helper first with:")
+            print('"C:\\Program Files\\LibreOffice\\program\\python.exe" helper.py')
+            print("Continuing anyway, but LibreOffice operations will fail...")
+    except Exception:
+        print("Failed to check helper status")
+
+    # Run the server using stdio transport
+    await mcp.run_stdio_async()
+    logging.info("MCP server exited")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/apps/codehelper/src-tauri/resources/libreoffice/mcp_server/main.py
+++ b/apps/codehelper/src-tauri/resources/libreoffice/mcp_server/main.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+import os
+import sys
+import subprocess
+import socket
+import time
+import platform
+import signal
+import atexit
+
+# Global variables to track child processes
+office_process = None
+helper_process = None
+
+
+def cleanup_processes():
+    """Clean up all child processes when the main process exits"""
+    global office_process, helper_process
+
+    print("Cleaning up processes...", file=sys.stderr)
+
+    if helper_process and helper_process.poll() is None:
+        print("Terminating helper process...", file=sys.stderr)
+        helper_process.terminate()
+        try:
+            helper_process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            helper_process.kill()
+
+    if office_process and office_process.poll() is None:
+        print("Terminating office process...", file=sys.stderr)
+        office_process.terminate()
+        try:
+            office_process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            office_process.kill()
+
+
+def signal_handler(signum, frame):
+    """Handle Ctrl+C and other signals"""
+    print("\nReceived interrupt signal. Shutting down...", file=sys.stderr)
+    cleanup_processes()
+    sys.exit(0)
+
+
+def get_office_path():
+    """Get the Collabora Office or LibreOffice executable path based on the operating system"""
+    system = platform.system().lower()
+    if system == "windows":
+        # Windows paths
+        possible_paths = [
+            r"C:\Program Files\Collabora Office\program\soffice.exe",
+            r"C:\Program Files (x86)\Collabora Office\program\soffice.exe",
+            r"C:\Program Files\LibreOffice\program\soffice.exe",  # Fallback to LibreOffice
+        ]
+    elif system == "linux":
+        # Linux paths - Collabora Office is typically installed in these locations
+        possible_paths = [
+            "/usr/bin/coolwsd",  # Collabora Online WebSocket Daemon
+            "/usr/bin/collaboraoffice",  # Collabora Office main executable
+            "/opt/collaboraoffice/program/soffice",
+            "/usr/lib/collaboraoffice/program/soffice",
+            # # Fallback to standard LibreOffice paths
+            # '/usr/bin/soffice',
+            # '/usr/lib/libreoffice/program/soffice',
+            # '/opt/libreoffice/program/soffice'
+        ]
+    else:
+        raise OSError(f"Unsupported operating system: {system}")
+
+    for path in possible_paths:
+        if os.path.exists(path):
+            return path
+    raise FileNotFoundError(
+        "Neither Collabora Office nor LibreOffice executable found. Please install either office suite."
+    )
+
+
+def get_python_path():
+    """Get the Python executable path based on the operating system"""
+    system = platform.system().lower()
+    if system == "windows":
+        possible_paths = [
+            r"C:\Program Files\Collabora Office\program\python.exe",
+            r"C:\Program Files (x86)\Collabora Office\program\python.exe",
+            r"C:\Program Files\LibreOffice\program\python.exe",
+        ]
+        for path in possible_paths:
+            if os.path.exists(path):
+                return path
+        return sys.executable  # Fallback to system Python
+    else:
+        return sys.executable  # Use the current Python interpreter on Linux
+
+
+def is_port_in_use(port):
+    """Check if a port is already in use"""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        return s.connect_ex(("localhost", port)) == 0
+
+
+def start_office(port=2002):
+    """Start Collabora Office in headless mode with socket"""
+    global office_process
+
+    if not is_port_in_use(port):
+        print("Starting Collabora Office with socket...", file=sys.stderr)
+        soffice_path = get_office_path()
+        office_process = subprocess.Popen(
+            [
+                soffice_path,
+                "-env:UserInstallation=file:///C:/Temp/LibreOfficeHeadlessProfile",
+                "--headless",
+                f"--accept=socket,host=localhost,port={port};urp;",
+                "--norestore",
+                "--nodefault",
+                "--nologo",
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        time.sleep(3)  # Give it time to start
+    else:
+        print(f"Office socket already running on port {port}", file=sys.stderr)
+
+
+def start_helper():
+    """Start the Office helper script"""
+    global helper_process
+
+    if not is_port_in_use(8765):
+        print("Starting Office helper...", file=sys.stderr)
+        exe_dir = os.path.dirname(sys.argv[0])
+        helper_script = os.path.join(exe_dir, "helper.py")
+        python_path = get_python_path()
+        helper_process = subprocess.Popen(
+            [python_path, helper_script],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        time.sleep(3)
+    else:
+        print("Helper script already running on port 8765", file=sys.stderr)
+
+
+def start_mcp_server():
+    """Start the MCP server, passing stdin/stdout through for JSON-RPC communication"""
+    print("Starting Office MCP server...", file=sys.stderr)
+    server_script = os.path.join(os.path.dirname(__file__), "libre.py")
+
+    # Pass stdin/stdout through so the parent process can communicate
+    # via JSON-RPC over stdio with the MCP server (libre.py)
+    subprocess.run(
+        [
+            sys.executable,  # Use the same Python interpreter
+            server_script,
+        ],
+        stdin=sys.stdin,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+    )
+
+
+def main():
+    # Register cleanup function to run when the program exits
+    atexit.register(cleanup_processes)
+
+    # Register signal handlers for graceful shutdown
+    signal.signal(signal.SIGINT, signal_handler)  # Ctrl+C
+    if platform.system() != "Windows":
+        signal.signal(signal.SIGTERM, signal_handler)  # Termination signal
+
+    try:
+        start_office()
+        start_helper()
+        start_mcp_server()
+    except KeyboardInterrupt:
+        print("\nReceived keyboard interrupt. Shutting down...", file=sys.stderr)
+        cleanup_processes()
+        sys.exit(0)
+    except Exception as e:
+        print(f"An error occurred: {e}", file=sys.stderr)
+        cleanup_processes()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/codehelper/src-tauri/src/commands/assistant.rs
+++ b/apps/codehelper/src-tauri/src/commands/assistant.rs
@@ -5,6 +5,7 @@ use crate::commands::inference::{
 };
 use crate::modes::blender::execute_blender_request;
 use crate::modes::gimp::{execute_gimp_request, EngineTextGenerator};
+use crate::modes::libreoffice::{execute_libreoffice_request, EngineTextPlanner};
 use crate::modes::registry::ModeProviderRegistry;
 use crate::modes::text_generation::EngineTextStreamer;
 use smolpc_assistant_types::{
@@ -48,6 +49,19 @@ pub async fn assistant_send(
             })
             .await
         }
+        AppMode::Writer | AppMode::Impress => {
+            let provider = registry.provider_for_mode(request.mode);
+            let engine_client = resolve_generation_client(&app_handle, &inference_state).await?;
+            let planner = EngineTextPlanner::new(engine_client.clone());
+            let generator = EngineTextStreamer::new(engine_client);
+
+            execute_libreoffice_request(provider, &planner, &generator, &request, &state, |event| {
+                if let Err(error) = on_event.send(event) {
+                    log::warn!("Failed to emit LibreOffice assistant event: {error}");
+                }
+            })
+            .await
+        }
         _ => Err(UNIFIED_ASSISTANT_NOT_IMPLEMENTED.to_string()),
     };
 
@@ -58,6 +72,8 @@ pub async fn assistant_send(
             "UNIFIED_ASSISTANT_NOT_IMPLEMENTED"
         } else if request.mode == AppMode::Blender {
             "BLENDER_ASSISTANT_FAILED"
+        } else if matches!(request.mode, AppMode::Writer | AppMode::Impress) {
+            "LIBREOFFICE_ASSISTANT_FAILED"
         } else {
             "GIMP_ASSISTANT_FAILED"
         };

--- a/apps/codehelper/src-tauri/src/modes/config.rs
+++ b/apps/codehelper/src-tauri/src/modes/config.rs
@@ -78,11 +78,11 @@ pub fn mode_config(mode: AppMode) -> ModeConfigDto {
                 icon: "file-text".to_string(),
                 provider_kind: ProviderKind::Mcp,
                 system_prompt_key: "mode.writer.default".to_string(),
-                suggestions: vec![
-                    "Draft an introduction for this report".to_string(),
-                    "Rewrite this paragraph for clarity".to_string(),
-                    "Summarize these meeting notes".to_string(),
-                ],
+                suggestions: profile
+                    .suggestions
+                    .iter()
+                    .map(|value| (*value).to_string())
+                    .collect(),
                 capabilities: shared_tool_mode_capabilities(false),
             }
         }
@@ -95,11 +95,11 @@ pub fn mode_config(mode: AppMode) -> ModeConfigDto {
                 icon: "table".to_string(),
                 provider_kind: ProviderKind::Mcp,
                 system_prompt_key: "mode.calc.default".to_string(),
-                suggestions: vec![
-                    "Explain what this formula should do".to_string(),
-                    "Outline a grade tracker sheet".to_string(),
-                    "Suggest a clean table layout".to_string(),
-                ],
+                suggestions: profile
+                    .suggestions
+                    .iter()
+                    .map(|value| (*value).to_string())
+                    .collect(),
                 capabilities: shared_tool_mode_capabilities(false),
             }
         }
@@ -112,11 +112,11 @@ pub fn mode_config(mode: AppMode) -> ModeConfigDto {
                 icon: "presentation".to_string(),
                 provider_kind: ProviderKind::Mcp,
                 system_prompt_key: "mode.impress.default".to_string(),
-                suggestions: vec![
-                    "Turn these notes into slide bullets".to_string(),
-                    "Suggest a three-slide deck outline".to_string(),
-                    "Improve this presentation structure".to_string(),
-                ],
+                suggestions: profile
+                    .suggestions
+                    .iter()
+                    .map(|value| (*value).to_string())
+                    .collect(),
                 capabilities: shared_tool_mode_capabilities(false),
             }
         }

--- a/apps/codehelper/src-tauri/src/modes/libreoffice/executor.rs
+++ b/apps/codehelper/src-tauri/src/modes/libreoffice/executor.rs
@@ -1,0 +1,716 @@
+use super::profiles::{allowed_tool_names, libreoffice_profile};
+use super::response::{build_libreoffice_response, build_local_fallback_summary};
+use crate::assistant::state::AssistantState;
+use crate::modes::provider::ToolProvider;
+use crate::modes::text_generation::TextStreamer;
+use async_trait::async_trait;
+use serde_json::{json, Value};
+use smolpc_assistant_types::{
+    AppMode, AssistantResponseDto, AssistantSendRequestDto, AssistantStreamEventDto,
+    ToolDefinitionDto, ToolExecutionResultDto,
+};
+use smolpc_engine_client::{EngineChatMessage, EngineClient};
+use smolpc_engine_core::GenerationConfig;
+use std::sync::Arc;
+use tokio::time::{timeout, Duration};
+
+const ASSISTANT_CANCELLED: &str = "ASSISTANT_CANCELLED";
+const SUMMARY_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Clone, Debug, PartialEq)]
+struct ToolCall {
+    name: String,
+    arguments: Value,
+}
+
+#[async_trait]
+pub trait TextPlanner: Send + Sync {
+    async fn generate(&self, messages: &[EngineChatMessage]) -> Result<String, String>;
+}
+
+pub struct EngineTextPlanner {
+    client: EngineClient,
+}
+
+impl EngineTextPlanner {
+    pub fn new(client: EngineClient) -> Self {
+        Self { client }
+    }
+
+    fn config() -> GenerationConfig {
+        GenerationConfig {
+            max_length: 384,
+            temperature: 0.0,
+            top_k: Some(20),
+            top_p: Some(0.9),
+            repetition_penalty: 1.05,
+            repetition_penalty_last_n: 128,
+        }
+    }
+}
+
+#[async_trait]
+impl TextPlanner for EngineTextPlanner {
+    async fn generate(&self, messages: &[EngineChatMessage]) -> Result<String, String> {
+        self.client
+            .generate_text_messages(messages, Some(Self::config()))
+            .await
+            .map(|result| result.text)
+            .map_err(|error| format!("LibreOffice planner generation failed: {error}"))
+    }
+}
+
+fn ensure_not_cancelled(state: &AssistantState) -> Result<(), String> {
+    if state.is_cancelled() {
+        Err(ASSISTANT_CANCELLED.to_string())
+    } else {
+        Ok(())
+    }
+}
+
+fn build_planner_messages(
+    mode: AppMode,
+    request: &AssistantSendRequestDto,
+    tools: &[ToolDefinitionDto],
+) -> Vec<EngineChatMessage> {
+    let profile = libreoffice_profile(mode).expect("writer or slides profile");
+    let tool_catalog = tools
+        .iter()
+        .map(|tool| {
+            format!(
+                "- {}: {}\n  inputSchema: {}",
+                tool.name, tool.description, tool.input_schema
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let system_prompt = format!(
+        "You are the unified LibreOffice {} assistant.\n\
+Choose at most one tool call for the user's latest request.\n\
+Return JSON only when a tool call is required, using exactly this shape:\n\
+{{\"tool_call\":{{\"name\":\"<tool_name>\",\"arguments\":{{...}}}}}}\n\
+Do not use markdown fences.\n\
+If no tool call is needed, return the final user-facing answer as plain text.\n\
+Only use tools from this allowlist:\n{}\n\
+Tool catalog:\n{}",
+        profile.label,
+        profile.allowed_tools.join(", "),
+        tool_catalog
+    );
+
+    let mut messages = vec![EngineChatMessage {
+        role: "system".to_string(),
+        content: system_prompt,
+    }];
+
+    if request.messages.is_empty() {
+        messages.push(EngineChatMessage {
+            role: "user".to_string(),
+            content: request.user_text.clone(),
+        });
+        return messages;
+    }
+
+    messages.extend(request.messages.iter().map(|message| EngineChatMessage {
+        role: message.role.clone(),
+        content: message.content.clone(),
+    }));
+    messages
+}
+
+fn build_summary_messages(
+    mode: AppMode,
+    user_text: &str,
+    tool_result: &ToolExecutionResultDto,
+) -> Vec<EngineChatMessage> {
+    let profile = libreoffice_profile(mode).expect("writer or slides profile");
+
+    vec![
+        EngineChatMessage {
+            role: "system".to_string(),
+            content: format!(
+                "You are the unified LibreOffice {} assistant. A document tool has already run successfully. Summarize the result for the user in 2 or 3 short sentences. Plain text only. Do not suggest replaying the action. Do not mention undo.",
+                profile.label
+            ),
+        },
+        EngineChatMessage {
+            role: "user".to_string(),
+            content: format!(
+                "Original request:\n{}\n\nExecuted tool: {}\n\nTool result JSON:\n{}",
+                user_text, tool_result.name, tool_result.payload
+            ),
+        },
+    ]
+}
+
+fn parse_tool_arguments(value: Option<&Value>) -> Value {
+    match value {
+        Some(Value::Object(map)) => Value::Object(map.clone()),
+        Some(Value::String(raw)) if !raw.trim().is_empty() => serde_json::from_str(raw)
+            .ok()
+            .filter(Value::is_object)
+            .unwrap_or_else(|| json!({})),
+        _ => json!({}),
+    }
+}
+
+fn parse_single_tool_call(value: &Value) -> Option<ToolCall> {
+    let object = value.as_object()?;
+    let function_field = object.get("function").and_then(Value::as_object);
+    let raw_name = object.get("name").and_then(Value::as_str).or_else(|| {
+        function_field
+            .and_then(|field| field.get("name"))
+            .and_then(Value::as_str)
+    })?;
+    let raw_arguments = object
+        .get("arguments")
+        .or_else(|| object.get("args"))
+        .or_else(|| function_field.and_then(|field| field.get("arguments")))
+        .or_else(|| function_field.and_then(|field| field.get("args")));
+
+    let name = raw_name.trim();
+    if name.is_empty() {
+        return None;
+    }
+
+    Some(ToolCall {
+        name: name.to_string(),
+        arguments: parse_tool_arguments(raw_arguments),
+    })
+}
+
+fn normalize_tool_calls(value: &Value) -> Vec<ToolCall> {
+    if let Some(array) = value.as_array() {
+        return array.iter().filter_map(parse_single_tool_call).collect();
+    }
+
+    let Some(object) = value.as_object() else {
+        return Vec::new();
+    };
+
+    if let Some(tool_calls) = object.get("tool_calls") {
+        return normalize_tool_calls(tool_calls);
+    }
+    if let Some(tool_call) = object.get("tool_call") {
+        return normalize_tool_calls(tool_call);
+    }
+
+    parse_single_tool_call(value).into_iter().collect()
+}
+
+fn extract_json_candidates(raw_text: &str) -> Vec<String> {
+    let trimmed = raw_text.trim();
+    let mut candidates = if trimmed.is_empty() {
+        Vec::new()
+    } else {
+        vec![trimmed.to_string()]
+    };
+
+    let mut remaining = raw_text;
+    while let Some(start) = remaining.find("```") {
+        remaining = &remaining[start + 3..];
+        if remaining.starts_with("json") {
+            remaining = &remaining[4..];
+        }
+        if let Some(end) = remaining.find("```") {
+            let candidate = remaining[..end].trim();
+            if !candidate.is_empty() {
+                candidates.push(candidate.to_string());
+            }
+            remaining = &remaining[end + 3..];
+        } else {
+            break;
+        }
+    }
+
+    candidates
+}
+
+fn extract_tool_call(raw_text: &str) -> Option<ToolCall> {
+    for candidate in extract_json_candidates(raw_text) {
+        if let Ok(parsed) = serde_json::from_str::<Value>(&candidate) {
+            if let Some(tool_call) = normalize_tool_calls(&parsed).into_iter().next() {
+                return Some(tool_call);
+            }
+        }
+    }
+
+    None
+}
+
+async fn stream_summary_with_fallback<F>(
+    mode: AppMode,
+    generator: &dyn TextStreamer,
+    state: &AssistantState,
+    user_text: &str,
+    tool_result: ToolExecutionResultDto,
+    mut emit: F,
+) -> AssistantResponseDto
+where
+    F: FnMut(AssistantStreamEventDto) + Send,
+{
+    let messages = build_summary_messages(mode, user_text, &tool_result);
+    emit(AssistantStreamEventDto::Status {
+        phase: "generating_summary".to_string(),
+        detail: format!(
+            "Summarizing the {} tool result for the user.",
+            tool_result.name
+        ),
+    });
+
+    let mut accumulated_text = String::new();
+    let mut used_local_fallback = false;
+    let reply = match timeout(
+        SUMMARY_TIMEOUT,
+        generator.generate_stream(&messages, state, &mut |token| {
+            accumulated_text.push_str(&token);
+            emit(AssistantStreamEventDto::Token { token });
+        }),
+    )
+    .await
+    {
+        Ok(Ok(reply)) if !reply.trim().is_empty() => reply,
+        Ok(Ok(_)) => {
+            used_local_fallback = true;
+            build_local_fallback_summary(&tool_result)
+        }
+        Ok(Err(_)) | Err(_) => {
+            used_local_fallback = true;
+            build_local_fallback_summary(&tool_result)
+        }
+    };
+
+    let tool_name = tool_result.name.clone();
+    let response = build_libreoffice_response(
+        mode,
+        if accumulated_text.trim().is_empty() {
+            reply
+        } else {
+            accumulated_text
+        },
+        Some(tool_name.as_str()),
+        used_local_fallback,
+        vec![tool_result],
+    );
+    emit(AssistantStreamEventDto::Complete {
+        response: response.clone(),
+    });
+    response
+}
+
+pub async fn execute_libreoffice_request<F>(
+    provider: Arc<dyn ToolProvider>,
+    planner: &dyn TextPlanner,
+    streamer: &dyn TextStreamer,
+    request: &AssistantSendRequestDto,
+    state: &AssistantState,
+    mut emit: F,
+) -> Result<AssistantResponseDto, String>
+where
+    F: FnMut(AssistantStreamEventDto) + Send,
+{
+    let mode = request.mode;
+    let profile = libreoffice_profile(mode)
+        .ok_or_else(|| format!("LibreOffice provider does not handle mode {mode:?}"))?;
+    if !profile.live_in_phase_6b {
+        return Err("UNIFIED_ASSISTANT_NOT_IMPLEMENTED".to_string());
+    }
+
+    emit(AssistantStreamEventDto::Status {
+        phase: "starting_libreoffice_request".to_string(),
+        detail: format!("Starting the {} request.", profile.label),
+    });
+
+    provider.connect_if_needed(mode).await?;
+    ensure_not_cancelled(state)?;
+
+    let tools = provider.list_tools(mode).await?;
+    if tools.is_empty() {
+        return Err(format!(
+            "{} is connected, but no {} tools are available yet.",
+            profile.label, profile.label
+        ));
+    }
+
+    emit(AssistantStreamEventDto::Status {
+        phase: "selecting_action".to_string(),
+        detail: format!("Selecting the safest {} action.", profile.label),
+    });
+
+    let planner_messages = build_planner_messages(mode, request, &tools);
+    let planner_output = planner.generate(&planner_messages).await?;
+    let tool_call = extract_tool_call(&planner_output);
+
+    if tool_call.is_none() {
+        let response = build_libreoffice_response(
+            mode,
+            if planner_output.trim().is_empty() {
+                format!(
+                    "I couldn't choose a safe {} action for that request. Try rephrasing it as a single supported step.",
+                    profile.label
+                )
+            } else {
+                planner_output.trim().to_string()
+            },
+            None,
+            false,
+            Vec::new(),
+        );
+        emit(AssistantStreamEventDto::Complete {
+            response: response.clone(),
+        });
+        return Ok(response);
+    }
+
+    let tool_call = tool_call.expect("checked above");
+    let allowlist = allowed_tool_names(mode);
+    if !allowlist.iter().any(|name| *name == tool_call.name) {
+        return Err(format!(
+            "{} is not an allowed {} tool in Phase 6B.",
+            tool_call.name, profile.label
+        ));
+    }
+
+    ensure_not_cancelled(state)?;
+    emit(AssistantStreamEventDto::ToolCall {
+        name: tool_call.name.clone(),
+        arguments: tool_call.arguments.clone(),
+    });
+    let tool_result = provider
+        .execute_tool(mode, &tool_call.name, tool_call.arguments.clone())
+        .await?;
+    emit(AssistantStreamEventDto::ToolResult {
+        name: tool_call.name,
+        result: tool_result.clone(),
+    });
+
+    if !tool_result.ok {
+        return Err(tool_result.summary);
+    }
+
+    let response =
+        stream_summary_with_fallback(mode, streamer, state, &request.user_text, tool_result, emit)
+            .await;
+    Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{execute_libreoffice_request, TextPlanner};
+    use crate::assistant::state::AssistantState;
+    use crate::modes::provider::{provider_state, ToolProvider};
+    use crate::modes::text_generation::TextStreamer;
+    use async_trait::async_trait;
+    use serde_json::json;
+    use smolpc_assistant_types::{
+        AppMode, AssistantMessageDto, AssistantSendRequestDto, AssistantStreamEventDto,
+        ProviderStateDto, ToolDefinitionDto, ToolExecutionResultDto,
+    };
+    use smolpc_engine_client::EngineChatMessage;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Default)]
+    struct MockProvider {
+        tools: Vec<ToolDefinitionDto>,
+        result: Option<ToolExecutionResultDto>,
+    }
+
+    #[async_trait]
+    impl ToolProvider for MockProvider {
+        async fn connect_if_needed(&self, mode: AppMode) -> Result<ProviderStateDto, String> {
+            Ok(provider_state(mode, "connected", None, true, false))
+        }
+
+        async fn status(&self, mode: AppMode) -> Result<ProviderStateDto, String> {
+            Ok(provider_state(mode, "connected", None, true, false))
+        }
+
+        async fn list_tools(&self, _mode: AppMode) -> Result<Vec<ToolDefinitionDto>, String> {
+            Ok(self.tools.clone())
+        }
+
+        async fn execute_tool(
+            &self,
+            _mode: AppMode,
+            _name: &str,
+            _arguments: serde_json::Value,
+        ) -> Result<ToolExecutionResultDto, String> {
+            self.result
+                .clone()
+                .ok_or_else(|| "missing tool result".to_string())
+        }
+
+        async fn undo_last_action(&self, _mode: AppMode) -> Result<(), String> {
+            Err("unsupported".to_string())
+        }
+
+        async fn disconnect_if_needed(&self, _mode: AppMode) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    struct MockPlanner {
+        reply: String,
+    }
+
+    #[async_trait]
+    impl TextPlanner for MockPlanner {
+        async fn generate(&self, _messages: &[EngineChatMessage]) -> Result<String, String> {
+            Ok(self.reply.clone())
+        }
+    }
+
+    struct MockStreamer;
+
+    #[async_trait]
+    impl TextStreamer for MockStreamer {
+        async fn generate_stream(
+            &self,
+            _messages: &[EngineChatMessage],
+            _state: &AssistantState,
+            on_token: &mut (dyn FnMut(String) + Send),
+        ) -> Result<String, String> {
+            on_token("Writer ".to_string());
+            on_token("summary".to_string());
+            Ok("Writer summary".to_string())
+        }
+    }
+
+    struct FailingStreamer;
+
+    #[async_trait]
+    impl TextStreamer for FailingStreamer {
+        async fn generate_stream(
+            &self,
+            _messages: &[EngineChatMessage],
+            _state: &AssistantState,
+            _on_token: &mut (dyn FnMut(String) + Send),
+        ) -> Result<String, String> {
+            Err("summary failed".to_string())
+        }
+    }
+
+    struct CancellableStreamer;
+
+    #[async_trait]
+    impl TextStreamer for CancellableStreamer {
+        async fn generate_stream(
+            &self,
+            _messages: &[EngineChatMessage],
+            state: &AssistantState,
+            _on_token: &mut (dyn FnMut(String) + Send),
+        ) -> Result<String, String> {
+            state.mark_cancelled();
+            Err("ASSISTANT_CANCELLED".to_string())
+        }
+    }
+
+    fn request(mode: AppMode, text: &str) -> AssistantSendRequestDto {
+        AssistantSendRequestDto {
+            mode,
+            chat_id: Some("chat".to_string()),
+            messages: vec![AssistantMessageDto {
+                role: "user".to_string(),
+                content: text.to_string(),
+            }],
+            user_text: text.to_string(),
+        }
+    }
+
+    fn writer_tool() -> ToolDefinitionDto {
+        ToolDefinitionDto {
+            name: "add_heading".to_string(),
+            description: "Add a heading".to_string(),
+            input_schema: json!({"type": "object"}),
+        }
+    }
+
+    fn slides_tool() -> ToolDefinitionDto {
+        ToolDefinitionDto {
+            name: "add_slide".to_string(),
+            description: "Add a slide".to_string(),
+            input_schema: json!({"type": "object"}),
+        }
+    }
+
+    fn ok_tool_result(name: &str) -> ToolExecutionResultDto {
+        ToolExecutionResultDto {
+            name: name.to_string(),
+            ok: true,
+            summary: format!("{name} completed"),
+            payload: json!({
+                "content": [
+                    {
+                        "type": "text",
+                        "text": format!("{name} completed successfully.")
+                    }
+                ]
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn writer_request_executes_one_allowed_tool_and_streams_summary() {
+        let provider = Arc::new(MockProvider {
+            tools: vec![writer_tool()],
+            result: Some(ok_tool_result("add_heading")),
+        });
+        let planner = MockPlanner {
+            reply: "{\"tool_call\":{\"name\":\"add_heading\",\"arguments\":{\"text\":\"Hello\"}}}"
+                .to_string(),
+        };
+        let streamer = MockStreamer;
+        let state = AssistantState::default();
+        let events = Arc::new(Mutex::new(Vec::<AssistantStreamEventDto>::new()));
+
+        let response = execute_libreoffice_request(
+            provider,
+            &planner,
+            &streamer,
+            &request(AppMode::Writer, "Add a heading"),
+            &state,
+            {
+                let events = Arc::clone(&events);
+                move |event| {
+                    events.lock().expect("events lock").push(event);
+                }
+            },
+        )
+        .await
+        .expect("writer response");
+
+        assert_eq!(response.reply, "Writer summary");
+        assert_eq!(response.tool_results.len(), 1);
+        let events = events.lock().expect("events lock");
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, AssistantStreamEventDto::Token { .. })));
+    }
+
+    #[tokio::test]
+    async fn impress_request_uses_json_fallback_tool_parsing() {
+        let provider = Arc::new(MockProvider {
+            tools: vec![slides_tool()],
+            result: Some(ok_tool_result("add_slide")),
+        });
+        let planner = MockPlanner {
+            reply: "```json\n{\"tool_call\":{\"name\":\"add_slide\",\"arguments\":{\"title\":\"Intro\"}}}\n```"
+                .to_string(),
+        };
+        let streamer = MockStreamer;
+        let state = AssistantState::default();
+
+        let response = execute_libreoffice_request(
+            provider,
+            &planner,
+            &streamer,
+            &request(AppMode::Impress, "Add a slide"),
+            &state,
+            |_| {},
+        )
+        .await
+        .expect("slides response");
+
+        assert_eq!(response.tool_results[0].name, "add_slide");
+    }
+
+    #[tokio::test]
+    async fn calc_mode_remains_unimplemented() {
+        let provider = Arc::new(MockProvider::default());
+        let planner = MockPlanner {
+            reply: "no-op".to_string(),
+        };
+        let streamer = MockStreamer;
+        let state = AssistantState::default();
+
+        let error = execute_libreoffice_request(
+            provider,
+            &planner,
+            &streamer,
+            &request(AppMode::Calc, "Open a sheet"),
+            &state,
+            |_| {},
+        )
+        .await
+        .expect_err("calc should remain scaffold-only");
+
+        assert_eq!(error, "UNIFIED_ASSISTANT_NOT_IMPLEMENTED");
+    }
+
+    #[tokio::test]
+    async fn summary_failure_falls_back_to_local_summary() {
+        let provider = Arc::new(MockProvider {
+            tools: vec![writer_tool()],
+            result: Some(ToolExecutionResultDto {
+                name: "list_documents".to_string(),
+                ok: true,
+                summary: "ok".to_string(),
+                payload: json!({
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Found 2 documents.\nName: alpha.odt\nName: beta.odt"
+                        }
+                    ]
+                }),
+            }),
+        });
+        let planner = MockPlanner {
+            reply: "{\"tool_call\":{\"name\":\"add_heading\",\"arguments\":{\"text\":\"Hello\"}}}"
+                .to_string(),
+        };
+        let streamer = FailingStreamer;
+        let state = AssistantState::default();
+
+        let response = execute_libreoffice_request(
+            provider,
+            &planner,
+            &streamer,
+            &request(AppMode::Writer, "List docs"),
+            &state,
+            |_| {},
+        )
+        .await
+        .expect("fallback response");
+
+        assert!(response.reply.contains("Found 2 document(s)."));
+        assert_eq!(
+            response.plan.expect("plan")["usedLocalFallbackSummary"],
+            json!(true)
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_after_tool_execution_uses_fallback_summary() {
+        let provider = Arc::new(MockProvider {
+            tools: vec![writer_tool()],
+            result: Some(ok_tool_result("add_heading")),
+        });
+        let planner = MockPlanner {
+            reply: "{\"tool_call\":{\"name\":\"add_heading\",\"arguments\":{\"text\":\"Hello\"}}}"
+                .to_string(),
+        };
+        let streamer = CancellableStreamer;
+        let state = AssistantState::default();
+
+        let response = execute_libreoffice_request(
+            provider,
+            &planner,
+            &streamer,
+            &request(AppMode::Writer, "Add heading"),
+            &state,
+            |_| {},
+        )
+        .await
+        .expect("fallback response");
+
+        assert!(response
+            .reply
+            .contains("add_heading completed successfully"));
+        assert_eq!(
+            response.plan.expect("plan")["usedLocalFallbackSummary"],
+            json!(true)
+        );
+    }
+}

--- a/apps/codehelper/src-tauri/src/modes/libreoffice/mod.rs
+++ b/apps/codehelper/src-tauri/src/modes/libreoffice/mod.rs
@@ -1,8 +1,11 @@
+mod executor;
 mod profiles;
 mod provider;
 mod resources;
+mod response;
 mod runtime;
 mod state;
 
+pub use executor::{execute_libreoffice_request, EngineTextPlanner};
 pub use profiles::{libreoffice_profile, LibreOfficeModeProfile};
 pub use provider::LibreOfficeProvider;

--- a/apps/codehelper/src-tauri/src/modes/libreoffice/profiles.rs
+++ b/apps/codehelper/src-tauri/src/modes/libreoffice/profiles.rs
@@ -2,49 +2,129 @@ use smolpc_assistant_types::AppMode;
 
 pub const LIBREOFFICE_DISABLED_REASON: &str =
     "LibreOffice integration is scaffolded in the unified app, but live document actions are not wired yet.";
+pub const WRITER_COMPOSER_PLACEHOLDER: &str =
+    "Ask LibreOffice Writer to create or edit a document (Shift+Enter for new line)...";
+pub const CALC_COMPOSER_PLACEHOLDER: &str =
+    "LibreOffice Calc is scaffolded here, but live spreadsheet chat is not active yet.";
+pub const SLIDES_COMPOSER_PLACEHOLDER: &str =
+    "Ask LibreOffice Slides to create or edit a presentation (Shift+Enter for new line)...";
+
+pub const WRITER_ALLOWED_TOOLS: &[&str] = &[
+    "create_blank_document",
+    "read_text_document",
+    "get_document_properties",
+    "list_documents",
+    "copy_document",
+    "add_text",
+    "add_heading",
+    "add_paragraph",
+    "add_table",
+    "insert_image",
+    "insert_page_break",
+    "format_text",
+    "search_replace_text",
+    "delete_text",
+    "format_table",
+    "delete_paragraph",
+    "apply_document_style",
+];
+
+pub const IMPRESS_ALLOWED_TOOLS: &[&str] = &[
+    "create_blank_presentation",
+    "read_presentation",
+    "get_document_properties",
+    "list_documents",
+    "copy_document",
+    "add_slide",
+    "edit_slide_content",
+    "edit_slide_title",
+    "delete_slide",
+    "apply_presentation_template",
+    "format_slide_content",
+    "format_slide_title",
+    "insert_slide_image",
+];
+
+pub const CALC_ALLOWED_TOOLS: &[&str] = &[];
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct LibreOfficeModeProfile {
     pub label: &'static str,
     pub subtitle: &'static str,
     pub disabled_reason: &'static str,
+    pub composer_placeholder: &'static str,
     pub source_coverage: &'static str,
     pub future_runtime_family: &'static str,
+    pub live_in_phase_6b: bool,
+    pub suggestions: &'static [&'static str],
+    pub allowed_tools: &'static [&'static str],
 }
 
 pub fn libreoffice_profile(mode: AppMode) -> Option<LibreOfficeModeProfile> {
     match mode {
-        // Writer already has meaningful standalone tool coverage on
-        // codex/libreoffice-port-track-a, but that behavior is not ported here yet.
         AppMode::Writer => Some(LibreOfficeModeProfile {
             label: "Writer",
             subtitle:
-                "LibreOffice Writer scaffold in the unified shell; live document actions land in the activation phase",
-            disabled_reason: LIBREOFFICE_DISABLED_REASON,
+                "Live LibreOffice Writer help for creating and editing documents through the unified assistant shell",
+            disabled_reason: "",
+            composer_placeholder: WRITER_COMPOSER_PLACEHOLDER,
             source_coverage:
                 "Writer already has meaningful source coverage on codex/libreoffice-port-track-a.",
             future_runtime_family: "Shared LibreOffice MCP runtime over stdio",
+            live_in_phase_6b: true,
+            suggestions: &[
+                "Create a blank document called lesson-plan.odt",
+                "Add a level 1 heading called Local AI in Schools",
+                "Insert a two-column table for topic and notes",
+            ],
+            allowed_tools: WRITER_ALLOWED_TOOLS,
         }),
-        // Calc is still scaffold-target only until the standalone branch matures further.
         AppMode::Calc => Some(LibreOfficeModeProfile {
             label: "Calc",
             subtitle:
                 "LibreOffice Calc scaffold in the unified shell; spreadsheet actions remain deferred for now",
             disabled_reason: LIBREOFFICE_DISABLED_REASON,
+            composer_placeholder: CALC_COMPOSER_PLACEHOLDER,
             source_coverage:
                 "Calc is not yet at parity on codex/libreoffice-port-track-a and remains scaffold-target only.",
             future_runtime_family: "Shared LibreOffice MCP runtime over stdio",
+            live_in_phase_6b: false,
+            suggestions: &[
+                "LibreOffice Calc activation is planned next",
+                "Spreadsheet tools are not wired yet",
+                "Check back after the activation follow-up",
+            ],
+            allowed_tools: CALC_ALLOWED_TOOLS,
         }),
-        // Impress / Slides already has meaningful standalone tool coverage, but remains inactive here.
         AppMode::Impress => Some(LibreOfficeModeProfile {
             label: "Slides",
             subtitle:
-                "LibreOffice Slides scaffold in the unified shell; live presentation actions land in the activation phase",
-            disabled_reason: LIBREOFFICE_DISABLED_REASON,
+                "Live LibreOffice Slides help for creating and editing presentations through the unified assistant shell",
+            disabled_reason: "",
+            composer_placeholder: SLIDES_COMPOSER_PLACEHOLDER,
             source_coverage:
                 "Slides already has meaningful source coverage on codex/libreoffice-port-track-a.",
             future_runtime_family: "Shared LibreOffice MCP runtime over stdio",
+            live_in_phase_6b: true,
+            suggestions: &[
+                "Create a blank presentation called demo-pitch.odp",
+                "Add a title slide for Local AI in Classrooms",
+                "Insert an image on slide 2 and scale it to fit",
+            ],
+            allowed_tools: IMPRESS_ALLOWED_TOOLS,
         }),
         _ => None,
     }
+}
+
+pub fn is_live_libreoffice_mode(mode: AppMode) -> bool {
+    libreoffice_profile(mode)
+        .map(|profile| profile.live_in_phase_6b)
+        .unwrap_or(false)
+}
+
+pub fn allowed_tool_names(mode: AppMode) -> &'static [&'static str] {
+    libreoffice_profile(mode)
+        .map(|profile| profile.allowed_tools)
+        .unwrap_or(CALC_ALLOWED_TOOLS)
 }

--- a/apps/codehelper/src-tauri/src/modes/libreoffice/provider.rs
+++ b/apps/codehelper/src-tauri/src/modes/libreoffice/provider.rs
@@ -1,6 +1,7 @@
-use super::profiles::libreoffice_profile;
+use super::profiles::{allowed_tool_names, is_live_libreoffice_mode, libreoffice_profile};
 use super::resources::{resolve_mcp_server_layout, ResourceResolutionOptions};
-use super::runtime::LibreOfficeRuntimeScaffold;
+use super::response::build_tool_execution_result;
+use super::runtime::LibreOfficeRuntimeConfig;
 use super::state::LibreOfficeProviderState;
 use crate::assistant::MODE_UNDO_NOT_SUPPORTED_IN_FOUNDATION;
 use crate::modes::provider::{
@@ -10,6 +11,7 @@ use async_trait::async_trait;
 use smolpc_assistant_types::{
     AppMode, ProviderStateDto, ToolDefinitionDto, ToolExecutionResultDto,
 };
+use smolpc_mcp_client::McpTool;
 use std::path::PathBuf;
 use tokio::sync::Mutex;
 
@@ -47,45 +49,199 @@ impl LibreOfficeProvider {
             .ok_or_else(|| format!("LibreOffice provider does not handle mode {mode:?}"))
     }
 
-    async fn validate_scaffold(&self, mode: AppMode) -> Result<ProviderStateDto, String> {
+    fn tool_definition(tool: McpTool) -> ToolDefinitionDto {
+        ToolDefinitionDto {
+            name: tool.name,
+            description: tool.description,
+            input_schema: tool.input_schema,
+        }
+    }
+
+    fn filtered_tools(mode: AppMode, raw_tools: Vec<McpTool>) -> Vec<ToolDefinitionDto> {
+        let allowlist = allowed_tool_names(mode);
+        raw_tools
+            .into_iter()
+            .filter(|tool| allowlist.iter().any(|name| *name == tool.name))
+            .map(Self::tool_definition)
+            .collect()
+    }
+
+    fn connected_state(mode: AppMode, detail: Option<String>) -> ProviderStateDto {
+        provider_state(mode, "connected", detail.as_deref(), true, false)
+    }
+
+    fn disconnected_state(mode: AppMode, state: &LibreOfficeProviderState) -> ProviderStateDto {
+        let label = if state.runtime_attempted && state.last_error.is_some() {
+            "error"
+        } else {
+            "disconnected"
+        };
+
+        provider_state(mode, label, state.last_error.as_deref(), true, false)
+    }
+
+    fn friendly_runtime_error(error: &str) -> String {
+        if error.contains("spawn stdio MCP command") {
+            return format!(
+                "Unable to start the LibreOffice MCP runtime. Make sure Python 3 is available or a bundled .venv exists. {error}"
+            );
+        }
+
+        format!(
+            "LibreOffice runtime failed. Make sure Python 3 and LibreOffice or Collabora are installed. {error}"
+        )
+    }
+
+    fn live_connected_detail(
+        mode: AppMode,
+        runtime: &LibreOfficeRuntimeConfig,
+        tools: &[ToolDefinitionDto],
+    ) -> String {
+        let profile = libreoffice_profile(mode).expect("writer or slides profile");
+        format!(
+            "{} is connected through the shared LibreOffice stdio MCP runtime. {} {} tool(s) available in this mode.",
+            profile.label,
+            runtime.summary(),
+            tools.len()
+        )
+    }
+
+    fn calc_scaffold_state(
+        mode: AppMode,
+        state: &mut LibreOfficeProviderState,
+    ) -> Result<ProviderStateDto, String> {
         let profile = Self::profile_for_mode(mode)?;
-        let mut state = self.state.lock().await;
+        let detail = format!(
+            "{} scaffold is present in the unified app, but live spreadsheet actions remain deferred in Phase 6B. {} Future runtime: {}.",
+            profile.label,
+            profile.source_coverage,
+            profile.future_runtime_family
+        );
+        state.tools.clear();
+        state.last_error = None;
+        Ok(provider_state(
+            mode,
+            "disconnected",
+            Some(detail.as_str()),
+            true,
+            false,
+        ))
+    }
 
-        match resolve_mcp_server_layout(self.resource_dir.as_deref(), self.resolution_options) {
-            Ok(layout) => {
-                let runtime = LibreOfficeRuntimeScaffold::from_layout(&layout);
-                let future_transport = runtime.stdio_transport_config();
-                state.scaffold_dir = Some(layout.mcp_server_dir.clone());
-                state.last_error = None;
+    fn validate_layout(
+        &self,
+    ) -> Result<
+        (
+            super::resources::LibreOfficeResourceLayout,
+            LibreOfficeRuntimeConfig,
+        ),
+        String,
+    > {
+        let layout =
+            resolve_mcp_server_layout(self.resource_dir.as_deref(), self.resolution_options)?;
+        let runtime = LibreOfficeRuntimeConfig::from_layout(&layout);
+        Ok((layout, runtime))
+    }
 
-                let detail = format!(
-                    "{} scaffold is present in the unified app, but live document actions are deferred to the activation branch. {} Future runtime: {}. Planned stdio entrypoint: {}.",
-                    profile.label,
-                    profile.source_coverage,
-                    runtime.summary(),
-                    future_transport.args.join(" ")
-                );
+    async fn connect_live_locked(
+        &self,
+        mode: AppMode,
+        state: &mut LibreOfficeProviderState,
+    ) -> Result<ProviderStateDto, String> {
+        let (layout, runtime) = self.validate_layout()?;
+        state.scaffold_dir = Some(layout.mcp_server_dir.clone());
+        state.runtime_attempted = true;
 
-                Ok(provider_state(
-                    mode,
-                    "disconnected",
-                    Some(detail.as_str()),
-                    true,
-                    false,
-                ))
+        let session = runtime
+            .connect_session()
+            .await
+            .map_err(|error| Self::friendly_runtime_error(&error))?;
+        let raw_tools = session
+            .list_tools()
+            .await
+            .map_err(|error| Self::friendly_runtime_error(&error.to_string()))?;
+        let tools = Self::filtered_tools(mode, raw_tools);
+
+        if tools.is_empty() {
+            let detail = format!(
+                "{} connected, but the runtime did not expose any {} allowlisted tools.",
+                libreoffice_profile(mode).expect("profile").label,
+                libreoffice_profile(mode).expect("profile").label
+            );
+            state.session = Some(session);
+            state.tools.clear();
+            state.last_error = Some(detail.clone());
+            return Ok(provider_state(
+                mode,
+                "error",
+                Some(detail.as_str()),
+                true,
+                false,
+            ));
+        }
+
+        state.session = Some(session);
+        state.tools = tools.clone();
+        state.last_error = None;
+        Ok(Self::connected_state(
+            mode,
+            Some(Self::live_connected_detail(mode, &runtime, &tools)),
+        ))
+    }
+
+    async fn refresh_live_state(
+        &self,
+        mode: AppMode,
+        state: &mut LibreOfficeProviderState,
+    ) -> ProviderStateDto {
+        if let Some(session) = state.session.as_ref() {
+            match session.list_tools().await {
+                Ok(raw_tools) => {
+                    let (_, runtime) = match self.validate_layout() {
+                        Ok(value) => value,
+                        Err(error) => {
+                            state.last_error = Some(error.clone());
+                            return provider_state(
+                                mode,
+                                "error",
+                                Some(error.as_str()),
+                                true,
+                                false,
+                            );
+                        }
+                    };
+                    let tools = Self::filtered_tools(mode, raw_tools);
+                    if tools.is_empty() {
+                        let detail = format!(
+                            "{} connected, but the runtime did not expose any {} allowlisted tools.",
+                            libreoffice_profile(mode).expect("profile").label,
+                            libreoffice_profile(mode).expect("profile").label
+                        );
+                        state.tools.clear();
+                        state.last_error = Some(detail.clone());
+                        return provider_state(mode, "error", Some(detail.as_str()), true, false);
+                    }
+                    state.tools = tools.clone();
+                    state.last_error = None;
+                    return Self::connected_state(
+                        mode,
+                        Some(Self::live_connected_detail(mode, &runtime, &tools)),
+                    );
+                }
+                Err(error) => {
+                    state.session = None;
+                    state.tools.clear();
+                    state.last_error = Some(Self::friendly_runtime_error(&error.to_string()));
+                }
             }
-            Err(error) => {
-                let detail = format!("LibreOffice scaffold validation failed: {error}");
-                state.scaffold_dir = None;
-                state.last_error = Some(detail.clone());
+        }
 
-                Ok(provider_state(
-                    mode,
-                    "error",
-                    Some(detail.as_str()),
-                    true,
-                    false,
-                ))
+        match self.connect_live_locked(mode, state).await {
+            Ok(provider_state) => provider_state,
+            Err(error) => {
+                let friendly = Self::friendly_runtime_error(&error);
+                state.last_error = Some(friendly.clone());
+                Self::disconnected_state(mode, state)
             }
         }
     }
@@ -94,31 +250,119 @@ impl LibreOfficeProvider {
 #[async_trait]
 impl ToolProvider for LibreOfficeProvider {
     async fn connect_if_needed(&self, mode: AppMode) -> Result<ProviderStateDto, String> {
-        self.validate_scaffold(mode).await
+        let mut state = self.state.lock().await;
+        if !is_live_libreoffice_mode(mode) {
+            return Self::calc_scaffold_state(mode, &mut state);
+        }
+
+        if state.session.is_some() && !state.tools.is_empty() {
+            return Ok(Self::connected_state(mode, state.last_error.clone()));
+        }
+
+        self.connect_live_locked(mode, &mut state).await
     }
 
     async fn status(&self, mode: AppMode) -> Result<ProviderStateDto, String> {
-        self.validate_scaffold(mode).await
+        let mut state = self.state.lock().await;
+
+        match self.validate_layout() {
+            Ok((layout, _runtime)) => {
+                state.scaffold_dir = Some(layout.mcp_server_dir);
+            }
+            Err(error) => {
+                state.scaffold_dir = None;
+                state.last_error = Some(error.clone());
+                return Ok(provider_state(
+                    mode,
+                    "error",
+                    Some(error.as_str()),
+                    true,
+                    false,
+                ));
+            }
+        }
+
+        if !is_live_libreoffice_mode(mode) {
+            return Self::calc_scaffold_state(mode, &mut state);
+        }
+
+        Ok(self.refresh_live_state(mode, &mut state).await)
     }
 
-    async fn list_tools(&self, _mode: AppMode) -> Result<Vec<ToolDefinitionDto>, String> {
-        Ok(Vec::new())
+    async fn list_tools(&self, mode: AppMode) -> Result<Vec<ToolDefinitionDto>, String> {
+        if !is_live_libreoffice_mode(mode) {
+            return Ok(Vec::new());
+        }
+
+        let state = self.state.lock().await;
+        Ok(state.tools.clone())
     }
 
     async fn execute_tool(
         &self,
-        _mode: AppMode,
-        _name: &str,
-        _arguments: serde_json::Value,
+        mode: AppMode,
+        name: &str,
+        arguments: serde_json::Value,
     ) -> Result<ToolExecutionResultDto, String> {
-        Err(FOUNDATION_PROVIDER_EXECUTION_NOT_IMPLEMENTED.to_string())
+        if !is_live_libreoffice_mode(mode) {
+            return Err(FOUNDATION_PROVIDER_EXECUTION_NOT_IMPLEMENTED.to_string());
+        }
+
+        if !allowed_tool_names(mode)
+            .iter()
+            .any(|candidate| *candidate == name)
+        {
+            return Err(format!(
+                "{name} is not available in {} mode.",
+                libreoffice_profile(mode).expect("profile").label
+            ));
+        }
+
+        {
+            let mut state = self.state.lock().await;
+            if state.session.is_none() {
+                self.connect_live_locked(mode, &mut state).await?;
+            }
+        }
+
+        let mut state = self.state.lock().await;
+        let session = state
+            .session
+            .as_ref()
+            .ok_or_else(|| "LibreOffice provider is not connected".to_string())?;
+
+        match session.call_tool(name, arguments).await {
+            Ok(payload) => {
+                let tool_result = build_tool_execution_result(name, payload);
+                if tool_result.ok {
+                    state.last_error = None;
+                } else {
+                    state.last_error = Some(tool_result.summary.clone());
+                }
+                Ok(tool_result)
+            }
+            Err(error) => {
+                let message = Self::friendly_runtime_error(&error.to_string());
+                state.session = None;
+                state.tools.clear();
+                state.last_error = Some(message.clone());
+                Err(message)
+            }
+        }
     }
 
     async fn undo_last_action(&self, _mode: AppMode) -> Result<(), String> {
         Err(MODE_UNDO_NOT_SUPPORTED_IN_FOUNDATION.to_string())
     }
 
-    async fn disconnect_if_needed(&self, _mode: AppMode) -> Result<(), String> {
+    async fn disconnect_if_needed(&self, mode: AppMode) -> Result<(), String> {
+        if !is_live_libreoffice_mode(mode) {
+            return Ok(());
+        }
+
+        let mut state = self.state.lock().await;
+        state.session = None;
+        state.tools.clear();
         Ok(())
     }
 }
@@ -132,7 +376,34 @@ mod tests {
     use std::fs;
     use tempfile::tempdir;
 
-    fn staged_resource_root() -> tempfile::TempDir {
+    const TEST_RUNTIME: &str = r#"#!/usr/bin/env python3
+import json
+import sys
+
+TOOLS = [
+    {"name": "add_heading", "description": "Add a heading", "inputSchema": {"type": "object"}},
+    {"name": "add_slide", "description": "Add a slide", "inputSchema": {"type": "object"}}
+]
+
+def send(value):
+    sys.stdout.write(json.dumps(value) + "\n")
+    sys.stdout.flush()
+
+for line in sys.stdin:
+    payload = json.loads(line)
+    method = payload.get("method")
+    if method == "initialize":
+        send({"jsonrpc": "2.0", "id": payload["id"], "result": {"serverInfo": {"name": "libre-mcp", "version": "test"}}})
+    elif method == "notifications/initialized":
+        continue
+    elif method == "tools/list":
+        send({"jsonrpc": "2.0", "id": payload["id"], "result": {"tools": TOOLS}})
+    elif method == "tools/call":
+        name = payload["params"]["name"]
+        send({"jsonrpc": "2.0", "id": payload["id"], "result": {"content": [{"type": "text", "text": f"{name} completed"}]}})
+"#;
+
+    fn staged_runtime_root(main_py: &str) -> tempfile::TempDir {
         let tempdir = tempdir().expect("tempdir");
         let staged_dir = tempdir
             .path()
@@ -141,12 +412,18 @@ mod tests {
             .join("mcp_server");
         fs::create_dir_all(&staged_dir).expect("create staged dir");
         fs::write(staged_dir.join("README.md"), "placeholder").expect("write readme");
+        fs::write(staged_dir.join("main.py"), main_py).expect("write main");
+        fs::write(staged_dir.join("libre.py"), "placeholder").expect("write libre");
+        fs::write(staged_dir.join("helper.py"), "placeholder").expect("write helper");
+        fs::write(staged_dir.join("helper_utils.py"), "placeholder").expect("write helper utils");
+        fs::write(staged_dir.join("helper_test_functions.py"), "placeholder")
+            .expect("write helper tests");
         tempdir
     }
 
     #[tokio::test]
-    async fn libreoffice_provider_reports_scaffold_detail_for_each_submode() {
-        let tempdir = staged_resource_root();
+    async fn writer_status_connects_and_filters_writer_tools() {
+        let tempdir = staged_runtime_root(TEST_RUNTIME);
         let provider = LibreOfficeProvider::with_resolution_options(
             Some(tempdir.path().to_path_buf()),
             ResourceResolutionOptions {
@@ -154,42 +431,79 @@ mod tests {
             },
         );
 
-        for (mode, label) in [
-            (AppMode::Writer, "Writer"),
-            (AppMode::Calc, "Calc"),
-            (AppMode::Impress, "Slides"),
-        ] {
-            let state = provider.status(mode).await.expect("provider state");
-            assert_eq!(state.mode, mode);
-            assert_eq!(state.state, "disconnected");
-            assert!(state.supports_tools);
-            assert!(!state.supports_undo);
-            assert!(state.detail.as_deref().expect("detail").contains(label));
-        }
-    }
-
-    #[tokio::test]
-    async fn connect_if_needed_revalidates_scaffold_without_tools() {
-        let tempdir = staged_resource_root();
-        let provider = LibreOfficeProvider::with_resolution_options(
-            Some(tempdir.path().to_path_buf()),
-            ResourceResolutionOptions {
-                allow_dev_fallback: false,
-            },
-        );
-
-        let state = provider
-            .connect_if_needed(AppMode::Writer)
-            .await
-            .expect("connect state");
+        let state = provider.status(AppMode::Writer).await.expect("status");
         let tools = provider.list_tools(AppMode::Writer).await.expect("tools");
 
-        assert_eq!(state.state, "disconnected");
-        assert!(tools.is_empty());
+        assert_eq!(state.state, "connected");
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "add_heading");
     }
 
     #[tokio::test]
-    async fn missing_staged_resource_directory_produces_honest_error_detail() {
+    async fn impress_status_connects_and_filters_slides_tools() {
+        let tempdir = staged_runtime_root(TEST_RUNTIME);
+        let provider = LibreOfficeProvider::with_resolution_options(
+            Some(tempdir.path().to_path_buf()),
+            ResourceResolutionOptions {
+                allow_dev_fallback: false,
+            },
+        );
+
+        let state = provider.status(AppMode::Impress).await.expect("status");
+        let tools = provider.list_tools(AppMode::Impress).await.expect("tools");
+
+        assert_eq!(state.state, "connected");
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "add_slide");
+    }
+
+    #[tokio::test]
+    async fn calc_mode_reports_scaffold_detail_without_starting_runtime() {
+        let tempdir = staged_runtime_root(
+            "from pathlib import Path\nPath('runtime-started.txt').write_text('started')\n",
+        );
+        let provider = LibreOfficeProvider::with_resolution_options(
+            Some(tempdir.path().to_path_buf()),
+            ResourceResolutionOptions {
+                allow_dev_fallback: false,
+            },
+        );
+
+        let state = provider.status(AppMode::Calc).await.expect("status");
+
+        assert_eq!(state.state, "disconnected");
+        assert!(state
+            .detail
+            .expect("detail")
+            .contains("spreadsheet actions remain deferred"));
+        assert!(
+            !tempdir.path().join("runtime-started.txt").exists(),
+            "Calc status should not start the runtime"
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_start_failure_produces_honest_error_detail() {
+        let tempdir =
+            staged_runtime_root("import sys\nsys.stderr.write('runtime failed')\nsys.exit(1)\n");
+        let provider = LibreOfficeProvider::with_resolution_options(
+            Some(tempdir.path().to_path_buf()),
+            ResourceResolutionOptions {
+                allow_dev_fallback: false,
+            },
+        );
+
+        let state = provider.status(AppMode::Writer).await.expect("status");
+
+        assert_eq!(state.state, "error");
+        assert!(state
+            .detail
+            .expect("detail")
+            .contains("LibreOffice runtime failed"));
+    }
+
+    #[tokio::test]
+    async fn missing_runtime_resources_produces_error_detail() {
         let tempdir = tempdir().expect("tempdir");
         let provider = LibreOfficeProvider::with_resolution_options(
             Some(tempdir.path().to_path_buf()),
@@ -198,17 +512,12 @@ mod tests {
             },
         );
 
-        let state = provider
-            .status(AppMode::Calc)
-            .await
-            .expect("provider state");
+        let state = provider.status(AppMode::Writer).await.expect("status");
 
         assert_eq!(state.state, "error");
-        assert_eq!(state.mode, AppMode::Calc);
         assert!(state
             .detail
-            .as_deref()
             .expect("detail")
-            .contains("scaffold validation failed"));
+            .contains("resources are not bundled yet"));
     }
 }

--- a/apps/codehelper/src-tauri/src/modes/libreoffice/resources.rs
+++ b/apps/codehelper/src-tauri/src/modes/libreoffice/resources.rs
@@ -17,6 +17,11 @@ impl Default for ResourceResolutionOptions {
 pub struct LibreOfficeResourceLayout {
     pub mcp_server_dir: PathBuf,
     pub readme_path: PathBuf,
+    pub main_py_path: PathBuf,
+    pub libre_py_path: PathBuf,
+    pub helper_py_path: PathBuf,
+    pub helper_utils_py_path: PathBuf,
+    pub helper_test_functions_py_path: PathBuf,
 }
 
 fn resource_candidates(
@@ -64,20 +69,41 @@ pub fn resolve_mcp_server_layout(
         }
 
         let readme_path = candidate.join("README.md");
-        if !readme_path.is_file() {
-            return Err(format!(
-                "LibreOffice scaffold resource directory exists at {} but README.md is missing.",
-                candidate.display()
-            ));
+        let main_py_path = candidate.join("main.py");
+        let libre_py_path = candidate.join("libre.py");
+        let helper_py_path = candidate.join("helper.py");
+        let helper_utils_py_path = candidate.join("helper_utils.py");
+        let helper_test_functions_py_path = candidate.join("helper_test_functions.py");
+
+        for (required_path, label) in [
+            (&readme_path, "README.md"),
+            (&main_py_path, "main.py"),
+            (&libre_py_path, "libre.py"),
+            (&helper_py_path, "helper.py"),
+            (&helper_utils_py_path, "helper_utils.py"),
+            (&helper_test_functions_py_path, "helper_test_functions.py"),
+        ] {
+            if !required_path.is_file() {
+                return Err(format!(
+                    "LibreOffice MCP resource directory exists at {} but {} is missing.",
+                    candidate.display(),
+                    label
+                ));
+            }
         }
 
         return Ok(LibreOfficeResourceLayout {
             mcp_server_dir: candidate,
             readme_path,
+            main_py_path,
+            libre_py_path,
+            helper_py_path,
+            helper_utils_py_path,
+            helper_test_functions_py_path,
         });
     }
 
-    Err("LibreOffice scaffold resources are not staged yet. Expected a tracked README under resources/libreoffice/mcp_server.".to_string())
+    Err("LibreOffice MCP runtime resources are not bundled yet. Expected README.md, main.py, libre.py, helper.py, helper_utils.py, and helper_test_functions.py under resources/libreoffice/mcp_server.".to_string())
 }
 
 #[cfg(test)]
@@ -96,6 +122,15 @@ mod tests {
             .join("mcp_server");
         fs::create_dir_all(&staged_dir).expect("create staged dir");
         fs::write(staged_dir.join("README.md"), "placeholder").expect("write readme");
+        fs::write(staged_dir.join("main.py"), "print('main')").expect("write main");
+        fs::write(staged_dir.join("libre.py"), "print('libre')").expect("write libre");
+        fs::write(staged_dir.join("helper.py"), "print('helper')").expect("write helper");
+        fs::write(staged_dir.join("helper_utils.py"), "print('utils')").expect("write utils");
+        fs::write(
+            staged_dir.join("helper_test_functions.py"),
+            "print('tests')",
+        )
+        .expect("write helper tests");
 
         let layout = resolve_mcp_server_layout(
             Some(tempdir.path()),
@@ -107,10 +142,12 @@ mod tests {
 
         assert_eq!(layout.mcp_server_dir, staged_dir);
         assert!(layout.readme_path.ends_with("README.md"));
+        assert!(layout.main_py_path.ends_with("main.py"));
+        assert!(layout.libre_py_path.ends_with("libre.py"));
     }
 
     #[test]
-    fn missing_readme_is_reported_as_an_error() {
+    fn missing_runtime_asset_is_reported_as_an_error() {
         let tempdir = tempdir().expect("tempdir");
         let staged_dir = tempdir
             .path()
@@ -118,6 +155,8 @@ mod tests {
             .join("libreoffice")
             .join("mcp_server");
         fs::create_dir_all(&staged_dir).expect("create staged dir");
+        fs::write(staged_dir.join("README.md"), "placeholder").expect("write readme");
+        fs::write(staged_dir.join("main.py"), "print('main')").expect("write main");
 
         let error = resolve_mcp_server_layout(
             Some(tempdir.path()),
@@ -127,6 +166,15 @@ mod tests {
         )
         .expect_err("missing readme should fail");
 
-        assert!(error.contains("README.md is missing"));
+        assert!(error.contains("libre.py is missing"));
+    }
+
+    #[test]
+    fn repo_bundled_runtime_assets_resolve_in_dev_mode() {
+        let layout = resolve_mcp_server_layout(None, ResourceResolutionOptions::default())
+            .expect("resolve repo layout");
+
+        assert!(layout.main_py_path.ends_with("main.py"));
+        assert!(layout.helper_py_path.ends_with("helper.py"));
     }
 }

--- a/apps/codehelper/src-tauri/src/modes/libreoffice/response.rs
+++ b/apps/codehelper/src-tauri/src/modes/libreoffice/response.rs
@@ -1,0 +1,195 @@
+use serde_json::Value;
+use smolpc_assistant_types::{AppMode, AssistantResponseDto, ToolExecutionResultDto};
+
+pub fn payload_is_error(payload: &Value) -> bool {
+    payload
+        .get("isError")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        || payload
+            .get("content")
+            .and_then(Value::as_array)
+            .and_then(|items| items.first())
+            .and_then(|first| first.get("text"))
+            .and_then(Value::as_str)
+            .map(|text| text.starts_with("Error:"))
+            .unwrap_or(false)
+}
+
+pub fn extract_primary_tool_text(payload: &Value) -> Option<String> {
+    payload
+        .get("content")
+        .and_then(Value::as_array)
+        .and_then(|items| items.first())
+        .and_then(|first| first.get("text"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| {
+            payload
+                .get("structuredContent")
+                .and_then(|content| content.get("result"))
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+}
+
+pub fn summarize_tool_result(name: &str, payload: &Value) -> String {
+    if let Some(text) = extract_primary_tool_text(payload) {
+        return text;
+    }
+
+    if payload_is_error(payload) {
+        return format!("{name} reported an error");
+    }
+
+    format!("{name} completed")
+}
+
+pub fn build_tool_execution_result(name: &str, payload: Value) -> ToolExecutionResultDto {
+    let ok = !payload_is_error(&payload);
+    let summary = summarize_tool_result(name, &payload);
+
+    ToolExecutionResultDto {
+        name: name.to_string(),
+        ok,
+        summary,
+        payload,
+    }
+}
+
+pub fn build_local_fallback_summary(tool_result: &ToolExecutionResultDto) -> String {
+    let text = extract_primary_tool_text(&tool_result.payload).unwrap_or_default();
+    if text.trim().is_empty() {
+        return if tool_result.summary.trim().is_empty() {
+            format!("{} completed.", tool_result.name)
+        } else {
+            tool_result.summary.clone()
+        };
+    }
+
+    let count_match = text
+        .to_ascii_lowercase()
+        .find("found ")
+        .and_then(|_| regex_capture_document_count(&text));
+    let name_matches = extract_named_entries(&text);
+
+    if let Some(doc_count) = count_match {
+        if !name_matches.is_empty() {
+            return format!(
+                "Found {} document(s). Example files: {}.",
+                doc_count,
+                name_matches.join(", ")
+            );
+        }
+
+        return format!("Found {} document(s).", doc_count);
+    }
+
+    if text.len() <= 280 {
+        text
+    } else {
+        format!("{}...", text.chars().take(280).collect::<String>())
+    }
+}
+
+pub fn build_libreoffice_response(
+    mode: AppMode,
+    reply: String,
+    tool_name: Option<&str>,
+    used_local_fallback: bool,
+    tool_results: Vec<ToolExecutionResultDto>,
+) -> AssistantResponseDto {
+    let mode_name = match mode {
+        AppMode::Writer => "writer",
+        AppMode::Impress => "impress",
+        AppMode::Calc => "calc",
+        _ => "unknown",
+    };
+
+    AssistantResponseDto {
+        reply,
+        explain: None,
+        undoable: false,
+        plan: Some(serde_json::json!({
+            "mode": mode_name,
+            "operation": if tool_name.is_some() { "tool_call_with_summary" } else { "direct_answer" },
+            "tool": tool_name,
+            "usedLocalFallbackSummary": used_local_fallback,
+            "toolCallCount": tool_results.len(),
+        })),
+        tool_results,
+    }
+}
+
+fn regex_capture_document_count(text: &str) -> Option<usize> {
+    let mut number = String::new();
+    let lower = text.to_ascii_lowercase();
+    let start = lower.find("found ")? + "found ".len();
+    for ch in lower[start..].chars() {
+        if ch.is_ascii_digit() {
+            number.push(ch);
+        } else if !number.is_empty() {
+            break;
+        } else if ch != ' ' {
+            return None;
+        }
+    }
+    number.parse::<usize>().ok()
+}
+
+fn extract_named_entries(text: &str) -> Vec<String> {
+    text.lines()
+        .filter_map(|line| line.split_once("Name:"))
+        .map(|(_, value)| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .take(3)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_libreoffice_response, build_local_fallback_summary, payload_is_error};
+    use serde_json::json;
+    use smolpc_assistant_types::{AppMode, ToolExecutionResultDto};
+
+    #[test]
+    fn fallback_summary_uses_document_count_and_names() {
+        let summary = build_local_fallback_summary(&ToolExecutionResultDto {
+            name: "list_documents".to_string(),
+            ok: true,
+            summary: "ok".to_string(),
+            payload: json!({
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Found 2 documents.\nName: alpha.odt\nName: beta.odt"
+                    }
+                ]
+            }),
+        });
+
+        assert!(summary.contains("Found 2 document(s)."));
+        assert!(summary.contains("alpha.odt"));
+    }
+
+    #[test]
+    fn error_payload_marks_result_as_error() {
+        assert!(payload_is_error(&json!({
+            "content": [{ "text": "Error: missing helper" }]
+        })));
+    }
+
+    #[test]
+    fn libreoffice_response_marks_messages_non_undoable() {
+        let response = build_libreoffice_response(
+            AppMode::Writer,
+            "Writer reply".to_string(),
+            Some("add_heading"),
+            false,
+            Vec::new(),
+        );
+
+        assert!(!response.undoable);
+        assert_eq!(response.plan.expect("plan")["mode"], "writer");
+    }
+}

--- a/apps/codehelper/src-tauri/src/modes/libreoffice/runtime.rs
+++ b/apps/codehelper/src-tauri/src/modes/libreoffice/runtime.rs
@@ -1,59 +1,119 @@
 use super::resources::LibreOfficeResourceLayout;
-use smolpc_mcp_client::StdioTransportConfig;
+use smolpc_mcp_client::{McpSession, StdioTransportConfig};
 use std::path::PathBuf;
 
 pub const LIBREOFFICE_HELPER_SOCKET_ADDR: &str = "localhost:8765";
+pub const LIBREOFFICE_OFFICE_SOCKET_ADDR: &str = "localhost:2002";
+const LIBREOFFICE_CLIENT_NAME: &str = "smolpc-unified-libreoffice";
+const LIBREOFFICE_CONNECT_HINT: &str =
+    "Make sure Python 3 is available and LibreOffice or Collabora is installed.";
+
 #[cfg(windows)]
 const DEFAULT_PYTHON_COMMAND: &str = "python";
 #[cfg(not(windows))]
 const DEFAULT_PYTHON_COMMAND: &str = "python3";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LibreOfficeRuntimeScaffold {
+pub struct LibreOfficeRuntimeConfig {
     pub entrypoint: PathBuf,
     pub working_dir: PathBuf,
     pub helper_socket_addr: String,
+    pub office_socket_addr: String,
+    pub python_command: String,
 }
 
-impl LibreOfficeRuntimeScaffold {
+impl LibreOfficeRuntimeConfig {
     pub fn from_layout(layout: &LibreOfficeResourceLayout) -> Self {
         Self {
-            entrypoint: layout.mcp_server_dir.join("main.py"),
+            entrypoint: layout.main_py_path.clone(),
             working_dir: layout.mcp_server_dir.clone(),
             helper_socket_addr: LIBREOFFICE_HELPER_SOCKET_ADDR.to_string(),
+            office_socket_addr: LIBREOFFICE_OFFICE_SOCKET_ADDR.to_string(),
+            python_command: resolve_python_command(&layout.mcp_server_dir),
         }
     }
 
     pub fn stdio_transport_config(&self) -> StdioTransportConfig {
         StdioTransportConfig {
-            command: DEFAULT_PYTHON_COMMAND.to_string(),
+            command: self.python_command.clone(),
             args: vec![self.entrypoint.to_string_lossy().to_string()],
             cwd: Some(self.working_dir.clone()),
         }
     }
 
+    pub async fn connect_session(&self) -> Result<McpSession, String> {
+        McpSession::connect_stdio(
+            self.stdio_transport_config(),
+            LIBREOFFICE_CLIENT_NAME,
+            env!("CARGO_PKG_VERSION"),
+        )
+        .await
+        .map_err(|error| {
+            format!(
+                "Unable to start the LibreOffice MCP runtime. {LIBREOFFICE_CONNECT_HINT} {error}"
+            )
+        })
+    }
+
     pub fn summary(&self) -> String {
         format!(
-            "shared LibreOffice MCP runtime over stdio via Python main.py with helper socket bridge on {}",
-            self.helper_socket_addr
+            "shared LibreOffice MCP runtime over stdio via {} main.py with helper socket bridge on {} and office socket {}",
+            self.python_command, self.helper_socket_addr, self.office_socket_addr
         )
     }
 }
 
+fn resolve_python_command(working_dir: &std::path::Path) -> String {
+    for candidate in bundled_python_candidates(working_dir) {
+        if candidate.is_file() {
+            return candidate.to_string_lossy().to_string();
+        }
+    }
+
+    DEFAULT_PYTHON_COMMAND.to_string()
+}
+
+fn bundled_python_candidates(working_dir: &std::path::Path) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    let venv_dir = working_dir.join(".venv");
+
+    #[cfg(windows)]
+    {
+        candidates.push(venv_dir.join("Scripts").join("python.exe"));
+    }
+
+    #[cfg(not(windows))]
+    {
+        candidates.push(venv_dir.join("bin").join("python3"));
+        candidates.push(venv_dir.join("bin").join("python"));
+    }
+
+    candidates
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{LibreOfficeRuntimeScaffold, LIBREOFFICE_HELPER_SOCKET_ADDR};
+    use super::{
+        LibreOfficeRuntimeConfig, LIBREOFFICE_HELPER_SOCKET_ADDR, LIBREOFFICE_OFFICE_SOCKET_ADDR,
+    };
     use crate::modes::libreoffice::resources::LibreOfficeResourceLayout;
     use std::path::PathBuf;
 
     #[test]
-    fn runtime_scaffold_produces_future_stdio_config() {
+    fn runtime_config_produces_stdio_setup() {
         let layout = LibreOfficeResourceLayout {
             mcp_server_dir: PathBuf::from("/tmp/libreoffice/mcp_server"),
             readme_path: PathBuf::from("/tmp/libreoffice/mcp_server/README.md"),
+            main_py_path: PathBuf::from("/tmp/libreoffice/mcp_server/main.py"),
+            libre_py_path: PathBuf::from("/tmp/libreoffice/mcp_server/libre.py"),
+            helper_py_path: PathBuf::from("/tmp/libreoffice/mcp_server/helper.py"),
+            helper_utils_py_path: PathBuf::from("/tmp/libreoffice/mcp_server/helper_utils.py"),
+            helper_test_functions_py_path: PathBuf::from(
+                "/tmp/libreoffice/mcp_server/helper_test_functions.py",
+            ),
         };
 
-        let runtime = LibreOfficeRuntimeScaffold::from_layout(&layout);
+        let runtime = LibreOfficeRuntimeConfig::from_layout(&layout);
         let config = runtime.stdio_transport_config();
 
         #[cfg(windows)]
@@ -65,5 +125,6 @@ mod tests {
             vec!["/tmp/libreoffice/mcp_server/main.py".to_string()]
         );
         assert_eq!(runtime.helper_socket_addr, LIBREOFFICE_HELPER_SOCKET_ADDR);
+        assert_eq!(runtime.office_socket_addr, LIBREOFFICE_OFFICE_SOCKET_ADDR);
     }
 }

--- a/apps/codehelper/src-tauri/src/modes/libreoffice/state.rs
+++ b/apps/codehelper/src-tauri/src/modes/libreoffice/state.rs
@@ -1,7 +1,12 @@
+use smolpc_assistant_types::ToolDefinitionDto;
+use smolpc_mcp_client::McpSession;
 use std::path::PathBuf;
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default)]
 pub struct LibreOfficeProviderState {
     pub scaffold_dir: Option<PathBuf>,
+    pub session: Option<McpSession>,
+    pub tools: Vec<ToolDefinitionDto>,
     pub last_error: Option<String>,
+    pub runtime_attempted: bool,
 }

--- a/apps/codehelper/src/App.svelte
+++ b/apps/codehelper/src/App.svelte
@@ -50,11 +50,11 @@
 	const BLENDER_COMPOSER_PLACEHOLDER =
 		'Ask about your Blender scene or a Blender workflow (Shift+Enter for new line)...';
 	const WRITER_COMPOSER_PLACEHOLDER =
-		'LibreOffice Writer is scaffolded here, but live document chat is not active yet.';
+		'Ask LibreOffice Writer to create or edit a document (Shift+Enter for new line)...';
 	const CALC_COMPOSER_PLACEHOLDER =
 		'LibreOffice Calc is scaffolded here, but live spreadsheet chat is not active yet.';
 	const SLIDES_COMPOSER_PLACEHOLDER =
-		'LibreOffice Slides is scaffolded here, but live presentation chat is not active yet.';
+		'Ask LibreOffice Slides to create or edit a presentation (Shift+Enter for new line)...';
 
 	const activeMode = $derived(modeStore.activeMode);
 	const activeModeConfig = $derived(modeStore.activeConfig);
@@ -66,6 +66,8 @@
 	const canUseCodePath = $derived(activeMode === 'code');
 	const canUseGimpPath = $derived(activeMode === 'gimp');
 	const canUseBlenderPath = $derived(activeMode === 'blender');
+	const canUseWriterPath = $derived(activeMode === 'writer');
+	const canUseImpressPath = $derived(activeMode === 'impress');
 	const isUnifiedRequestRunning = $derived(
 		currentUnifiedMode !== null && currentUnifiedChatId !== null && currentUnifiedMessageId !== null
 	);
@@ -73,10 +75,18 @@
 	const isBlenderRequestRunning = $derived(
 		currentUnifiedMode === 'blender' && isUnifiedRequestRunning
 	);
+	const isWriterRequestRunning = $derived(
+		currentUnifiedMode === 'writer' && isUnifiedRequestRunning
+	);
+	const isImpressRequestRunning = $derived(
+		currentUnifiedMode === 'impress' && isUnifiedRequestRunning
+	);
 	const currentUnifiedModeLabel = $derived(
 		currentUnifiedMode ? (modeStore.getConfig(currentUnifiedMode)?.label ?? 'Another mode') : null
 	);
-	const hasLiveComposer = $derived(canUseCodePath || canUseGimpPath || canUseBlenderPath);
+	const hasLiveComposer = $derived(
+		canUseCodePath || canUseGimpPath || canUseBlenderPath || canUseWriterPath || canUseImpressPath
+	);
 	const modeLabel = $derived(activeModeConfig?.label ?? 'Mode');
 	const modeSubtitle = $derived(activeModeConfig?.subtitle ?? 'Unified assistant workspace');
 	const modeSuggestions = $derived(activeModeConfig?.suggestions ?? []);
@@ -134,16 +144,19 @@
 			return `${currentUnifiedModeLabel ?? 'Another mode'} is still processing a request. Switch back to that mode to wait or cancel it.`;
 		}
 
-		if ((canUseGimpPath || canUseBlenderPath) && inferenceStore.isGenerating) {
+		if (
+			(canUseGimpPath || canUseBlenderPath || canUseWriterPath || canUseImpressPath) &&
+			inferenceStore.isGenerating
+		) {
 			return `Code mode is still generating a response. Wait for it to finish before starting a ${modeLabel} request.`;
 		}
 
-		if (canUseGimpPath && isBlenderRequestRunning) {
-			return 'Blender mode is still processing a request. Switch back to Blender to wait or cancel it.';
-		}
-
-		if (canUseBlenderPath && isGimpRequestRunning) {
-			return 'GIMP mode is still processing a request. Switch back to GIMP to wait or cancel it.';
+		if (
+			(canUseGimpPath || canUseBlenderPath || canUseWriterPath || canUseImpressPath) &&
+			isUnifiedRequestRunning &&
+			currentUnifiedMode !== activeMode
+		) {
+			return `${currentUnifiedModeLabel ?? 'Another mode'} is still processing a request. Switch back to that mode to wait or cancel it.`;
 		}
 
 		return null;
@@ -156,7 +169,11 @@
 				? isGimpRequestRunning
 				: canUseBlenderPath
 					? isBlenderRequestRunning
-					: false
+					: canUseWriterPath
+						? isWriterRequestRunning
+						: canUseImpressPath
+							? isImpressRequestRunning
+							: false
 	);
 	const composerPlaceholder = $derived(composerPlaceholderForMode(activeMode));
 	const pageTitle = $derived(currentChat?.title ?? defaultChatTitleForMode(activeMode));
@@ -394,6 +411,16 @@ Teaching rules:
 
 		if (activeMode === 'blender') {
 			await handleBlenderMessage(content);
+			return;
+		}
+
+		if (activeMode === 'writer') {
+			await handleWriterMessage(content);
+			return;
+		}
+
+		if (activeMode === 'impress') {
+			await handleImpressMessage(content);
 			return;
 		}
 
@@ -657,12 +684,93 @@ Teaching rules:
 		}
 	}
 
-	async function handleUnifiedModeMessage(mode: 'gimp' | 'blender', content: string) {
+	function applyLibreOfficeEvent(
+		mode: 'writer' | 'impress',
+		chatId: string,
+		messageId: string,
+		event: AssistantStreamEvent,
+		streamedResponse: UnifiedStreamAccumulator
+	) {
+		switch (event.kind) {
+			case 'status':
+				if (!streamedResponse.hasSeenToken) {
+					updateUnifiedStreamingMessage(mode, chatId, messageId, {
+						content: event.detail,
+						toolResults: streamedResponse.toolResults,
+						isStreaming: true
+					});
+				}
+				break;
+			case 'tool_call':
+				if (!streamedResponse.hasSeenToken) {
+					updateUnifiedStreamingMessage(mode, chatId, messageId, {
+						content: `Running ${event.name}...`,
+						toolResults: streamedResponse.toolResults,
+						isStreaming: true
+					});
+				}
+				break;
+			case 'tool_result': {
+				const toolResults = [...(streamedResponse.toolResults ?? []), event.result];
+				streamedResponse.toolResults = toolResults;
+				updateUnifiedStreamingMessage(mode, chatId, messageId, {
+					content: streamedResponse.hasSeenToken
+						? streamedResponse.accumulatedText
+						: event.result.summary,
+					toolResults,
+					isStreaming: true
+				});
+				break;
+			}
+			case 'token':
+				streamedResponse.hasSeenToken = true;
+				streamedResponse.accumulatedText += event.token;
+				updateUnifiedStreamingMessage(mode, chatId, messageId, {
+					content: streamedResponse.accumulatedText,
+					toolResults: streamedResponse.toolResults,
+					isStreaming: true
+				});
+				break;
+			case 'complete': {
+				streamedResponse.current = event.response;
+				finalizeUnifiedResponse(mode, chatId, messageId, {
+					...event.response,
+					reply:
+						streamedResponse.hasSeenToken && streamedResponse.accumulatedText.length > 0
+							? streamedResponse.accumulatedText
+							: event.response.reply,
+					toolResults: streamedResponse.toolResults ?? event.response.toolResults
+				});
+				break;
+			}
+			case 'error':
+				updateUnifiedStreamingMessage(mode, chatId, messageId, {
+					content: `Error: ${event.message}`,
+					explain: null,
+					undoable: false,
+					toolResults: streamedResponse.toolResults,
+					plan: undefined,
+					isStreaming: false
+				});
+				break;
+		}
+	}
+
+	async function handleUnifiedModeMessage(
+		mode: 'gimp' | 'blender' | 'writer' | 'impress',
+		content: string
+	) {
 		if (
 			activeMode !== mode ||
 			currentUnifiedMode !== null ||
 			inferenceStore.isGenerating ||
-			(mode === 'gimp' ? !canUseGimpPath : !canUseBlenderPath)
+			(mode === 'gimp'
+				? !canUseGimpPath
+				: mode === 'blender'
+					? !canUseBlenderPath
+					: mode === 'writer'
+						? !canUseWriterPath
+						: !canUseImpressPath)
 		) {
 			return;
 		}
@@ -694,7 +802,11 @@ Teaching rules:
 			content:
 				mode === 'gimp'
 					? 'Selecting the best GIMP action for this request.'
-					: 'Starting the Blender tutoring request.',
+					: mode === 'blender'
+						? 'Starting the Blender tutoring request.'
+						: mode === 'writer'
+							? 'Starting the Writer request.'
+							: 'Starting the Slides request.',
 			timestamp: Date.now(),
 			isStreaming: true
 		};
@@ -729,14 +841,19 @@ Teaching rules:
 					return;
 				}
 
-				applyBlenderEvent(chatId, messageId, event, streamedResponse);
+				if (mode === 'blender') {
+					applyBlenderEvent(chatId, messageId, event, streamedResponse);
+					return;
+				}
+
+				applyLibreOfficeEvent(mode, chatId, messageId, event, streamedResponse);
 			});
 
 			if (!streamedResponse.current) {
 				finalizeUnifiedResponse(mode, chatId, messageId, {
 					...response,
 					reply:
-						mode === 'blender' &&
+						(mode === 'blender' || mode === 'writer' || mode === 'impress') &&
 						streamedResponse.hasSeenToken &&
 						streamedResponse.accumulatedText.length > 0
 							? streamedResponse.accumulatedText
@@ -768,6 +885,14 @@ Teaching rules:
 
 	async function handleBlenderMessage(content: string) {
 		await handleUnifiedModeMessage('blender', content);
+	}
+
+	async function handleWriterMessage(content: string) {
+		await handleUnifiedModeMessage('writer', content);
+	}
+
+	async function handleImpressMessage(content: string) {
+		await handleUnifiedModeMessage('impress', content);
 	}
 
 	function findNearestUserPrompt(messageId: string): string | null {
@@ -868,14 +993,23 @@ Teaching rules:
 	}
 
 	function handleExampleSelect(prompt: string) {
-		if (activeMode !== 'code' && activeMode !== 'gimp' && activeMode !== 'blender') return;
+		if (
+			activeMode !== 'code' &&
+			activeMode !== 'gimp' &&
+			activeMode !== 'blender' &&
+			activeMode !== 'writer' &&
+			activeMode !== 'impress'
+		)
+			return;
 		handleSendMessage(prompt);
 	}
 
 	async function handleCancelGeneration() {
 		if (
 			(activeMode === 'gimp' && isGimpRequestRunning) ||
-			(activeMode === 'blender' && isBlenderRequestRunning)
+			(activeMode === 'blender' && isBlenderRequestRunning) ||
+			(activeMode === 'writer' && isWriterRequestRunning) ||
+			(activeMode === 'impress' && isImpressRequestRunning)
 		) {
 			try {
 				await assistantCancel();

--- a/apps/codehelper/src/lib/components/chat/WelcomeState.svelte
+++ b/apps/codehelper/src/lib/components/chat/WelcomeState.svelte
@@ -54,25 +54,24 @@
 				'Blender mode is live in Phase 5. Ask about the current scene, modifiers, modeling workflows, or general Blender questions and the assistant will ground answers with scene context and local Blender reference docs when helpful.'
 		},
 		writer: {
-			chip: 'Writer Scaffold',
-			headline:
-				'LibreOffice Writer is staged in the unified shell, but live document actions are still deferred.',
+			chip: 'Writer Mode',
+			headline: 'Create and edit LibreOffice Writer documents from the unified assistant shell.',
 			description:
-				'Phase 6A keeps Writer visible, mode-aware, and merge-safe while the shared LibreOffice provider and runtime import stay deferred to the later activation branch.'
+				'Writer is live in Phase 6B. Ask the unified assistant to create documents, add headings or paragraphs, insert tables, or apply supported Writer formatting actions through the shared LibreOffice runtime.'
 		},
 		calc: {
 			chip: 'Calc Scaffold',
 			headline:
 				'LibreOffice Calc stays scaffolded in the shell while spreadsheet functionality catches up.',
 			description:
-				'Calc shares the future LibreOffice provider family, but this phase deliberately keeps it placeholder-only because the standalone branch is not yet at parity.'
+				'Calc still shares the future LibreOffice provider family, but Phase 6B deliberately keeps it placeholder-only because the reference branch is not yet at parity for spreadsheet workflows.'
 		},
 		impress: {
-			chip: 'Slides Scaffold',
+			chip: 'Slides Mode',
 			headline:
-				'LibreOffice Slides is staged in the shell so activation work can land on a stable UI.',
+				'Create and edit LibreOffice Slides presentations from the unified assistant shell.',
 			description:
-				'Slides is the user-facing label for Impress and remains placeholder-only in Phase 6A while the shared LibreOffice runtime stays out of the unified app.'
+				'Slides is the user-facing label for Impress and is live in Phase 6B. Ask for supported presentation actions such as creating a deck, adding slides, editing titles or content, and inserting slide images through the shared LibreOffice runtime.'
 		}
 	};
 

--- a/apps/codehelper/src/lib/types/mode.ts
+++ b/apps/codehelper/src/lib/types/mode.ts
@@ -96,14 +96,14 @@ export const FALLBACK_MODE_CONFIGS: ModeConfigDto[] = [
 		id: 'writer',
 		label: 'Writer',
 		subtitle:
-			'LibreOffice Writer scaffold in the unified shell; live document actions land in the activation phase',
+			'Live LibreOffice Writer help for creating and editing documents through the unified assistant shell',
 		icon: 'file-text',
 		providerKind: 'mcp',
 		systemPromptKey: 'mode.writer.default',
 		suggestions: [
-			'Draft an introduction for this report',
-			'Rewrite this paragraph for clarity',
-			'Summarize these meeting notes'
+			'Create a blank document called lesson-plan.odt',
+			'Add a level 1 heading called Local AI in Schools',
+			'Insert a two-column table for topic and notes'
 		],
 		capabilities: {
 			supportsTools: true,
@@ -124,9 +124,9 @@ export const FALLBACK_MODE_CONFIGS: ModeConfigDto[] = [
 		providerKind: 'mcp',
 		systemPromptKey: 'mode.calc.default',
 		suggestions: [
-			'Explain what this formula should do',
-			'Outline a grade tracker sheet',
-			'Suggest a clean table layout'
+			'LibreOffice Calc activation is planned next',
+			'Spreadsheet tools are not wired yet',
+			'Check back after the activation follow-up'
 		],
 		capabilities: {
 			supportsTools: true,
@@ -142,14 +142,14 @@ export const FALLBACK_MODE_CONFIGS: ModeConfigDto[] = [
 		id: 'impress',
 		label: 'Slides',
 		subtitle:
-			'LibreOffice Slides scaffold in the unified shell; live presentation actions land in the activation phase',
+			'Live LibreOffice Slides help for creating and editing presentations through the unified assistant shell',
 		icon: 'presentation',
 		providerKind: 'mcp',
 		systemPromptKey: 'mode.impress.default',
 		suggestions: [
-			'Turn these notes into slide bullets',
-			'Suggest a three-slide deck outline',
-			'Improve this presentation structure'
+			'Create a blank presentation called demo-pitch.odp',
+			'Add a title slide for Local AI in Classrooms',
+			'Insert an image on slide 2 and scale it to fit'
 		],
 		capabilities: {
 			supportsTools: true,


### PR DESCRIPTION
## Summary
- activate Writer and Slides/Impress through the unified LibreOffice provider and stdio MCP runtime
- keep Calc scaffold-only with honest shell copy and no send path
- import the pinned LibreOffice runtime assets into unified resources and add the one-tool-plus-summary execution flow

## Validation
- cargo test -p smolpc-mcp-client
- cargo check -p smolpc-code-helper
- cargo test -p smolpc-code-helper --lib
- npm run check --workspace apps/codehelper