### PR TITLE
docs: close out Phase 6B LibreOffice activation

### DIFF
--- a/docs/unified-assistant-spec/ARCHITECTURE.md
+++ b/docs/unified-assistant-spec/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # SmolPC Unified Assistant -- Architecture
 
-**Last Updated:** 2026-03-16
+**Last Updated:** 2026-03-17
 **Status:** Canonical architecture for the unified frontend
 
 ## 1. Product Shape
@@ -261,6 +261,11 @@ After Phase 6B:
     `origin/codex/libreoffice-port-track-a` commit
     `7acad1fa0eb31e32a5485069e85c021d14284455` and continues treating that
     branch as a read-only reference source.
+11. LibreOffice execution stays intentionally narrow in this phase:
+    - one tool call maximum per assistant turn
+    - one summary follow-up maximum after tool execution
+    - deterministic local summary fallback if the summary step fails, times out,
+      or is cancelled after the document tool already ran
 
 ## 9. Repository Boundaries
 

--- a/docs/unified-assistant-spec/CURRENT_STATE.md
+++ b/docs/unified-assistant-spec/CURRENT_STATE.md
@@ -1,33 +1,36 @@
 # Current State
 
 **Last Updated:** 2026-03-17
-**Phase:** Phase 6A LibreOffice scaffolding is merged; Phase 6B LibreOffice activation is the current next implementation phase
+**Phase:** Phase 6B LibreOffice activation is merged; Phase 7 hardening and packaging is the current next implementation phase
 
 ## Branch Roles
 
-| Branch                                       | Role                                       |
-| -------------------------------------------- | ------------------------------------------ |
-| `docs/unified-assistant-spec`                | Canonical architecture/spec branch         |
-| `dev/unified-assistant`                      | Implementation mainline after docs merge   |
-| `codex/unified-foundation`                   | Merged Phase 1 implementation branch       |
-| `codex/unified-foundation-status-docs`       | Phase 1 closeout docs branch               |
-| `codex/unified-shell-docs`                   | Merged Phase 2 preflight docs branch       |
-| `codex/unified-shell`                        | Merged Phase 2 shell implementation branch |
-| `codex/unified-shell-status-docs`            | Merged Phase 2 closeout docs branch        |
-| `codex/unified-shell-followups`              | Merged post-Phase-2 shell hardening branch |
-| `codex/unified-shell-followups-status-docs`  | Merged shell follow-up docs sync branch    |
-| `codex/unified-code-mode-docs`               | Merged Phase 3 preflight docs branch       |
-| `codex/unified-code-mode`                    | Merged Phase 3 implementation branch       |
-| `codex/unified-code-mode-status-docs`        | Merged Phase 3 closeout docs branch        |
-| `codex/unified-gimp-mode-docs`               | Merged Phase 4 preflight docs branch       |
-| `codex/unified-gimp-mode`                    | Merged Phase 4 implementation branch       |
-| `codex/unified-gimp-mode-status-docs`        | Phase 4 closeout docs branch               |
-| `codex/unified-blender-mode-docs`            | Merged Phase 5 preflight docs branch       |
-| `codex/unified-blender-mode`                 | Merged Phase 5 implementation branch       |
-| `codex/unified-blender-mode-status-docs`     | Phase 5 closeout docs branch               |
-| `codex/unified-libreoffice-mode-docs`        | Merged Phase 6A preflight docs branch      |
-| `codex/unified-libreoffice-mode`             | Merged Phase 6A implementation branch      |
-| `codex/unified-libreoffice-mode-status-docs` | Phase 6A closeout docs branch              |
+| Branch                                             | Role                                       |
+| -------------------------------------------------- | ------------------------------------------ |
+| `docs/unified-assistant-spec`                      | Canonical architecture/spec branch         |
+| `dev/unified-assistant`                            | Implementation mainline after docs merge   |
+| `codex/unified-foundation`                         | Merged Phase 1 implementation branch       |
+| `codex/unified-foundation-status-docs`             | Phase 1 closeout docs branch               |
+| `codex/unified-shell-docs`                         | Merged Phase 2 preflight docs branch       |
+| `codex/unified-shell`                              | Merged Phase 2 shell implementation branch |
+| `codex/unified-shell-status-docs`                  | Merged Phase 2 closeout docs branch        |
+| `codex/unified-shell-followups`                    | Merged post-Phase-2 shell hardening branch |
+| `codex/unified-shell-followups-status-docs`        | Merged shell follow-up docs sync branch    |
+| `codex/unified-code-mode-docs`                     | Merged Phase 3 preflight docs branch       |
+| `codex/unified-code-mode`                          | Merged Phase 3 implementation branch       |
+| `codex/unified-code-mode-status-docs`              | Merged Phase 3 closeout docs branch        |
+| `codex/unified-gimp-mode-docs`                     | Merged Phase 4 preflight docs branch       |
+| `codex/unified-gimp-mode`                          | Merged Phase 4 implementation branch       |
+| `codex/unified-gimp-mode-status-docs`              | Merged Phase 4 closeout docs branch        |
+| `codex/unified-blender-mode-docs`                  | Merged Phase 5 preflight docs branch       |
+| `codex/unified-blender-mode`                       | Merged Phase 5 implementation branch       |
+| `codex/unified-blender-mode-status-docs`           | Merged Phase 5 closeout docs branch        |
+| `codex/unified-libreoffice-mode-docs`              | Merged Phase 6A preflight docs branch      |
+| `codex/unified-libreoffice-mode`                   | Merged Phase 6A implementation branch      |
+| `codex/unified-libreoffice-mode-status-docs`       | Merged Phase 6A closeout docs branch       |
+| `codex/unified-libreoffice-activation-docs`        | Merged Phase 6B preflight docs branch      |
+| `codex/unified-libreoffice-activation`             | Merged Phase 6B implementation branch      |
+| `codex/unified-libreoffice-activation-status-docs` | Merged Phase 6B closeout docs branch       |
 
 ## What Is Done
 
@@ -283,42 +286,70 @@ Validation completed for the merged LibreOffice scaffolding:
 - PR `#75` checks green, including `Incremental Style Gates` and
   `Tauri Build Check`
 
+Phase 6B LibreOffice activation is now merged into `dev/unified-assistant`
+via PR `#78`.
+
+Merged LibreOffice activation now present in `dev/unified-assistant`:
+
+- imported Python MCP runtime assets now live under
+  `apps/codehelper/src-tauri/resources/libreoffice/mcp_server/`
+- `assistant_send` is now operational for `writer` and `impress`
+- `assistant_send(calc)` remains scaffold-only
+- `mode_status(writer|impress)` now reports real runtime-backed provider state
+- `mode_refresh_tools(writer|impress)` now starts or refreshes the shared stdio
+  MCP runtime and returns mode-filtered allowlisted tools
+- `mode_status(calc)` and `mode_refresh_tools(calc)` remain scaffold-aware and
+  do not launch the runtime
+- Writer and Slides now use the unified shell's live request path with status,
+  tool, token, complete, and error events
+- Writer and Slides enforce one tool call maximum per assistant turn plus one
+  summary follow-up maximum
+- Writer and Slides fall back to a deterministic local summary if the summary
+  generation step fails, times out, or is cancelled after a successful tool
+  call
+- Writer and Slides do not expose Undo, Regenerate, Continue, or Branch Chat
+  because document tool calls are side-effectful
+- Calc remains an honest scaffold-only mode with disabled composer and no fake
+  tool surface
+- no files under `apps/libreoffice-assistant/` were modified
+
+Validation completed for the merged LibreOffice activation:
+
+- `cargo test -p smolpc-mcp-client`
+- `cargo check -p smolpc-code-helper`
+- `cargo test -p smolpc-code-helper --lib`
+- `npm run check --workspace apps/codehelper`
+- PR `#78` merged into `dev/unified-assistant`
+
 ## What Has Not Started
 
-- live LibreOffice activation inside the unified app
+- live Calc activation inside the unified app
 - launcher cleanup beyond the foundation test fix
 - unified-app packaging hardening beyond the tracked OpenVINO placeholder
 - Windows end-to-end validation for the unified app
 
 ## Next Workstreams
 
-The next official step from the current merged Phase 6A baseline is the
-Phase 6B LibreOffice activation implementation flow:
+The next official step from the current merged Phase 6B baseline is the
+Phase 7 hardening and packaging flow:
 
-1. create `codex/unified-libreoffice-activation-docs`
-2. lock the first live LibreOffice activation scope in docs:
-   - Writer live
-   - Slides live
-   - Calc still scaffold-only
-   - imported Python runtime assets pinned to
-     `7acad1fa0eb31e32a5485069e85c021d14284455`
-   - one shared `LibreOfficeProvider`
-   - stdio MCP child process via `main.py`
-   - helper socket on `localhost:8765`
-   - headless office socket on `localhost:2002`
+1. create `codex/unified-hardening-docs`
+2. lock the hardening scope in docs:
+   - packaged resource-path validation
+   - Windows runtime validation
+   - launcher-assumption cleanup
+   - remaining cross-mode polish and regression-proofing
 3. merge docs into `docs/unified-assistant-spec`
 4. merge `docs/unified-assistant-spec` into `dev/unified-assistant`
-5. create `codex/unified-libreoffice-activation`
-6. activate Writer and Slides only through the shared unified provider
-7. close out LibreOffice activation in docs
-8. continue serial merge order:
-   - Hardening and Windows packaging validation
+5. create `codex/unified-hardening`
+6. implement the hardening and packaging validation branch
+7. close out hardening in docs
 
 The current merged GIMP and Blender implementations plus the merged
-LibreOffice scaffold leave these future phase boundaries intact:
+LibreOffice activation leave these future phase boundaries intact:
 
-1. `assistant_send` remains scaffold-only for Writer / Calc / Slides until the
-   dedicated Phase 6B activation branch lands
+1. `assistant_send` is now live for Writer / Slides but remains scaffold-only
+   for Calc
 2. Code mode still does not use the unified provider/orchestration path
 3. packaging still assumes an external GIMP install plus external MCP
    plugin/server runtime
@@ -326,8 +357,8 @@ LibreOffice scaffold leave these future phase boundaries intact:
 5. no standalone app directories were taken over by the unified branch
 6. `origin/codex/libreoffice-port-track-a` remains the separate LibreOffice
    functionality branch and is not a merge base for unified work
-7. Phase 7 hardening does not start until the Phase 6B activation closeout docs
-   are merged
+7. Phase 7 hardening starts only after the Phase 6B activation closeout docs are
+   merged
 
 ## Known Risks
 
@@ -352,10 +383,9 @@ LibreOffice scaffold leave these future phase boundaries intact:
 
 The current next-step baseline is correct only when:
 
-1. Phase 6A LibreOffice scaffolding is merged into `dev/unified-assistant`
-2. the Phase 6A closeout docs are merged into `docs/unified-assistant-spec`
+1. Phase 6B LibreOffice activation is merged into `dev/unified-assistant`
+2. the Phase 6B closeout docs are merged into `docs/unified-assistant-spec`
 3. those docs are merged back into `dev/unified-assistant`
-4. the next branch starts from a baseline that records LibreOffice activation
-   as the next official step rather than hardening
-5. the next live LibreOffice scope is explicitly Writer + Slides first while
-   Calc remains scaffold-only
+4. the next branch starts from a baseline that records hardening as the next
+   official step
+5. Writer and Slides are documented as live while Calc remains scaffold-only

--- a/docs/unified-assistant-spec/FRONTEND_SPEC.md
+++ b/docs/unified-assistant-spec/FRONTEND_SPEC.md
@@ -1,6 +1,6 @@
 # SmolPC Unified Assistant -- Frontend Specification
 
-**Last Updated:** 2026-03-16
+**Last Updated:** 2026-03-17
 **Status:** Canonical frontend spec for the unified app
 
 ## 1. Frontend Direction
@@ -478,8 +478,10 @@ Before provider integrations land:
    `assistant_send` for `blender`.
 7. Land LibreOffice scaffolding into one shared provider with Writer/Calc/Slides
    frontend configs while keeping those modes disabled.
-8. Activate live LibreOffice behavior for Writer and Slides in a later
-   dedicated branch while keeping Calc scaffold-only.
+8. Activate live LibreOffice behavior for Writer and Slides in a dedicated
+   activation branch while keeping Calc scaffold-only.
+9. Start hardening and packaging work only after the LibreOffice activation
+   closeout docs are merged.
 
 The frontend should not import or embed standalone app code directly. It should
 consume new unified stores, mode configs, and Tauri command contracts.

--- a/docs/unified-assistant-spec/IMPLEMENTATION_PHASES.md
+++ b/docs/unified-assistant-spec/IMPLEMENTATION_PHASES.md
@@ -1,7 +1,7 @@
 # Unified Assistant Implementation Phases
 
 **Last Updated:** 2026-03-17
-**Status:** Phase 6A LibreOffice scaffolding is merged; Phase 6B LibreOffice activation is the current next implementation phase
+**Status:** Phase 6B LibreOffice activation is merged; Phase 7 hardening and packaging is the current next implementation phase
 
 ## Phase 0: Documentation Baseline
 
@@ -44,18 +44,14 @@
   - tracked OpenVINO placeholder directory
   - clean frontend audit lockfile
 
-## Branch Order After Phase 6A
+## Branch Order After Phase 6B
 
-1. `codex/unified-libreoffice-activation-docs`
+1. `codex/unified-hardening-docs`
 2. merge into `docs/unified-assistant-spec`
 3. merge `docs/unified-assistant-spec` into `dev/unified-assistant`
-4. `codex/unified-libreoffice-activation`
+4. `codex/unified-hardening`
 5. merge into `dev/unified-assistant`
-6. `codex/unified-libreoffice-activation-status-docs`
-7. merge into `docs/unified-assistant-spec`
-8. merge `docs/unified-assistant-spec` into `dev/unified-assistant`
-9. `codex/unified-hardening-docs`
-10. `codex/unified-hardening`
+6. hardening closeout docs as needed
 
 ## Phase 2: Unified Shell
 
@@ -396,6 +392,28 @@
 - `mode_status(writer|impress)` and `mode_refresh_tools(writer|impress)` are
   runtime-backed
 - hardening can begin from a real LibreOffice integration baseline
+
+**Current branch status**
+
+- preflight docs merged into `docs/unified-assistant-spec`, then into
+  `dev/unified-assistant`
+- implementation merged via PR `#78`
+- merged Phase 6B activation now present in `dev/unified-assistant`:
+  - imported Python runtime assets now live under
+    `apps/codehelper/src-tauri/resources/libreoffice/mcp_server/`
+  - Writer and Slides are live runtime-backed modes through the shared
+    `LibreOfficeProvider`
+  - Calc remains scaffold-only with disabled composer and no live send path
+  - `assistant_send(writer)` and `assistant_send(impress)` are operational
+  - `mode_status(writer|impress)` and `mode_refresh_tools(writer|impress)` are
+    live and mode-filtered
+  - Writer and Slides enforce one tool call maximum per turn plus one summary
+    follow-up maximum
+  - deterministic local summary fallback is used if summary generation fails,
+    times out, or is cancelled after a successful tool call
+  - Writer and Slides do not expose Undo, Regenerate, Continue, or Branch Chat
+    in the unified shell
+  - no edits to `apps/libreoffice-assistant/`
 
 ## Phase 7: Hardening And Packaging
 

--- a/docs/unified-assistant-spec/LEARNINGS.md
+++ b/docs/unified-assistant-spec/LEARNINGS.md
@@ -4,7 +4,7 @@
 >
 > **Audience:** Every AI session. Read relevant sections before working on that subsystem.
 >
-> **Last Updated:** 2026-03-16
+> **Last Updated:** 2026-03-17
 
 ---
 
@@ -75,6 +75,8 @@
 
 - **Live non-Code modes still need a single shared-generation gate** (2026-03): Phase 5 made Blender a second live non-Code mode, but it still shares the same engine runtime as Code. The shell can allow mode switching during Blender generation, yet it must block starting any competing live-mode request until the active non-Code run finishes or is cancelled.
 
+- **Side-effectful document modes should not inherit replay-style chat actions** (2026-03): Writer and Slides tool calls mutate real documents, so automatically replayable actions like `Regenerate`, `Continue`, and `Branch Chat` are a bad fit by default. Keep those affordances on tutoring/code modes unless the document workflow has explicit idempotency or undo semantics.
+
 ---
 
 ## MCP
@@ -82,6 +84,8 @@
 - **Make the shared MCP client async before real transports land** (2026-03): stdio and TCP transports are inherently async. If the shared JSON-RPC client starts synchronous, every real implementation either blocks a thread or forces a breaking trait change later.
 
 - **Shared providers must be mode-aware at the provider boundary** (2026-03): LibreOffice serves Writer, Calc, and Slides from one runtime. Patching `ProviderStateDto.mode` later in the command layer is too fragile; the provider contract itself must accept the requested mode for status, tool discovery, undo, and execution.
+
+- **Planner allowlists are not enough for side-effectful tools** (2026-03): Once Writer and Slides went live, the backend still had to enforce the per-mode tool allowlist in `list_tools()` and `execute_tool()`. Relying on prompt instructions alone would leave document-modifying tools exposed to planner mistakes or malformed fallback payloads.
 
 - **GIMP MCP uses TCP, not stdio** (2026-03): `maorcc/gimp-mcp` connects to GIMP's Script-Fu console via TCP. The MCP server itself listens on TCP port 10008. This is different from most MCP servers which use stdio.
 
@@ -148,6 +152,8 @@
 - **Context compaction is the biggest risk** (2026-03): Long AI sessions lose synthesized research when context compacts. Always persist findings to documentation files before they're lost. This entire docs/unified-assistant-spec directory was created specifically to prevent research loss.
 
 - **Dirty clones need selective staging, not cleanup churn** (2026-03): The shared clone used for unified work can contain unrelated local diffs from other workstreams. For implementation branches, stage only the files that belong to the phase and leave unrelated dirt alone instead of widening the branch scope with cleanup commits.
+
+- **Reference-branch runtime imports should be pinned to an exact commit** (2026-03): Pulling large runtime assets from an active standalone branch is only reviewable if the unified branch records the exact source commit it imported from. That keeps follow-up syncs auditable and avoids silently drifting with unrelated standalone work.
 
 - **Bridge handles need explicit drop cleanup or Rust tests can hang** (2026-03): Lazy-start provider runtimes that spawn local servers must stop those tasks when the handle is dropped. Without explicit cleanup, the lib test binary can finish its assertions but never exit because detached bridge tasks are still alive.
 

--- a/docs/unified-assistant-spec/MCP_INTEGRATION.md
+++ b/docs/unified-assistant-spec/MCP_INTEGRATION.md
@@ -1,6 +1,6 @@
 # MCP And Provider Integration
 
-**Last Updated:** 2026-03-16
+**Last Updated:** 2026-03-17
 **Status:** Canonical tool-integration spec for the unified app
 
 ## 1. Scope
@@ -464,6 +464,9 @@ keeping Calc scaffold-only:
   runtime and returns submode-filtered tool lists
 - `mode_refresh_tools(calc)` revalidates scaffold state only and does not start
   the runtime
+- Writer and Slides expose only their allowlisted subset through
+  `list_tools(...)`, even though the imported runtime has a broader raw tool
+  catalog
 - the shared runtime contract remains:
   - stdio MCP child process via `main.py`
   - helper socket on `localhost:8765`

--- a/docs/unified-assistant-spec/PACKAGING.md
+++ b/docs/unified-assistant-spec/PACKAGING.md
@@ -1,6 +1,6 @@
 # Packaging And Distribution
 
-**Last Updated:** 2026-03-16
+**Last Updated:** 2026-03-17
 **Status:** Packaging baseline for the unified app
 
 ## 1. Packaging Direction
@@ -44,13 +44,13 @@ scope of the unified frontend.
 
 ## 4. Bundled Resource Categories
 
-| Resource group          | Needed for         | Notes                                                                          |
-| ----------------------- | ------------------ | ------------------------------------------------------------------------------ |
-| Engine runtime bundle   | all modes          | shared engine startup and backend runtime selection                            |
-| Models                  | all modes          | shared model discovery                                                         |
-| GIMP provider assets    | GIMP               | provider-owned configuration or helper assets only; not the GIMP app itself    |
-| Blender bridge assets   | Blender            | bridge helpers and any bundled support files                                   |
-| LibreOffice MCP runtime | Writer/Calc/Slides | staged placeholder in Phase 6A, bundled provider runtime only after activation |
+| Resource group          | Needed for         | Notes                                                                              |
+| ----------------------- | ------------------ | ---------------------------------------------------------------------------------- |
+| Engine runtime bundle   | all modes          | shared engine startup and backend runtime selection                                |
+| Models                  | all modes          | shared model discovery                                                             |
+| GIMP provider assets    | GIMP               | provider-owned configuration or helper assets only; not the GIMP app itself        |
+| Blender bridge assets   | Blender            | bridge helpers and any bundled support files                                       |
+| LibreOffice MCP runtime | Writer/Calc/Slides | bundled provider runtime for Writer/Slides in Phase 6B; Calc remains scaffold-only |
 
 ## 5. Resource Rules
 
@@ -201,4 +201,4 @@ These remain for later implementation phases:
 - final model distribution approach
 - whether some provider assets ship always or are staged optionally
 - exact bundle layout for Blender supplementary tooling
-- exact bundle timing for the full LibreOffice MCP runtime import
+- future Calc runtime/tool activation scope beyond the current Writer/Slides import


### PR DESCRIPTION
## Summary
- record the merged Phase 6B LibreOffice activation state
- shift the documented next step from LibreOffice activation to hardening
- capture the merged Writer/Slides live behavior, Calc scaffold boundary, and packaging/learning updates

## Validation
- npx prettier --check docs/unified-assistant-spec/CURRENT_STATE.md docs/unified-assistant-spec/IMPLEMENTATION_PHASES.md docs/unified-assistant-spec/ARCHITECTURE.md docs/unified-assistant-spec/MCP_INTEGRATION.md docs/unified-assistant-spec/FRONTEND_SPEC.md docs/unified-assistant-spec/PACKAGING.md docs/unified-assistant-spec/LEARNINGS.md