### PR TITLE
docs(self-contained): lock phase 2 foundation scope

### DIFF
--- a/docs/unified-assistant-self-contained-spec/ARCHITECTURE.md
+++ b/docs/unified-assistant-self-contained-spec/ARCHITECTURE.md
@@ -94,6 +94,14 @@ Responsibilities:
 - expose setup health and repair state
 - launch host apps on demand
 
+Phase 2 foundation limits:
+
+- the subsystem is app-level, not mode-level
+- it reports readiness for the whole app
+- it does not replace `mode_status`
+- it does not launch host apps in Phase 2
+- it does not provision Blender or GIMP user-profile integrations in Phase 2
+
 ### 4.4 Mode providers
 
 Responsibilities:
@@ -125,6 +133,20 @@ New internal interfaces to establish in the implementation line:
 - `RuntimeSupervisor`
 - `BundledPythonRuntime`
 
+Phase 2 public setup surface:
+
+- `setup_status`
+- `setup_prepare`
+
+Phase 2 setup item ids:
+
+- `engine_runtime`
+- `bundled_model`
+- `bundled_python`
+- `host_gimp`
+- `host_blender`
+- `host_libreoffice`
+
 Expected responsibilities:
 
 - `OwnedIntegration`: one provider-owned packaged integration bundle
@@ -133,7 +155,30 @@ Expected responsibilities:
 - `RuntimeSupervisor`: start/stop/check long-lived provider runtimes
 - `BundledPythonRuntime`: resolve packaged interpreter, wheels, and environment
 
-## 7. Mode-Specific Architecture
+## 7. Phase 2 Resource And State Layout
+
+Phase 2 establishes these packaged resource roots:
+
+- `resources/python/`
+- `resources/gimp/`
+- `resources/blender/`
+- `resources/libreoffice/`
+- `resources/models/`
+
+Each resource root must have a tracked manifest with:
+
+- `version`
+- `source`
+- `expectedPaths`
+- `status`
+
+Phase 2 also establishes app-local-data setup roots under:
+
+- `setup/python/`
+- `setup/state/`
+- `setup/logs/`
+
+## 8. Mode-Specific Architecture
 
 ### 7.1 Code
 
@@ -141,32 +186,32 @@ Expected responsibilities:
 - engine + bundled model only
 - remains on current inference path
 
-### 7.2 LibreOffice
+### 8.2 LibreOffice
 
 - host app remains external: LibreOffice / Collabora
 - bundled runtime scripts stay in unified resources
-- packaged Python runtime replaces system Python dependency
+- packaged Python runtime replaces system Python dependency in Phase 3
 - provider auto-launches `soffice` when needed
 - Writer and Slides remain side-effectful single-tool-turn modes
 - Calc stays scaffold-only
 
-### 7.3 Blender
+### 8.3 Blender
 
 - bridge server stays inside the unified app
 - addon payload becomes bundled unified-app-owned resource
-- provider auto-installs/enables addon in Blender profile
-- provider launches Blender when needed
+- provider auto-installs/enables addon in Blender profile in Phase 4
+- provider launches Blender when needed in Phase 4
 - addon-facing token-file contract remains unchanged
 
-### 7.4 GIMP
+### 8.4 GIMP
 
 - provider transport stays TCP on `127.0.0.1:10008`
 - self-contained line vendors a pinned `gimp-mcp` snapshot
 - plugin/server payload becomes bundled unified-app-owned resource
-- provider provisions plugin files into the GIMP profile
-- provider launches both GIMP and the bundled GIMP MCP runtime when needed
+- provider provisions plugin files into the GIMP profile in Phase 5
+- provider launches both GIMP and the bundled GIMP MCP runtime when needed in Phase 5
 
-## 8. Boot Flow
+## 9. Boot Flow
 
 On app launch:
 
@@ -177,7 +222,14 @@ On app launch:
 5. collect host-app presence status in background
 6. do not eagerly launch host apps unless explicitly configured later
 
-## 9. Mode Activation Flow
+Phase 2 stop-point:
+
+- steps 1, 4, and 5 are introduced now
+- step 2 stays as it already exists on the demo baseline
+- step 3 becomes a formal packaged-resource contract in Phase 2, not a new model-selection change
+- step 6 remains the rule
+
+## 10. Mode Activation Flow
 
 On first use of a live external mode:
 
@@ -188,7 +240,10 @@ On first use of a live external mode:
 5. provider reports live status and available tools
 6. assistant flow proceeds normally
 
-## 10. Deferred Architecture
+Phase 2 does not yet implement this full flow. It only adds the shared setup
+and readiness layer that later phases call into.
+
+## 11. Deferred Architecture
 
 Not part of this line:
 

--- a/docs/unified-assistant-self-contained-spec/CURRENT_STATE.md
+++ b/docs/unified-assistant-self-contained-spec/CURRENT_STATE.md
@@ -1,7 +1,7 @@
 # Current State
 
 **Last Updated:** 2026-03-17
-**Status:** Demo line frozen; self-contained delivery line opened
+**Status:** Demo line frozen; self-contained Phase 2 foundation is the current phase
 
 ## 1. Branch State
 
@@ -98,34 +98,63 @@ The self-contained delivery line must ship:
 | Blender     | Bridge already owned by unified app; addon still external         | Bundle and provision addon from repo source                 |
 | GIMP        | Unified provider exists, but runtime/plugin ownership is external | Vendor pinned upstream `gimp-mcp` snapshot and provision it |
 
-## 6. Step 1 Status
+## 6. Phase Status
 
-Step 1 of the self-contained plan is this docs line:
+### Phase 1
+
+Complete:
 
 - branch cut and freeze policy documented
-- new mainlines established
+- new self-contained mainlines established
 - self-contained master plan documented
 - architecture, packaging, model, and provenance rules documented
 
-No implementation branch should open on the self-contained line until this
-docs baseline is merged into both new mainlines.
+### Phase 1A
 
-## 7. Next Official Branch
+Complete:
 
-After this docs baseline merges through the new mainlines, the next branch is:
+- baseline cleanup docs merged into `docs/unified-assistant-self-contained-spec`
+- baseline cleanup sync merged into `dev/unified-assistant-self-contained`
+- docs-sync and status-sync workflow now documented as required branch policy
 
-- `codex/unified-self-contained-foundation-docs`
+### Phase 2
 
-That phase establishes:
+Current phase:
+
+- foundation docs are the active workstream
+- no implementation branch should open until the Phase 2 docs preflight is
+  merged into both self-contained mainlines
+
+## 7. Phase 2 Scope
+
+Phase 2 establishes the self-contained foundation only:
 
 - setup/provisioning subsystem
-- host-app detection
-- resource manifests
-- bundled Python ownership
-- bundled default model ownership
-- startup orchestration
+- host-app detection for GIMP, Blender, and LibreOffice
+- resource manifests for bundled assets
+- bundled Python ownership scaffolding
+- bundled default model ownership scaffolding
+- setup status and repair surface
 
-## 8. Known Risks
+Phase 2 does not yet include:
+
+- Blender addon provisioning
+- GIMP plugin/server provisioning
+- LibreOffice runtime switchover to bundled Python
+- host-app launch orchestration
+- Calc activation
+
+## 8. Next Official Branches
+
+The next required branch sequence is:
+
+1. `codex/unified-self-contained-foundation-docs`
+2. `codex/unified-self-contained-foundation-docs-sync`
+3. `codex/unified-self-contained-foundation`
+4. `codex/unified-self-contained-foundation-status-docs`
+5. `codex/unified-self-contained-foundation-status-sync`
+
+## 9. Known Risks
 
 | Risk                   | Why it matters                                                                                                   |
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------- |

--- a/docs/unified-assistant-self-contained-spec/IMPLEMENTATION_PHASES.md
+++ b/docs/unified-assistant-self-contained-spec/IMPLEMENTATION_PHASES.md
@@ -1,7 +1,7 @@
 # Self-Contained Delivery Phases
 
 **Last Updated:** 2026-03-17
-**Status:** Branch cut complete; baseline cleanup is the current phase
+**Status:** Branch cut and baseline cleanup complete; Phase 2 foundation docs are current
 
 ## Phase 0: Demo Freeze And Branch Cut
 
@@ -69,29 +69,43 @@
 
 1. `codex/unified-self-contained-foundation-docs`
 2. merge into `docs/unified-assistant-self-contained-spec`
-3. merge docs into `dev/unified-assistant-self-contained`
-4. `codex/unified-self-contained-foundation`
-5. merge into `dev/unified-assistant-self-contained`
-6. `codex/unified-self-contained-foundation-status-docs`
-7. merge into `docs/unified-assistant-self-contained-spec`
-8. merge docs into `dev/unified-assistant-self-contained`
+3. `codex/unified-self-contained-foundation-docs-sync`
+4. merge into `dev/unified-assistant-self-contained`
+5. `codex/unified-self-contained-foundation`
+6. merge into `dev/unified-assistant-self-contained`
+7. `codex/unified-self-contained-foundation-status-docs`
+8. merge into `docs/unified-assistant-self-contained-spec`
+9. `codex/unified-self-contained-foundation-status-sync`
+10. merge into `dev/unified-assistant-self-contained`
 
 **Scope**
 
 - setup/provisioning subsystem
 - host-app detection for GIMP, Blender, LibreOffice
 - resource version manifests
-- bundled app-private Python ownership
-- one bundled default model
-- startup orchestration for engine and model
+- bundled app-private Python ownership scaffolding
+- one bundled default model ownership scaffolding
 - setup status/repair surface
+- packaged resource contract for Python and models
+
+**Locked Phase 2 non-goals**
+
+- no mode activation changes
+- no Blender addon provisioning yet
+- no GIMP plugin/server provisioning yet
+- no LibreOffice runtime switchover yet
+- no host-app launch orchestration yet
+- no Calc activation
+- no GitHub workflow redesign
 
 **Exit criteria**
 
-- fresh install requires no system Python
-- engine auto-starts
-- bundled default model resolves from packaged resources
-- setup layer reports host-app, provisioned-asset, and runtime readiness state honestly
+- setup subsystem exists in the implementation line
+- `setup_status` and `setup_prepare` exist
+- setup layer reports host-app and bundled-asset readiness honestly
+- packaged resource contracts for bundled Python and the default model are established
+- existing Code, GIMP, Blender, Writer, and Slides behavior remains unchanged
+- Calc remains explicitly out of scope
 
 ## Phase 3: LibreOffice Self-Contained Runtime
 

--- a/docs/unified-assistant-self-contained-spec/MCP_INTEGRATION.md
+++ b/docs/unified-assistant-self-contained-spec/MCP_INTEGRATION.md
@@ -8,6 +8,9 @@
 This document defines how each non-Code mode becomes self-contained without
 changing the public assistant command surface.
 
+Phase 2 foundation adds app-level setup commands and setup state, but it does
+not change live mode activation behavior.
+
 Public command surface remains:
 
 - `list_modes`
@@ -29,6 +32,9 @@ New app-level setup commands are added separately:
 | `local`       | Code                       | app-owned engine only                                 |
 | `mcp`         | GIMP, Writer, Calc, Slides | app-owned runtime or transport plus external host app |
 | `hybrid`      | Blender                    | app-owned bridge plus provisioned addon               |
+
+Phase 2 keeps the existing live provider behavior intact while adding the
+shared setup/provisioning substrate those providers will later consume.
 
 ## 3. Stable Provider Interface
 
@@ -126,16 +132,33 @@ Ownership rules:
 `setup_status` should expose:
 
 - host app detected/missing
-- provider assets provisioned/outdated/missing
-- provider runtime ready/not ready
+- bundled foundation assets ready/missing/not prepared
 - repair action availability
+
+Phase 2 setup item ids are locked to:
+
+- `engine_runtime`
+- `bundled_model`
+- `bundled_python`
+- `host_gimp`
+- `host_blender`
+- `host_libreoffice`
 
 `setup_prepare` should:
 
-- provision missing bundled assets
-- validate packaged runtime resources
-- repair version drift when safe
-- never silently mutate user profile state without explicit provider/setup intent
+- validate manifests
+- prepare app-local setup directories
+- extract or install the bundled Python runtime when packaged payloads are present
+- validate the packaged model manifest and resource path
+- refresh host-app detection state
+
+`setup_prepare` must not in Phase 2:
+
+- provision Blender addons
+- provision GIMP plugins
+- edit Blender or GIMP user profiles
+- launch GIMP, Blender, or LibreOffice
+- replace `mode_refresh_tools`
 
 ## 7. Provisioning Rules
 
@@ -151,6 +174,9 @@ Expected provisioners:
 - `LibreOfficeProvisioner`
 - `BlenderAddonProvisioner`
 - `GimpPluginProvisioner`
+
+Phase 2 only establishes the shared provisioning foundation. It does not ship
+mode-specific provisioners yet.
 
 ## 8. Runtime Supervision Rules
 
@@ -169,6 +195,10 @@ Expected supervisors:
 - LibreOffice runtime supervisor
 - Blender bridge supervisor
 - GIMP MCP runtime supervisor
+
+Phase 2 introduces the shared setup state and packaged-resource validation
+needed before those provider-specific supervisors take ownership in later
+phases.
 
 ## 9. Non-Goals In This Line
 

--- a/docs/unified-assistant-self-contained-spec/MODEL_STRATEGY.md
+++ b/docs/unified-assistant-self-contained-spec/MODEL_STRATEGY.md
@@ -36,6 +36,13 @@ That means:
 - the engine auto-start path resolves that model automatically
 - setup status can report if the packaged model is missing or damaged
 
+Phase 2 foundation requirement:
+
+- the packaged app must have a defined resource contract at `resources/models/`
+- the self-contained line keeps the current engine behavior that prefers a bundled
+  `resource_dir/models` when present
+- Phase 2 validates that contract; it does not change model ordering or inference DTOs
+
 ## 3. Fallback And Future Policy
 
 Allowed in the future, but not part of this finish line:
@@ -80,6 +87,12 @@ The self-contained line must validate:
 - engine startup can load the bundled default model
 - no external model setup is required
 - missing/damaged model resources produce honest setup status
+
+Phase 2 additionally requires:
+
+- build-artifact staging for the bundled model is defined and scripted
+- packaged artifact selection for `qwen3-4b-instruct-2507` is pinned and reviewable
+- Windows runtime validation is still treated as required follow-up, not assumed complete
 
 ## 7. Deferred Questions
 

--- a/docs/unified-assistant-self-contained-spec/PACKAGING.md
+++ b/docs/unified-assistant-self-contained-spec/PACKAGING.md
@@ -45,6 +45,9 @@ The installer must not assume the user will separately install:
       host-data/
 ```
 
+Phase 2 adds the resource and manifest contract for `resources/models/` and
+`resources/python/`, but it does not yet ship the final packaged payloads.
+
 ## 4. Bundled Resource Categories
 
 | Resource group              | Needed for                          | Notes                                       |
@@ -71,6 +74,12 @@ Not external:
 - Python runtime
 - model provisioning
 
+Phase 2 stop-point:
+
+- host-app detection becomes real
+- host-app launch remains deferred
+- plugin/addon provisioning remains deferred
+
 ## 6. Packaging Invariants
 
 1. One installer.
@@ -90,6 +99,12 @@ Packaged builds must support:
 - version markers so upgrades can reapply only when required
 - repair flow through setup commands/UI
 
+Phase 2 establishes the manifest and staging-hook contract behind those goals:
+
+- tracked resource manifests under each provider-owned resource root
+- staging scripts for bundled model and bundled Python payloads
+- setup commands that validate packaged resource presence without mutating host-app profiles
+
 ## 8. Validation Checklist
 
 Before calling the self-contained line ready, verify on Windows:
@@ -104,6 +119,13 @@ Before calling the self-contained line ready, verify on Windows:
 8. first GIMP use provisions plugin/server and launches GIMP
 9. Calc remains disabled
 10. upgrade path preserves chats and reprovisions only when asset version changed
+
+Phase 2 validation focuses on:
+
+1. packaged resource manifests resolve honestly
+2. setup status reports missing vs ready foundation items
+3. setup prepare does not launch host apps
+4. existing live mode behavior does not regress
 
 ## 9. Deferred Packaging Questions
 

--- a/docs/unified-assistant-self-contained-spec/README.md
+++ b/docs/unified-assistant-self-contained-spec/README.md
@@ -76,7 +76,8 @@ Never branch new self-contained work from the frozen demo branches.
 1. [ARCHITECTURE.md](ARCHITECTURE.md)
 2. [MCP_INTEGRATION.md](MCP_INTEGRATION.md)
 3. [PACKAGING.md](PACKAGING.md)
-4. [THIRD_PARTY_PROVENANCE.md](THIRD_PARTY_PROVENANCE.md)
+4. [SETUP_SPEC.md](SETUP_SPEC.md)
+5. [THIRD_PARTY_PROVENANCE.md](THIRD_PARTY_PROVENANCE.md)
 
 ### Runtime / model work
 
@@ -90,7 +91,8 @@ Never branch new self-contained work from the frozen demo branches.
 1. [CURRENT_STATE.md](CURRENT_STATE.md)
 2. [GIT_WORKFLOW.md](GIT_WORKFLOW.md)
 3. [IMPLEMENTATION_PHASES.md](IMPLEMENTATION_PHASES.md)
-4. [SELF_CONTAINED_PLAN.md](SELF_CONTAINED_PLAN.md)
+4. [SETUP_SPEC.md](SETUP_SPEC.md)
+5. [SELF_CONTAINED_PLAN.md](SELF_CONTAINED_PLAN.md)
 
 ### Historical carried-over references
 
@@ -113,6 +115,7 @@ self-contained roadmap phases.
 | [MCP_INTEGRATION.md](MCP_INTEGRATION.md)               | Mode-by-mode integration ownership, transports, and runtime supervision rules     |
 | [PACKAGING.md](PACKAGING.md)                           | Packaged layout, bundled runtime rules, and Windows validation checklist          |
 | [MODEL_STRATEGY.md](MODEL_STRATEGY.md)                 | Bundled default model decision and future model packaging policy                  |
+| [SETUP_SPEC.md](SETUP_SPEC.md)                         | App-level setup subsystem, public setup DTOs, setup commands, and Phase 2 limits  |
 | [SELF_CONTAINED_PLAN.md](SELF_CONTAINED_PLAN.md)       | Master roadmap from demo baseline to externally usable self-contained app         |
 | [THIRD_PARTY_PROVENANCE.md](THIRD_PARTY_PROVENANCE.md) | Pinned source, license, and modification tracking for imported third-party assets |
 | [GIT_WORKFLOW.md](GIT_WORKFLOW.md)                     | Required branch policy for the self-contained line                                |
@@ -137,6 +140,15 @@ self-contained roadmap phases.
 | Blender integration   | Reuse existing repo addon source; provision automatically              |
 | GIMP integration      | Vendor pinned upstream `gimp-mcp` snapshot and provision automatically |
 | Provenance            | Mandatory before bundling imported third-party runtime assets          |
+
+## Current Phase
+
+The current active docs-first phase is Phase 2 foundation:
+
+- add the setup subsystem and app-level setup UI surface
+- add host-app detection
+- add bundled Python and model ownership scaffolding
+- keep current live mode behavior unchanged
 
 ## Rule Of Thumb
 

--- a/docs/unified-assistant-self-contained-spec/RESOURCES.md
+++ b/docs/unified-assistant-self-contained-spec/RESOURCES.md
@@ -27,6 +27,22 @@ not changed since then.
 | Bundled Python packaging    | `uv`, `uv tool`, `uv pip`, and packaged wheel/runtime inputs                                     | This is the planned app-private Python foundation for LibreOffice first, and likely for GIMP-side runtime ownership later.                 |
 | Bundled model packaging     | Engine model registry plus packaged resource layout under `apps/codehelper/src-tauri/resources/` | The self-contained finish line requires shipping a default model payload instead of expecting external model installation.                 |
 
+Phase 2 adds the first tracked packaged-resource manifests for:
+
+- `apps/codehelper/src-tauri/resources/python/`
+- `apps/codehelper/src-tauri/resources/gimp/`
+- `apps/codehelper/src-tauri/resources/blender/`
+- `apps/codehelper/src-tauri/resources/libreoffice/`
+- `apps/codehelper/src-tauri/resources/models/`
+
+Re-verify any upstream resource or toolchain link relied on by a new phase
+before opening that phase's docs branch. This is especially important for:
+
+- Python packaging inputs
+- Blender CLI/bootstrap behavior
+- GIMP plugin/runtime provenance
+- Windows packaging/runtime assumptions
+
 ---
 
 ## Table of Contents

--- a/docs/unified-assistant-self-contained-spec/SETUP_SPEC.md
+++ b/docs/unified-assistant-self-contained-spec/SETUP_SPEC.md
@@ -1,0 +1,181 @@
+# Setup Subsystem Spec
+
+**Last Updated:** 2026-03-17
+**Status:** Phase 2 foundation contract
+
+## 1. Purpose
+
+The setup subsystem is the app-level foundation for self-contained delivery.
+
+It does three things:
+
+- reports whether the app-owned foundation pieces are ready
+- prepares app-local setup state when bundled payloads are available
+- gives later provider-specific provisioning phases one shared place to plug into
+
+It is not a replacement for per-mode `mode_status`.
+
+## 2. Phase 2 Scope
+
+Phase 2 setup work is limited to:
+
+- app-level setup state
+- setup commands
+- host-app detection
+- packaged resource manifest validation
+- bundled Python preparation scaffolding
+- bundled model readiness validation
+- one lightweight setup banner and setup panel
+
+Phase 2 setup work does not include:
+
+- Blender addon provisioning
+- GIMP plugin/server provisioning
+- host-app launch
+- LibreOffice runtime switchover to bundled Python
+- any mode activation change
+
+## 3. Public Commands
+
+Phase 2 adds:
+
+- `setup_status`
+- `setup_prepare`
+
+### `setup_status`
+
+Returns the current app-level setup snapshot.
+
+### `setup_prepare`
+
+Prepares the app-owned foundation items that can be prepared in Phase 2, then
+returns the updated app-level setup snapshot.
+
+`setup_prepare` in Phase 2 must:
+
+- validate tracked resource manifests
+- create app-local setup directories
+- prepare bundled Python from packaged payloads when present
+- validate the packaged model resource contract
+- refresh host-app detection
+
+`setup_prepare` in Phase 2 must not:
+
+- launch GIMP, Blender, or LibreOffice
+- mutate Blender or GIMP user profiles
+- provision addons or plugins
+- replace existing mode-specific commands
+
+## 4. Public DTOs
+
+```ts
+type SetupItemState = 'ready' | 'missing' | 'not_prepared' | 'error';
+
+interface SetupItemDto {
+	id: string;
+	label: string;
+	state: SetupItemState;
+	detail: string | null;
+	required: boolean;
+	canPrepare: boolean;
+}
+
+interface SetupStatusDto {
+	overallState: 'ready' | 'needs_attention' | 'error';
+	items: SetupItemDto[];
+	lastError: string | null;
+}
+```
+
+## 5. Locked Phase 2 Setup Item Ids
+
+Phase 2 uses these item ids and no others:
+
+- `engine_runtime`
+- `bundled_model`
+- `bundled_python`
+- `host_gimp`
+- `host_blender`
+- `host_libreoffice`
+
+Expected meanings:
+
+- `engine_runtime`: current engine runtime path contract is usable
+- `bundled_model`: packaged default model manifest and resource path resolve
+- `bundled_python`: packaged Python manifest exists and the app-local runtime is ready or prepare-able
+- `host_gimp`: GIMP install detected or missing
+- `host_blender`: Blender install detected or missing
+- `host_libreoffice`: LibreOffice / Collabora install detected or missing
+
+## 6. Setup State Rules
+
+The setup subsystem is app-level, not mode-level.
+
+That means:
+
+- setup state can show that the app needs attention without breaking shell load
+- host-app absence is reported honestly, not as a fatal app startup error
+- modes continue to use their own provider status and error paths
+- Phase 2 keeps current mode composer availability unchanged
+
+## 7. Detection Rules
+
+Windows host-app detection order:
+
+1. cached resolved path from setup state, if still valid
+2. Windows App Paths or registry lookup when available
+3. standard install directories
+4. `PATH` lookup
+
+Phase 2 detection is read-only:
+
+- it does not launch host apps
+- it does not repair host app installs
+- it does not write provider-specific user-profile files
+
+## 8. Resource And App-Local Layout
+
+Phase 2 resource roots:
+
+- `resources/python/`
+- `resources/gimp/`
+- `resources/blender/`
+- `resources/libreoffice/`
+- `resources/models/`
+
+Each root must have a tracked manifest with:
+
+- `version`
+- `source`
+- `expectedPaths`
+- `status`
+
+Phase 2 app-local setup roots:
+
+- `setup/python/`
+- `setup/state/`
+- `setup/logs/`
+
+## 9. Frontend Contract
+
+Phase 2 adds:
+
+- one background setup-store initialization
+- one setup banner when `overallState !== 'ready'`
+- one setup panel with item-level detail and a single `Prepare` action
+
+The setup surface must remain lightweight:
+
+- no settings page migration
+- no blocking first-run wizard
+- no mode routing changes
+- no chat partitioning changes
+
+## 10. Later-Phase Handoff
+
+Later phases build on this subsystem:
+
+- Phase 3: LibreOffice uses bundled Python ownership from setup
+- Phase 4: Blender addon provisioning plugs into setup/provision state
+- Phase 5: GIMP plugin/server provisioning plugs into setup/provision state
+- Phase 6: packaged release validation uses setup status as the first-run and repair surface

--- a/docs/unified-assistant-self-contained-spec/THIRD_PARTY_PROVENANCE.md
+++ b/docs/unified-assistant-self-contained-spec/THIRD_PARTY_PROVENANCE.md
@@ -29,6 +29,17 @@ Required fields:
 | Bundled `uv` tooling/runtime support           | packaging-side toolchain                                                                           | pending        | pending                                                           | not yet added                             | Phase 2 foundation import                                                                   |
 | Default bundled model `qwen3-4b-instruct-2507` | current engine-supported model artifact source                                                     | pending        | pending                                                           | not yet bundled                           | Phase 2 foundation import; exact packaged artifact validation is still required             |
 
+## Phase 2 Provenance Rule
+
+Phase 2 may add manifests and staging hooks for bundled Python and the default
+model, but it should not silently treat those artifacts as fully cleared for
+release packaging. The tracker must stay honest about:
+
+- exact pinned packaged artifact source
+- license review status
+- whether the payload is committed, staged at build time, or still pending
+- whether Windows packaged validation has actually been performed
+
 ## Per-Component Template
 
 ### Component Name


### PR DESCRIPTION
## Summary\n- lock the Phase 2 foundation scope on the self-contained docs line\n- add the setup subsystem contract and setup DTO/command expectations\n- clarify packaging, provenance, and phase boundaries before implementation\n\n## Testing\n- npx prettier --check docs/unified-assistant-self-contained-spec/*.md\n- per-file npx prettier --check on changed docs