### PR TITLE
Hardening: close LibreOffice helper socket cleanup gap

### DIFF
--- a/apps/codehelper/src-tauri/resources/libreoffice/mcp_server/libre.py
+++ b/apps/codehelper/src-tauri/resources/libreoffice/mcp_server/libre.py
@@ -153,6 +153,7 @@ def queue_worker():
             request_id, command = request_queue.get(timeout=1)
 
             # Process the request
+            client_socket = None
             try:
                 client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 client_socket.settimeout(30)  # 30 second timeout
@@ -162,7 +163,6 @@ def queue_worker():
                 request_payload["_smolpc_auth_token"] = HELPER_AUTH_TOKEN
                 _send_helper_frame(client_socket, request_payload)
                 response = _normalize_helper_response(_recv_helper_frame(client_socket))
-                client_socket.close()
             except socket.timeout:
                 response = {
                     "status": "error",
@@ -183,6 +183,12 @@ def queue_worker():
                     "status": "error",
                     "message": f"Error communicating with helper: {str(e)}",
                 }
+            finally:
+                if client_socket is not None:
+                    try:
+                        client_socket.close()
+                    except OSError:
+                        pass
 
             # Store the response
             with response_lock:

--- a/apps/codehelper/src-tauri/src/modes/libreoffice/provider.rs
+++ b/apps/codehelper/src-tauri/src/modes/libreoffice/provider.rs
@@ -198,7 +198,6 @@ impl LibreOfficeProvider {
         let tools = Self::filtered_tools(mode, raw_tools);
 
         let mut state = self.state.lock().await;
-        state.scaffold_dir = Some(layout.mcp_server_dir);
         state.session = Some(Arc::clone(&session));
 
         if tools.is_empty() {


### PR DESCRIPTION
## Summary
- always close the LibreOffice helper client socket on exception paths
- remove the redundant scaffold_dir assignment in the shared LibreOffice provider

## Validation
- cargo check -p smolpc-code-helper
- cargo test -p smolpc-code-helper --lib