### PR TITLE
Phase 7 hardening docs preflight

### DIFF
--- a/docs/unified-assistant-spec/ARCHITECTURE.md
+++ b/docs/unified-assistant-spec/ARCHITECTURE.md
@@ -172,6 +172,9 @@ only in the command layer.
 - Phase 6A lands the LibreOffice provider scaffold and shared stdio MCP prep.
 - Phase 6B activates Writer and Slides through that same shared provider while
   Calc remains scaffold-only.
+- Phase 7 keeps that provider split intact while hardening the imported
+  LibreOffice runtime, removing launcher assumptions, and finishing v1 with
+  Calc still deferred.
 
 ## 7. Frontend Shell
 
@@ -321,3 +324,4 @@ and then be pulled into the unified branches.
 6. Standalone apps remain merge-safe sources of truth while the port is in
    progress.
 7. Windows is the delivery target for packaging and validation.
+8. V1 completion does not require Calc activation; Calc remains post-v1 work.

--- a/docs/unified-assistant-spec/CURRENT_STATE.md
+++ b/docs/unified-assistant-spec/CURRENT_STATE.md
@@ -1,7 +1,7 @@
 # Current State
 
 **Last Updated:** 2026-03-17
-**Phase:** Phase 6B LibreOffice activation is merged; Phase 7 hardening and packaging is the current next implementation phase
+**Phase:** Phase 6B LibreOffice activation is merged; Phase 7 hardening and packaging is locked as the v1 finish-line phase
 
 ## Branch Roles
 
@@ -335,15 +335,19 @@ Phase 7 hardening and packaging flow:
 
 1. create `codex/unified-hardening-docs`
 2. lock the hardening scope in docs:
+   - LibreOffice runtime security and reliability hardening
    - packaged resource-path validation
+   - packaged identity cleanup to `SmolPC Unified Assistant`
    - Windows runtime validation
    - launcher-assumption cleanup
-   - remaining cross-mode polish and regression-proofing
+   - remaining cross-mode polish and regression-proofing without new mode activation
 3. merge docs into `docs/unified-assistant-spec`
 4. merge `docs/unified-assistant-spec` into `dev/unified-assistant`
 5. create `codex/unified-hardening`
 6. implement the hardening and packaging validation branch
-7. close out hardening in docs
+7. create `codex/unified-hardening-status-docs`
+8. merge closeout docs into `docs/unified-assistant-spec`
+9. merge `docs/unified-assistant-spec` into `dev/unified-assistant`
 
 The current merged GIMP and Blender implementations plus the merged
 LibreOffice activation leave these future phase boundaries intact:
@@ -359,6 +363,8 @@ LibreOffice activation leave these future phase boundaries intact:
    functionality branch and is not a merge base for unified work
 7. Phase 7 hardening starts only after the Phase 6B activation closeout docs are
    merged
+8. Phase 7 can still call v1 complete with Calc deferred; Calc activation is
+   post-v1 work rather than a hardening requirement
 
 ## Known Risks
 
@@ -389,3 +395,5 @@ The current next-step baseline is correct only when:
 4. the next branch starts from a baseline that records hardening as the next
    official step
 5. Writer and Slides are documented as live while Calc remains scaffold-only
+6. hardening is documented as the v1 finish-line phase rather than another
+   activation phase

--- a/docs/unified-assistant-spec/FRONTEND_SPEC.md
+++ b/docs/unified-assistant-spec/FRONTEND_SPEC.md
@@ -465,6 +465,17 @@ Before provider integrations land:
 - the shell must not show Undo, Regenerate, Continue, or Branch Chat for
   Writer or Slides in Phase 6B.
 
+### Phase 7 hardening and packaging
+
+- no new mode activation happens in Phase 7
+- Writer and Slides keep the Phase 6B live behavior
+- Calc stays visible but disabled and remains post-v1 work
+- Code mode keeps the existing inference path and does not switch onto
+  `assistant_send()`
+- the shared shell product identity becomes `SmolPC Unified Assistant`
+- no launcher-owned UI surface, provider toggle UI, or settings UI is added in
+  this phase
+
 ## 14. Migration Path
 
 1. Preserve the current Codehelper shell as the shared shell.
@@ -480,8 +491,8 @@ Before provider integrations land:
    frontend configs while keeping those modes disabled.
 8. Activate live LibreOffice behavior for Writer and Slides in a dedicated
    activation branch while keeping Calc scaffold-only.
-9. Start hardening and packaging work only after the LibreOffice activation
-   closeout docs are merged.
+9. Finish v1 in a hardening and packaging branch after the LibreOffice
+   activation closeout docs are merged, with Calc still deferred.
 
 The frontend should not import or embed standalone app code directly. It should
 consume new unified stores, mode configs, and Tauri command contracts.

--- a/docs/unified-assistant-spec/IMPLEMENTATION_PHASES.md
+++ b/docs/unified-assistant-spec/IMPLEMENTATION_PHASES.md
@@ -1,7 +1,7 @@
 # Unified Assistant Implementation Phases
 
 **Last Updated:** 2026-03-17
-**Status:** Phase 6B LibreOffice activation is merged; Phase 7 hardening and packaging is the current next implementation phase
+**Status:** Phase 6B LibreOffice activation is merged; Phase 7 hardening and packaging is locked as the v1 finish-line phase
 
 ## Phase 0: Documentation Baseline
 
@@ -51,7 +51,9 @@
 3. merge `docs/unified-assistant-spec` into `dev/unified-assistant`
 4. `codex/unified-hardening`
 5. merge into `dev/unified-assistant`
-6. hardening closeout docs as needed
+6. `codex/unified-hardening-status-docs`
+7. merge into `docs/unified-assistant-spec`
+8. merge `docs/unified-assistant-spec` into `dev/unified-assistant`
 
 ## Phase 2: Unified Shell
 
@@ -421,13 +423,34 @@
 
 **Scope**
 
+- finish the unified app for v1 with Calc still deferred
+- harden the imported LibreOffice runtime and shared provider session handling
 - remove remaining launcher assumptions
-- validate packaged resource paths
-- Windows-only end-to-end verification
+- validate packaged resource paths and packaged identity cleanup
+- Windows-only end-to-end verification and launcher-independent startup
+
+**Phase 7 preflight decisions**
+
+- Phase 7 is the v1 finish-line phase for the unified app.
+- Calc remains scaffold-only after Phase 7 and is explicitly post-v1 work.
+- No new mode activation happens in Phase 7.
+- Code mode does not switch onto `assistant_send` in Phase 7.
+- LibreOffice helper transport stays on `localhost:8765`; office socket stays
+  `localhost:2002`.
+- Hardening focuses on authentication, framing bounds, subprocess lifecycle,
+  response validation, packaging cleanup, and launcher removal rather than a new
+  transport family.
+- Visible packaged app branding becomes `SmolPC Unified Assistant`.
+- The bundle identifier remains `com.smolpc.codehelper` in Phase 7 to avoid an
+  installer-migration decision inside the hardening branch.
+- Phase 7 closeout is explicit:
+  `codex/unified-hardening-status-docs`.
 
 **Exit criteria**
 
 - unified app is Windows-valid without launcher runtime ownership
+- v1 is considered complete with Code, GIMP, Blender, Writer, and Slides live
+  while Calc remains deferred
 
 ## Merge-Safety Constraints
 
@@ -440,12 +463,12 @@ These apply to every implementation phase:
 
 ## Windows Validation Milestones
 
-| Milestone         | Required proof                               |
-| ----------------- | -------------------------------------------- |
-| Foundation ready  | commands and DTOs compile cleanly            |
-| Shell ready       | six modes visible in one shell               |
-| Code ready        | existing Codehelper experience preserved     |
-| GIMP ready        | tool call and undo work                      |
-| Blender ready     | bridge-backed workflow works                 |
-| LibreOffice ready | Writer/Calc/Slides all work via one provider |
-| Packaging ready   | packaged app runs without launcher ownership |
+| Milestone         | Required proof                                     |
+| ----------------- | -------------------------------------------------- |
+| Foundation ready  | commands and DTOs compile cleanly                  |
+| Shell ready       | six modes visible in one shell                     |
+| Code ready        | existing Codehelper experience preserved           |
+| GIMP ready        | tool call and undo work                            |
+| Blender ready     | bridge-backed workflow works                       |
+| LibreOffice ready | Writer/Slides live via one provider; Calc deferred |
+| Packaging ready   | packaged app runs without launcher ownership       |

--- a/docs/unified-assistant-spec/LEARNINGS.md
+++ b/docs/unified-assistant-spec/LEARNINGS.md
@@ -157,6 +157,8 @@
 
 - **Bridge handles need explicit drop cleanup or Rust tests can hang** (2026-03): Lazy-start provider runtimes that spawn local servers must stop those tasks when the handle is dropped. Without explicit cleanup, the lib test binary can finish its assertions but never exit because detached bridge tasks are still alive.
 
+- **Local helper sockets still need auth and framing limits** (2026-03): Binding a provider helper to loopback is not enough by itself once the runtime becomes live. The LibreOffice helper path needed a per-runtime auth token, hard frame-size ceilings, and strict response validation before Phase 7 could treat it as shippable.
+
 ---
 
 ## Historical VS Code Extension Research

--- a/docs/unified-assistant-spec/MCP_INTEGRATION.md
+++ b/docs/unified-assistant-spec/MCP_INTEGRATION.md
@@ -518,6 +518,28 @@ keeping Calc scaffold-only:
     out, or is cancelled after a successful tool call
   - cancellation does not roll back an already executed document tool
 
+## 9.5 Phase 7 LibreOffice hardening rule
+
+Phase 7 keeps the Phase 6B runtime contract and tool allowlists unchanged while
+hardening the internal LibreOffice runtime boundary:
+
+- helper socket stays on `localhost:8765`
+- office socket stays on `localhost:2002`
+- helper transport gains a per-runtime auth token
+- helper framing gains explicit size bounds
+- helper responses are schema-validated before use
+- provider session ownership becomes shareable so document tool execution does
+  not depend on holding the provider state lock across MCP calls
+- Writer and Slides remain the only live LibreOffice submodes
+- Calc remains scaffold-only and post-v1
+
+Phase 7 does not:
+
+- activate Calc
+- change the public Tauri command names
+- change the assistant DTO wire shapes
+- change the Code-mode execution path
+
 ## 10. Planner Boundary
 
 The frontend never executes tools directly.

--- a/docs/unified-assistant-spec/PACKAGING.md
+++ b/docs/unified-assistant-spec/PACKAGING.md
@@ -1,12 +1,20 @@
 # Packaging And Distribution
 
 **Last Updated:** 2026-03-17
-**Status:** Packaging baseline for the unified app
+**Status:** Packaging baseline for the unified app; Phase 7 hardening is the v1 finish-line packaging phase
 
 ## 1. Packaging Direction
 
 The shipping target is **one unified Windows desktop app** built from
 `apps/codehelper`.
+
+Phase 7 packaging decisions:
+
+- visible packaged identity is `SmolPC Unified Assistant`
+- Tauri `productName` and window title should use that name
+- the bundle identifier remains `com.smolpc.codehelper` in Phase 7
+- launcher-owned resources are removed from the unified app package
+- Calc remains scaffold-only and does not block v1 packaging closeout
 
 The launcher is not required for:
 
@@ -137,6 +145,21 @@ Phase 6B assumes:
 
 Phase 6B packaging validation covers the first real LibreOffice runtime
 connection checks for Writer and Slides while Calc remains scaffold-only.
+
+### 5.2.4 Phase 7 hardening and packaging rule
+
+Phase 7 keeps the Phase 6B runtime addresses unchanged:
+
+- helper socket bridge on `localhost:8765`
+- headless office socket on `localhost:2002`
+
+Phase 7 adds:
+
+- authenticated helper traffic inside the imported LibreOffice runtime
+- explicit helper message-size bounds and response validation
+- explicit bundled LibreOffice runtime resources in Tauri config
+- removal of launcher resources from the unified app bundle
+- visible packaged branding aligned to `SmolPC Unified Assistant`
 
 ### 5.3 No launcher-owned runtime paths
 


### PR DESCRIPTION
## Summary
- lock Phase 7 as the v1 finish-line phase
- make the hardening closeout docs branch explicit in the workflow
- document Calc as post-v1 and fix the stale LibreOffice-ready milestone
- lock launcher removal, packaging identity cleanup, and LibreOffice hardening scope

## Validation
- npx prettier --check docs/unified-assistant-spec/IMPLEMENTATION_PHASES.md docs/unified-assistant-spec/CURRENT_STATE.md docs/unified-assistant-spec/ARCHITECTURE.md docs/unified-assistant-spec/MCP_INTEGRATION.md docs/unified-assistant-spec/FRONTEND_SPEC.md docs/unified-assistant-spec/PACKAGING.md docs/unified-assistant-spec/LEARNINGS.md