### PR TITLE
Phase 7: close out unified hardening

### DIFF
--- a/docs/unified-assistant-spec/ARCHITECTURE.md
+++ b/docs/unified-assistant-spec/ARCHITECTURE.md
@@ -175,6 +175,11 @@ only in the command layer.
 - Phase 7 keeps that provider split intact while hardening the imported
   LibreOffice runtime, removing launcher assumptions, and finishing v1 with
   Calc still deferred.
+- After Phase 7, the shared LibreOffice provider owns:
+  - provider-validated runtime log-path setup
+  - authenticated helper-socket traffic
+  - bounded helper request/response framing
+  - shareable session ownership during live tool execution
 
 ## 7. Frontend Shell
 
@@ -311,7 +316,7 @@ and then be pulled into the unified branches.
 | Standalone apps | Port behavior into adapters; do not merge directories        |
 | Engine          | Prefer contract reuse over direct internal edits             |
 | Packaging       | Document and validate after provider integration, not before |
-| Launcher        | Out of scope for runtime ownership                           |
+| Launcher        | Removed from unified runtime ownership after Phase 7         |
 
 ## 11. Critical Invariants
 

--- a/docs/unified-assistant-spec/CURRENT_STATE.md
+++ b/docs/unified-assistant-spec/CURRENT_STATE.md
@@ -1,7 +1,7 @@
 # Current State
 
 **Last Updated:** 2026-03-17
-**Phase:** Phase 6B LibreOffice activation is merged; Phase 7 hardening and packaging is locked as the v1 finish-line phase
+**Phase:** Phase 7 hardening and packaging is merged; v1 unified app is complete with Calc deferred
 
 ## Branch Roles
 
@@ -31,6 +31,9 @@
 | `codex/unified-libreoffice-activation-docs`        | Merged Phase 6B preflight docs branch      |
 | `codex/unified-libreoffice-activation`             | Merged Phase 6B implementation branch      |
 | `codex/unified-libreoffice-activation-status-docs` | Merged Phase 6B closeout docs branch       |
+| `codex/unified-hardening-docs`                     | Merged Phase 7 preflight docs branch       |
+| `codex/unified-hardening`                          | Merged Phase 7 implementation branch       |
+| `codex/unified-hardening-status-docs`              | Merged Phase 7 closeout docs branch        |
 
 ## What Is Done
 
@@ -321,50 +324,67 @@ Validation completed for the merged LibreOffice activation:
 - `npm run check --workspace apps/codehelper`
 - PR `#78` merged into `dev/unified-assistant`
 
+Phase 7 hardening and packaging is now merged into `dev/unified-assistant`
+via PR `#82`.
+
+Merged Phase 7 hardening now present in `dev/unified-assistant`:
+
+- LibreOffice helper traffic now uses a per-runtime auth token inside the
+  imported Python runtime
+- LibreOffice helper framing now enforces a hard `10 MiB` message-size ceiling
+  on both request and response payloads
+- LibreOffice helper responses are now schema-validated before use and malformed
+  responses are treated as hard runtime errors
+- the LibreOffice runtime now receives a provider-owned validated log directory
+  path from Rust rather than trusting arbitrary external log-path input
+- LibreOffice runtime startup and shutdown now use bounded polling and
+  terminate-then-kill cleanup instead of blind sleeps
+- `LibreOfficeProvider` now keeps session ownership behind a clonable shared
+  handle so tool execution no longer depends on holding the provider state lock
+  across MCP calls
+- launcher commands, launcher state wiring, launcher resources, and launcher
+  ownership assumptions have been removed from the unified app
+- packaged product identity now uses `SmolPC Unified Assistant` for visible app
+  naming while keeping the bundle identifier `com.smolpc.codehelper`
+- Calc remains scaffold-only and post-v1
+
+Validation completed for the merged Phase 7 hardening branch:
+
+- `cargo test -p smolpc-mcp-client`
+- `cargo check -p smolpc-code-helper`
+- `cargo test -p smolpc-code-helper --lib`
+- `npm run check --workspace apps/codehelper`
+- local packaging/resource validation in the unified Tauri config test now
+  verifies bundled LibreOffice and Blender resources while excluding launcher
+  resources
+- real Windows packaged-app validation was not executed in this branch and
+  remains a manual shipping follow-up
+
 ## What Has Not Started
 
 - live Calc activation inside the unified app
-- launcher cleanup beyond the foundation test fix
-- unified-app packaging hardening beyond the tracked OpenVINO placeholder
-- Windows end-to-end validation for the unified app
+- migrating Code mode onto `assistant_send`
+- a real Windows packaged-app smoke test on target hardware
+- any bundle-identifier migration away from `com.smolpc.codehelper`
 
 ## Next Workstreams
 
-The next official step from the current merged Phase 6B baseline is the
-Phase 7 hardening and packaging flow:
+Phase 7 closes the required v1 unified-app branch flow. There is no mandatory
+Phase 8 branch locked yet.
 
-1. create `codex/unified-hardening-docs`
-2. lock the hardening scope in docs:
-   - LibreOffice runtime security and reliability hardening
-   - packaged resource-path validation
-   - packaged identity cleanup to `SmolPC Unified Assistant`
-   - Windows runtime validation
-   - launcher-assumption cleanup
-   - remaining cross-mode polish and regression-proofing without new mode activation
-3. merge docs into `docs/unified-assistant-spec`
-4. merge `docs/unified-assistant-spec` into `dev/unified-assistant`
-5. create `codex/unified-hardening`
-6. implement the hardening and packaging validation branch
-7. create `codex/unified-hardening-status-docs`
-8. merge closeout docs into `docs/unified-assistant-spec`
-9. merge `docs/unified-assistant-spec` into `dev/unified-assistant`
+If post-v1 work starts, it should still follow the same docs-first workflow:
 
-The current merged GIMP and Blender implementations plus the merged
-LibreOffice activation leave these future phase boundaries intact:
+1. create a docs branch from `origin/docs/unified-assistant-spec`
+2. merge docs into `docs/unified-assistant-spec`
+3. merge docs into `dev/unified-assistant`
+4. create the implementation branch from updated `origin/dev/unified-assistant`
 
-1. `assistant_send` is now live for Writer / Slides but remains scaffold-only
-   for Calc
-2. Code mode still does not use the unified provider/orchestration path
-3. packaging still assumes an external GIMP install plus external MCP
-   plugin/server runtime
-4. Blender stays bridge-first and does not require `blender-mcp` in Phase 5
-5. no standalone app directories were taken over by the unified branch
-6. `origin/codex/libreoffice-port-track-a` remains the separate LibreOffice
-   functionality branch and is not a merge base for unified work
-7. Phase 7 hardening starts only after the Phase 6B activation closeout docs are
-   merged
-8. Phase 7 can still call v1 complete with Calc deferred; Calc activation is
-   post-v1 work rather than a hardening requirement
+The most likely post-v1 follow-ups are:
+
+1. live Calc activation
+2. a real Windows packaged-app validation pass
+3. optional packaging/distribution follow-ups such as bundle-identifier
+   migration
 
 ## Known Risks
 
@@ -387,13 +407,12 @@ LibreOffice activation leave these future phase boundaries intact:
 
 ## Current Success Condition
 
-The current next-step baseline is correct only when:
+The current v1 baseline is correct only when:
 
-1. Phase 6B LibreOffice activation is merged into `dev/unified-assistant`
-2. the Phase 6B closeout docs are merged into `docs/unified-assistant-spec`
+1. Phase 7 hardening is merged into `dev/unified-assistant`
+2. the Phase 7 closeout docs are merged into `docs/unified-assistant-spec`
 3. those docs are merged back into `dev/unified-assistant`
-4. the next branch starts from a baseline that records hardening as the next
-   official step
-5. Writer and Slides are documented as live while Calc remains scaffold-only
-6. hardening is documented as the v1 finish-line phase rather than another
-   activation phase
+4. Code, GIMP, Blender, Writer, and Slides are documented as live
+5. Calc remains documented as scaffold-only and post-v1
+6. launcher assumptions are documented as removed from the unified app runtime
+7. Windows packaged-app validation is recorded as still pending manual follow-up

--- a/docs/unified-assistant-spec/FRONTEND_SPEC.md
+++ b/docs/unified-assistant-spec/FRONTEND_SPEC.md
@@ -472,9 +472,10 @@ Before provider integrations land:
 - Calc stays visible but disabled and remains post-v1 work
 - Code mode keeps the existing inference path and does not switch onto
   `assistant_send()`
-- the shared shell product identity becomes `SmolPC Unified Assistant`
-- no launcher-owned UI surface, provider toggle UI, or settings UI is added in
+- the shared shell product identity is now `SmolPC Unified Assistant`
+- no launcher-owned UI surface, provider toggle UI, or settings UI was added in
   this phase
+- launcher-only commands are no longer part of the unified app surface
 
 ## 14. Migration Path
 

--- a/docs/unified-assistant-spec/IMPLEMENTATION_PHASES.md
+++ b/docs/unified-assistant-spec/IMPLEMENTATION_PHASES.md
@@ -1,7 +1,7 @@
 # Unified Assistant Implementation Phases
 
 **Last Updated:** 2026-03-17
-**Status:** Phase 6B LibreOffice activation is merged; Phase 7 hardening and packaging is locked as the v1 finish-line phase
+**Status:** Phase 7 hardening and packaging is merged; v1 is complete with Calc deferred
 
 ## Phase 0: Documentation Baseline
 
@@ -44,7 +44,7 @@
   - tracked OpenVINO placeholder directory
   - clean frontend audit lockfile
 
-## Branch Order After Phase 6B
+## Branch Order Through Phase 7
 
 1. `codex/unified-hardening-docs`
 2. merge into `docs/unified-assistant-spec`
@@ -451,6 +451,33 @@
 - unified app is Windows-valid without launcher runtime ownership
 - v1 is considered complete with Code, GIMP, Blender, Writer, and Slides live
   while Calc remains deferred
+
+**Current branch status**
+
+- preflight docs merged into `docs/unified-assistant-spec`, then into
+  `dev/unified-assistant`
+- implementation merged via PR `#82`
+- merged Phase 7 hardening now present in `dev/unified-assistant`:
+  - LibreOffice helper traffic now uses a per-runtime auth token
+  - LibreOffice helper framing now enforces hard request/response size bounds
+  - LibreOffice helper responses are schema-validated before use
+  - LibreOffice runtime startup/shutdown now use bounded polling and explicit
+    terminate-then-kill cleanup
+  - provider-owned LibreOffice log paths are resolved and validated by the
+    unified app
+  - `LibreOfficeProvider` now uses shareable session ownership for live tool
+    execution
+  - launcher commands/resources/state have been removed from the unified app
+  - visible packaged identity now uses `SmolPC Unified Assistant`
+  - bundle identifier remains `com.smolpc.codehelper`
+  - Calc remains scaffold-only and post-v1
+- validation completed in the implementation branch:
+  - `cargo test -p smolpc-mcp-client`
+  - `cargo check -p smolpc-code-helper`
+  - `cargo test -p smolpc-code-helper --lib`
+  - `npm run check --workspace apps/codehelper`
+  - Windows packaged-app validation is still a manual follow-up outside this
+    branch environment
 
 ## Merge-Safety Constraints
 

--- a/docs/unified-assistant-spec/LEARNINGS.md
+++ b/docs/unified-assistant-spec/LEARNINGS.md
@@ -159,6 +159,8 @@
 
 - **Local helper sockets still need auth and framing limits** (2026-03): Binding a provider helper to loopback is not enough by itself once the runtime becomes live. The LibreOffice helper path needed a per-runtime auth token, hard frame-size ceilings, and strict response validation before Phase 7 could treat it as shippable.
 
+- **Fake dependency shims are enough to regression-test local runtimes** (2026-03): The Phase 7 hardening branch could test the LibreOffice helper auth/framing behavior and the LibreOffice MCP client's response validation without a real LibreOffice install by spawning the imported Python scripts with fake UNO/MCP shim modules. That is a practical way to keep protocol hardening covered in `cargo test`.
+
 ---
 
 ## Historical VS Code Extension Research

--- a/docs/unified-assistant-spec/MCP_INTEGRATION.md
+++ b/docs/unified-assistant-spec/MCP_INTEGRATION.md
@@ -520,14 +520,18 @@ keeping Calc scaffold-only:
 
 ## 9.5 Phase 7 LibreOffice hardening rule
 
-Phase 7 keeps the Phase 6B runtime contract and tool allowlists unchanged while
+Phase 7 kept the Phase 6B runtime contract and tool allowlists unchanged while
 hardening the internal LibreOffice runtime boundary:
 
 - helper socket stays on `localhost:8765`
 - office socket stays on `localhost:2002`
 - helper transport gains a per-runtime auth token
-- helper framing gains explicit size bounds
+- helper framing gains explicit `10 MiB` size bounds
 - helper responses are schema-validated before use
+- provider-owned log-path resolution now happens on the Rust side and the
+  Python runtime validates the supplied absolute path before use
+- runtime startup/shutdown now use bounded polling plus terminate-then-kill
+  cleanup
 - provider session ownership becomes shareable so document tool execution does
   not depend on holding the provider state lock across MCP calls
 - Writer and Slides remain the only live LibreOffice submodes

--- a/docs/unified-assistant-spec/PACKAGING.md
+++ b/docs/unified-assistant-spec/PACKAGING.md
@@ -1,7 +1,7 @@
 # Packaging And Distribution
 
 **Last Updated:** 2026-03-17
-**Status:** Packaging baseline for the unified app; Phase 7 hardening is the v1 finish-line packaging phase
+**Status:** Phase 7 hardening is merged; v1 packaging baseline is closed out with Calc deferred
 
 ## 1. Packaging Direction
 
@@ -11,7 +11,7 @@ The shipping target is **one unified Windows desktop app** built from
 Phase 7 packaging decisions:
 
 - visible packaged identity is `SmolPC Unified Assistant`
-- Tauri `productName` and window title should use that name
+- Tauri `productName` and window title now use that name
 - the bundle identifier remains `com.smolpc.codehelper` in Phase 7
 - launcher-owned resources are removed from the unified app package
 - Calc remains scaffold-only and does not block v1 packaging closeout
@@ -160,6 +160,7 @@ Phase 7 adds:
 - explicit bundled LibreOffice runtime resources in Tauri config
 - removal of launcher resources from the unified app bundle
 - visible packaged branding aligned to `SmolPC Unified Assistant`
+- shareable provider-side LibreOffice session ownership during tool execution
 
 ### 5.3 No launcher-owned runtime paths
 
@@ -177,6 +178,11 @@ The packaging plan is valid only after Windows verification covers:
 5. Blender provider connection behavior
 6. LibreOffice provider connection behavior
 7. packaged resource path resolution
+
+**Current recorded result:** the Phase 7 branch completed local compile/test
+validation and packaged-resource config validation, but no real Windows
+packaged-app run was executed in this branch environment. Windows validation is
+still a manual shipping follow-up.
 
 ## 7. Dev vs Packaged Resolution
 
@@ -215,6 +221,17 @@ Before calling the packaging plan complete, verify:
 - Blender mode fails gracefully if Blender bridge is unavailable
 - Blender mode fails gracefully if port `5179` is already occupied
 - staged LibreOffice resource paths resolve correctly in the unified app
+
+Phase 7 merged with these validation results already recorded:
+
+- `cargo test -p smolpc-mcp-client`
+- `cargo check -p smolpc-code-helper`
+- `cargo test -p smolpc-code-helper --lib`
+- `npm run check --workspace apps/codehelper`
+- unified Tauri config tests now verify:
+  - visible packaged identity uses `SmolPC Unified Assistant`
+  - bundled resources include LibreOffice and Blender assets
+  - launcher resources are excluded from the unified app package
 
 ## 10. Deferred Packaging Questions
 


### PR DESCRIPTION
## Summary
- record Phase 7 hardening as merged into dev/unified-assistant
- mark v1 unified app complete with Calc deferred
- capture the landed runtime, launcher, branding, and packaging changes

## Validation
- npx prettier --check docs/unified-assistant-spec/CURRENT_STATE.md docs/unified-assistant-spec/IMPLEMENTATION_PHASES.md docs/unified-assistant-spec/ARCHITECTURE.md docs/unified-assistant-spec/MCP_INTEGRATION.md docs/unified-assistant-spec/FRONTEND_SPEC.md docs/unified-assistant-spec/PACKAGING.md docs/unified-assistant-spec/LEARNINGS.md