### PR TITLE
feat(self-contained): add phase 2 setup foundation

### DIFF
--- a/apps/codehelper/scripts/self-contained/stage-bundled-model.mjs
+++ b/apps/codehelper/scripts/self-contained/stage-bundled-model.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const source = process.env.SMOLPC_BUNDLED_MODEL_SOURCE;
+if (!source) {
+	console.error('SMOLPC_BUNDLED_MODEL_SOURCE is required');
+	process.exit(1);
+}
+
+const repoRoot = path.resolve(import.meta.dirname, '..', '..', '..', '..');
+const targetRoot = path.join(
+	repoRoot,
+	'apps',
+	'codehelper',
+	'src-tauri',
+	'resources',
+	'models',
+	'qwen3-4b-instruct-2507'
+);
+
+await fs.rm(targetRoot, { recursive: true, force: true });
+await fs.mkdir(path.dirname(targetRoot), { recursive: true });
+await fs.cp(source, targetRoot, { recursive: true });
+console.log(`Staged bundled model into ${targetRoot}`);

--- a/apps/codehelper/scripts/self-contained/stage-python-runtime.mjs
+++ b/apps/codehelper/scripts/self-contained/stage-python-runtime.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const source = process.env.SMOLPC_BUNDLED_PYTHON_SOURCE;
+if (!source) {
+	console.error('SMOLPC_BUNDLED_PYTHON_SOURCE is required');
+	process.exit(1);
+}
+
+const repoRoot = path.resolve(import.meta.dirname, '..', '..', '..', '..');
+const targetRoot = path.join(
+	repoRoot,
+	'apps',
+	'codehelper',
+	'src-tauri',
+	'resources',
+	'python',
+	'payload'
+);
+
+await fs.rm(targetRoot, { recursive: true, force: true });
+await fs.mkdir(path.dirname(targetRoot), { recursive: true });
+await fs.cp(source, targetRoot, { recursive: true });
+console.log(`Staged bundled Python payload into ${targetRoot}`);

--- a/apps/codehelper/scripts/self-contained/validate-resource-manifests.mjs
+++ b/apps/codehelper/scripts/self-contained/validate-resource-manifests.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const resourceRoots = ['python', 'gimp', 'blender', 'libreoffice', 'models'];
+
+const repoRoot = path.resolve(import.meta.dirname, '..', '..', '..', '..');
+const resourcesRoot = path.join(repoRoot, 'apps', 'codehelper', 'src-tauri', 'resources');
+
+async function validateManifest(resourceName) {
+	const resourceRoot = path.join(resourcesRoot, resourceName);
+	const manifestPath = path.join(resourceRoot, 'manifest.json');
+	const raw = await fs.readFile(manifestPath, 'utf8');
+	const manifest = JSON.parse(raw);
+
+	for (const field of ['version', 'source', 'expectedPaths', 'status']) {
+		if (!(field in manifest)) {
+			throw new Error(`${resourceName}: manifest missing required field '${field}'`);
+		}
+	}
+
+	if (!Array.isArray(manifest.expectedPaths) || manifest.expectedPaths.length === 0) {
+		throw new Error(`${resourceName}: expectedPaths must be a non-empty array`);
+	}
+
+	return {
+		resourceName,
+		manifest
+	};
+}
+
+async function main() {
+	const results = await Promise.all(resourceRoots.map(validateManifest));
+	for (const { resourceName, manifest } of results) {
+		console.log(
+			`${resourceName}: version=${manifest.version} status=${manifest.status} expectedPaths=${manifest.expectedPaths.join(',')}`
+		);
+	}
+}
+
+main().catch((error) => {
+	console.error(error.message);
+	process.exitCode = 1;
+});

--- a/apps/codehelper/src-tauri/resources/blender/README.md
+++ b/apps/codehelper/src-tauri/resources/blender/README.md
@@ -1,0 +1,7 @@
+# Blender Bundled Resource Root
+
+This directory already contains bundled Blender-side resources used by the
+unified app.
+
+Phase 2 adds the tracked resource manifest here so later self-contained phases
+can version and provision Blender-owned assets explicitly.

--- a/apps/codehelper/src-tauri/resources/blender/manifest.json
+++ b/apps/codehelper/src-tauri/resources/blender/manifest.json
@@ -1,0 +1,6 @@
+{
+  "version": "phase2-foundation-placeholder",
+  "source": "in-repo blender resources",
+  "expectedPaths": ["README.md", "rag_system"],
+  "status": "tracked"
+}

--- a/apps/codehelper/src-tauri/resources/gimp/README.md
+++ b/apps/codehelper/src-tauri/resources/gimp/README.md
@@ -1,0 +1,6 @@
+# GIMP Bundled Resource Placeholder
+
+This directory will hold the bundled GIMP plugin and MCP server payload for the
+self-contained line.
+
+Phase 2 only establishes the tracked resource root and manifest.

--- a/apps/codehelper/src-tauri/resources/gimp/manifest.json
+++ b/apps/codehelper/src-tauri/resources/gimp/manifest.json
@@ -1,0 +1,6 @@
+{
+  "version": "phase2-foundation-placeholder",
+  "source": "pending pinned gimp-mcp import",
+  "expectedPaths": ["README.md"],
+  "status": "placeholder"
+}

--- a/apps/codehelper/src-tauri/resources/libreoffice/README.md
+++ b/apps/codehelper/src-tauri/resources/libreoffice/README.md
@@ -1,0 +1,7 @@
+# LibreOffice Bundled Resource Root
+
+This directory already contains the bundled LibreOffice MCP runtime scripts used
+by the unified app.
+
+Phase 2 adds the tracked resource manifest here so later self-contained phases
+can manage packaged ownership explicitly.

--- a/apps/codehelper/src-tauri/resources/libreoffice/manifest.json
+++ b/apps/codehelper/src-tauri/resources/libreoffice/manifest.json
@@ -1,0 +1,6 @@
+{
+  "version": "phase2-foundation-placeholder",
+  "source": "imported libreoffice runtime scripts",
+  "expectedPaths": ["README.md", "mcp_server"],
+  "status": "tracked"
+}

--- a/apps/codehelper/src-tauri/resources/models/README.md
+++ b/apps/codehelper/src-tauri/resources/models/README.md
@@ -1,0 +1,7 @@
+# Bundled Model Placeholder
+
+This directory defines the packaged resource contract for the bundled default
+model on the self-contained line.
+
+Phase 2 locks the default model id and the staging contract here, but the model
+payload itself is staged at build or release time rather than committed into git.

--- a/apps/codehelper/src-tauri/resources/models/manifest.json
+++ b/apps/codehelper/src-tauri/resources/models/manifest.json
@@ -1,0 +1,6 @@
+{
+  "version": "phase2-foundation-placeholder",
+  "source": "qwen3-4b-instruct-2507 staging contract",
+  "expectedPaths": ["README.md", "qwen3-4b-instruct-2507"],
+  "status": "placeholder"
+}

--- a/apps/codehelper/src-tauri/resources/python/README.md
+++ b/apps/codehelper/src-tauri/resources/python/README.md
@@ -1,0 +1,12 @@
+# Bundled Python Placeholder
+
+This directory defines the packaged resource contract for the app-private
+Python runtime used by the self-contained line.
+
+Phase 2 tracks the manifest and staging contract here, but it does not commit
+the final large runtime payload into git history.
+
+Expected future staged contents:
+
+- `payload/`
+- runtime wheels or environment inputs needed for bundled execution

--- a/apps/codehelper/src-tauri/resources/python/manifest.json
+++ b/apps/codehelper/src-tauri/resources/python/manifest.json
@@ -1,0 +1,6 @@
+{
+  "version": "phase2-foundation-placeholder",
+  "source": "self-contained staging contract",
+  "expectedPaths": ["README.md", "payload"],
+  "status": "placeholder"
+}

--- a/apps/codehelper/src-tauri/src/commands/mod.rs
+++ b/apps/codehelper/src-tauri/src/commands/mod.rs
@@ -6,3 +6,4 @@ pub mod errors;
 pub mod hardware;
 pub mod inference;
 pub mod modes;
+pub mod setup;

--- a/apps/codehelper/src-tauri/src/commands/setup.rs
+++ b/apps/codehelper/src-tauri/src/commands/setup.rs
@@ -1,0 +1,12 @@
+use crate::setup::{collect_setup_status, prepare_setup, SetupState};
+use smolpc_assistant_types::SetupStatusDto;
+
+#[tauri::command]
+pub async fn setup_status(state: tauri::State<'_, SetupState>) -> Result<SetupStatusDto, String> {
+    Ok(collect_setup_status(&state).await)
+}
+
+#[tauri::command]
+pub async fn setup_prepare(state: tauri::State<'_, SetupState>) -> Result<SetupStatusDto, String> {
+    Ok(prepare_setup(&state).await)
+}

--- a/apps/codehelper/src-tauri/src/lib.rs
+++ b/apps/codehelper/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod commands;
 mod hardware;
 mod modes;
 mod security;
+mod setup;
 
 use assistant::state::AssistantState;
 use commands::assistant::{assistant_cancel, assistant_send, mode_undo};
@@ -18,7 +19,9 @@ use commands::inference::{
     set_inference_runtime_mode, unload_model, InferenceState,
 };
 use commands::modes::{list_modes, mode_refresh_tools, mode_status};
+use commands::setup::{setup_prepare, setup_status};
 use modes::registry::ModeProviderRegistry;
+use setup::SetupState;
 use tauri::Manager;
 #[allow(clippy::missing_panics_doc)]
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -48,6 +51,10 @@ pub fn run() {
                     None
                 }
             };
+            app.manage(SetupState::new(
+                resource_dir.clone(),
+                app_local_data_dir.clone(),
+            ));
             app.manage(ModeProviderRegistry::new(resource_dir, app_local_data_dir));
             Ok(())
         })
@@ -78,6 +85,8 @@ pub fn run() {
             set_inference_runtime_mode,
             engine_ensure_started,
             engine_status,
+            setup_status,
+            setup_prepare,
             list_modes,
             mode_status,
             mode_refresh_tools,
@@ -110,6 +119,9 @@ mod tests {
             .iter()
             .any(|entry| entry == "resources/libreoffice"));
         assert!(resources.iter().any(|entry| entry == "resources/blender"));
+        assert!(resources.iter().any(|entry| entry == "resources/gimp"));
+        assert!(resources.iter().any(|entry| entry == "resources/python"));
+        assert!(resources.iter().any(|entry| entry == "resources/models"));
         assert!(!resources.iter().any(|entry| {
             entry
                 .as_str()

--- a/apps/codehelper/src-tauri/src/setup/host_apps.rs
+++ b/apps/codehelper/src-tauri/src/setup/host_apps.rs
@@ -1,0 +1,271 @@
+use super::types::{
+    SETUP_ITEM_HOST_BLENDER, SETUP_ITEM_HOST_GIMP, SETUP_ITEM_HOST_LIBREOFFICE,
+};
+use std::collections::HashMap;
+use std::env;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HostAppDetection {
+    pub id: &'static str,
+    pub label: &'static str,
+    pub path: Option<PathBuf>,
+    pub detail: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+struct HostAppSpec {
+    id: &'static str,
+    label: &'static str,
+    executable_names: &'static [&'static str],
+    standard_paths: Vec<PathBuf>,
+}
+
+pub fn detect_all(cached: &HashMap<String, PathBuf>) -> Vec<HostAppDetection> {
+    all_specs()
+        .into_iter()
+        .map(|spec| detect_host_app(&spec, cached.get(spec.id)))
+        .collect()
+}
+
+fn detect_host_app(spec: &HostAppSpec, cached: Option<&PathBuf>) -> HostAppDetection {
+    let resolved = cached
+        .filter(|path| path.exists())
+        .cloned()
+        .or_else(|| lookup_windows_app_paths(spec))
+        .or_else(|| lookup_standard_paths(spec))
+        .or_else(|| lookup_on_path(spec));
+
+    let detail = resolved.as_ref().map(|path| {
+        format!(
+            "{} detected at {}",
+            spec.label,
+            path.to_string_lossy()
+        )
+    });
+
+    HostAppDetection {
+        id: spec.id,
+        label: spec.label,
+        path: resolved,
+        detail,
+    }
+}
+
+fn all_specs() -> Vec<HostAppSpec> {
+    vec![
+        HostAppSpec {
+            id: SETUP_ITEM_HOST_GIMP,
+            label: "GIMP",
+            executable_names: if cfg!(windows) {
+                &["gimp-2.10.exe", "gimp.exe"]
+            } else {
+                &["gimp", "gimp-2.10"]
+            },
+            standard_paths: standard_paths_for_gimp(),
+        },
+        HostAppSpec {
+            id: SETUP_ITEM_HOST_BLENDER,
+            label: "Blender",
+            executable_names: if cfg!(windows) {
+                &["blender.exe"]
+            } else {
+                &["blender"]
+            },
+            standard_paths: standard_paths_for_blender(),
+        },
+        HostAppSpec {
+            id: SETUP_ITEM_HOST_LIBREOFFICE,
+            label: "LibreOffice",
+            executable_names: if cfg!(windows) {
+                &["soffice.exe"]
+            } else {
+                &["soffice"]
+            },
+            standard_paths: standard_paths_for_libreoffice(),
+        },
+    ]
+}
+
+fn program_files_candidates() -> Vec<PathBuf> {
+    ["ProgramFiles", "ProgramFiles(x86)"]
+        .into_iter()
+        .filter_map(env::var_os)
+        .map(PathBuf::from)
+        .collect()
+}
+
+fn standard_paths_for_gimp() -> Vec<PathBuf> {
+    if cfg!(windows) {
+        program_files_candidates()
+            .into_iter()
+            .flat_map(|root| {
+                [
+                    root.join("GIMP 2").join("bin").join("gimp-2.10.exe"),
+                    root.join("GIMP 3").join("bin").join("gimp-3.exe"),
+                ]
+            })
+            .collect()
+    } else if cfg!(target_os = "macos") {
+        vec![
+            PathBuf::from("/Applications/GIMP.app/Contents/MacOS/gimp"),
+            PathBuf::from("/opt/homebrew/bin/gimp"),
+        ]
+    } else {
+        vec![PathBuf::from("/usr/bin/gimp"), PathBuf::from("/usr/local/bin/gimp")]
+    }
+}
+
+fn standard_paths_for_blender() -> Vec<PathBuf> {
+    if cfg!(windows) {
+        program_files_candidates()
+            .into_iter()
+            .flat_map(|root| {
+                [
+                    root.join("Blender Foundation")
+                        .join("Blender 4.2")
+                        .join("blender.exe"),
+                    root.join("Blender Foundation")
+                        .join("Blender 4.1")
+                        .join("blender.exe"),
+                    root.join("Blender Foundation")
+                        .join("Blender 4.0")
+                        .join("blender.exe"),
+                ]
+            })
+            .collect()
+    } else if cfg!(target_os = "macos") {
+        vec![
+            PathBuf::from("/Applications/Blender.app/Contents/MacOS/Blender"),
+            PathBuf::from("/opt/homebrew/bin/blender"),
+        ]
+    } else {
+        vec![
+            PathBuf::from("/usr/bin/blender"),
+            PathBuf::from("/usr/local/bin/blender"),
+        ]
+    }
+}
+
+fn standard_paths_for_libreoffice() -> Vec<PathBuf> {
+    if cfg!(windows) {
+        program_files_candidates()
+            .into_iter()
+            .flat_map(|root| {
+                [
+                    root.join("LibreOffice").join("program").join("soffice.exe"),
+                    root.join("Collabora Office").join("program").join("soffice.exe"),
+                ]
+            })
+            .collect()
+    } else if cfg!(target_os = "macos") {
+        vec![
+            PathBuf::from("/Applications/LibreOffice.app/Contents/MacOS/soffice"),
+            PathBuf::from("/Applications/Collabora Office.app/Contents/MacOS/soffice"),
+        ]
+    } else {
+        vec![
+            PathBuf::from("/usr/bin/soffice"),
+            PathBuf::from("/usr/local/bin/soffice"),
+            PathBuf::from("/snap/bin/libreoffice"),
+        ]
+    }
+}
+
+fn lookup_standard_paths(spec: &HostAppSpec) -> Option<PathBuf> {
+    spec.standard_paths.iter().find(|path| path.exists()).cloned()
+}
+
+fn lookup_on_path(spec: &HostAppSpec) -> Option<PathBuf> {
+    let path_var = env::var_os("PATH")?;
+    env::split_paths(&path_var)
+        .flat_map(|dir| {
+            spec.executable_names
+                .iter()
+                .map(move |name| dir.join(name))
+                .collect::<Vec<_>>()
+        })
+        .find(|candidate| candidate.exists())
+}
+
+#[cfg(windows)]
+fn lookup_windows_app_paths(spec: &HostAppSpec) -> Option<PathBuf> {
+    for executable in spec.executable_names {
+        let key = format!(r"HKLM\Software\Microsoft\Windows\CurrentVersion\App Paths\{executable}");
+        let output = std::process::Command::new("reg")
+            .args(["query", &key, "/ve"])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            continue;
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if let Some(path) = parse_reg_query_path(&stdout) {
+            if path.exists() {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(windows)]
+fn parse_reg_query_path(stdout: &str) -> Option<PathBuf> {
+    stdout
+        .lines()
+        .find_map(|line| line.split("REG_SZ").nth(1))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+#[cfg(not(windows))]
+fn lookup_windows_app_paths(_spec: &HostAppSpec) -> Option<PathBuf> {
+    None
+}
+
+#[allow(dead_code)]
+fn _path_exists(path: &Path) -> bool {
+    path.exists()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{detect_host_app, HostAppSpec};
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    #[test]
+    fn cached_path_wins_when_it_still_exists() {
+        let temp = TempDir::new().expect("temp dir");
+        let executable = temp.path().join("blender.exe");
+        std::fs::write(&executable, "bin").expect("write executable");
+
+        let spec = HostAppSpec {
+            id: "host_blender",
+            label: "Blender",
+            executable_names: &["blender.exe"],
+            standard_paths: vec![],
+        };
+
+        let detection = detect_host_app(&spec, Some(&executable));
+        assert_eq!(detection.path, Some(executable));
+    }
+
+    #[test]
+    fn standard_path_is_used_when_cached_path_is_missing() {
+        let temp = TempDir::new().expect("temp dir");
+        let executable = temp.path().join("gimp.exe");
+        std::fs::write(&executable, "bin").expect("write executable");
+
+        let spec = HostAppSpec {
+            id: "host_gimp",
+            label: "GIMP",
+            executable_names: &["gimp.exe"],
+            standard_paths: vec![executable.clone()],
+        };
+
+        let detection = detect_host_app(&spec, Some(&PathBuf::from("/missing/gimp.exe")));
+        assert_eq!(detection.path, Some(executable));
+    }
+}

--- a/apps/codehelper/src-tauri/src/setup/launch.rs
+++ b/apps/codehelper/src-tauri/src/setup/launch.rs
@@ -1,0 +1,9 @@
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LaunchReadiness {
+    Deferred,
+}
+
+pub fn phase2_launch_detail() -> &'static str {
+    "Host-app launch orchestration is deferred until later self-contained phases."
+}

--- a/apps/codehelper/src-tauri/src/setup/manifests.rs
+++ b/apps/codehelper/src-tauri/src/setup/manifests.rs
@@ -1,0 +1,125 @@
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceManifest {
+    pub version: String,
+    pub source: String,
+    pub expected_paths: Vec<String>,
+    pub status: String,
+}
+
+pub fn resource_root(resource_dir: Option<&Path>, resource_name: &str) -> Result<PathBuf, String> {
+    let base = resource_dir.ok_or_else(|| "Tauri resource directory is unavailable".to_string())?;
+    let root = base.join(resource_name);
+    if root.exists() {
+        Ok(root)
+    } else {
+        Err(format!(
+            "Bundled resource root is missing: {}",
+            root.display()
+        ))
+    }
+}
+
+pub fn manifest_path(root: &Path) -> PathBuf {
+    root.join("manifest.json")
+}
+
+pub fn load_manifest(root: &Path) -> Result<ResourceManifest, String> {
+    let path = manifest_path(root);
+    let raw = std::fs::read_to_string(&path)
+        .map_err(|error| format!("Failed to read manifest {}: {error}", path.display()))?;
+    let manifest: ResourceManifest = serde_json::from_str(&raw)
+        .map_err(|error| format!("Failed to parse manifest {}: {error}", path.display()))?;
+    validate_manifest(&manifest)?;
+    Ok(manifest)
+}
+
+pub fn validate_manifest(manifest: &ResourceManifest) -> Result<(), String> {
+    if manifest.version.trim().is_empty() {
+        return Err("Manifest version must not be empty".to_string());
+    }
+    if manifest.source.trim().is_empty() {
+        return Err("Manifest source must not be empty".to_string());
+    }
+    if manifest.status.trim().is_empty() {
+        return Err("Manifest status must not be empty".to_string());
+    }
+    if manifest.expected_paths.is_empty() {
+        return Err("Manifest expectedPaths must not be empty".to_string());
+    }
+    if manifest
+        .expected_paths
+        .iter()
+        .any(|value| value.trim().is_empty())
+    {
+        return Err("Manifest expectedPaths entries must not be empty".to_string());
+    }
+    Ok(())
+}
+
+pub fn missing_expected_paths(root: &Path, manifest: &ResourceManifest) -> Vec<String> {
+    manifest
+        .expected_paths
+        .iter()
+        .filter(|relative| !root.join(relative.as_str()).exists())
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{load_manifest, missing_expected_paths, validate_manifest, ResourceManifest};
+    use tempfile::TempDir;
+
+    #[test]
+    fn validate_manifest_rejects_empty_values() {
+        let manifest = ResourceManifest {
+            version: "".to_string(),
+            source: "phase2".to_string(),
+            expected_paths: vec!["payload".to_string()],
+            status: "placeholder".to_string(),
+        };
+
+        let error = validate_manifest(&manifest).expect_err("validation should fail");
+        assert!(error.contains("version"));
+    }
+
+    #[test]
+    fn missing_expected_paths_reports_relative_entries() {
+        let temp = TempDir::new().expect("temp dir");
+        std::fs::create_dir_all(temp.path().join("payload")).expect("payload dir");
+
+        let manifest = ResourceManifest {
+            version: "1".to_string(),
+            source: "tests".to_string(),
+            expected_paths: vec!["payload".to_string(), "README.md".to_string()],
+            status: "placeholder".to_string(),
+        };
+
+        let missing = missing_expected_paths(temp.path(), &manifest);
+        assert_eq!(missing, vec!["README.md".to_string()]);
+    }
+
+    #[test]
+    fn load_manifest_parses_camel_case_file() {
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().join("manifest.json");
+        std::fs::write(
+            &path,
+            r#"{
+              "version": "phase2",
+              "source": "tests",
+              "expectedPaths": ["payload"],
+              "status": "placeholder"
+            }"#,
+        )
+        .expect("write manifest");
+
+        let manifest = load_manifest(temp.path()).expect("load manifest");
+        assert_eq!(manifest.version, "phase2");
+        assert_eq!(manifest.expected_paths, vec!["payload"]);
+    }
+}

--- a/apps/codehelper/src-tauri/src/setup/mod.rs
+++ b/apps/codehelper/src-tauri/src/setup/mod.rs
@@ -1,0 +1,13 @@
+pub mod host_apps;
+pub mod launch;
+pub mod manifests;
+pub mod models;
+pub mod provision;
+pub mod python;
+pub mod state;
+pub mod status;
+pub mod types;
+
+pub use provision::prepare_setup;
+pub use state::SetupState;
+pub use status::collect_setup_status;

--- a/apps/codehelper/src-tauri/src/setup/models.rs
+++ b/apps/codehelper/src-tauri/src/setup/models.rs
@@ -1,0 +1,106 @@
+use super::manifests::{load_manifest, missing_expected_paths, resource_root};
+use super::types::{DEFAULT_BUNDLED_MODEL_ID, SETUP_ITEM_BUNDLED_MODEL};
+use smolpc_assistant_types::{SetupItemDto, SetupItemStateDto};
+use std::path::Path;
+
+pub fn bundled_model_item(resource_dir: Option<&Path>) -> SetupItemDto {
+    let detail_prefix = "Bundled default model";
+    match resource_root(resource_dir, "models") {
+        Ok(root) => match load_manifest(&root) {
+            Ok(manifest) => {
+                let missing = missing_expected_paths(&root, &manifest);
+                let default_model_path = root.join(DEFAULT_BUNDLED_MODEL_ID);
+                if !default_model_path.exists() {
+                    return SetupItemDto {
+                        id: SETUP_ITEM_BUNDLED_MODEL.to_string(),
+                        label: "Bundled model".to_string(),
+                        state: SetupItemStateDto::NotPrepared,
+                        detail: Some(format!(
+                            "{detail_prefix} is not staged yet. Missing {}",
+                            default_model_path.display()
+                        )),
+                        required: true,
+                        can_prepare: false,
+                    };
+                }
+
+                if !missing.is_empty() {
+                    return SetupItemDto {
+                        id: SETUP_ITEM_BUNDLED_MODEL.to_string(),
+                        label: "Bundled model".to_string(),
+                        state: SetupItemStateDto::NotPrepared,
+                        detail: Some(format!(
+                            "{detail_prefix} manifest is present, but staged paths are missing: {}",
+                            missing.join(", ")
+                        )),
+                        required: true,
+                        can_prepare: false,
+                    };
+                }
+
+                SetupItemDto {
+                    id: SETUP_ITEM_BUNDLED_MODEL.to_string(),
+                    label: "Bundled model".to_string(),
+                    state: SetupItemStateDto::Ready,
+                    detail: Some(format!(
+                        "{detail_prefix} is staged at {}",
+                        default_model_path.display()
+                    )),
+                    required: true,
+                    can_prepare: false,
+                }
+            }
+            Err(error) => SetupItemDto {
+                id: SETUP_ITEM_BUNDLED_MODEL.to_string(),
+                label: "Bundled model".to_string(),
+                state: SetupItemStateDto::Missing,
+                detail: Some(error),
+                required: true,
+                can_prepare: false,
+            },
+        },
+        Err(error) => SetupItemDto {
+            id: SETUP_ITEM_BUNDLED_MODEL.to_string(),
+            label: "Bundled model".to_string(),
+            state: SetupItemStateDto::Missing,
+            detail: Some(error),
+            required: true,
+            can_prepare: false,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::bundled_model_item;
+    use smolpc_assistant_types::SetupItemStateDto;
+    use tempfile::TempDir;
+
+    #[test]
+    fn bundled_model_item_reports_missing_manifest() {
+        let temp = TempDir::new().expect("temp dir");
+        let item = bundled_model_item(Some(temp.path()));
+        assert_eq!(item.state, SetupItemStateDto::Missing);
+    }
+
+    #[test]
+    fn bundled_model_item_reports_ready_when_manifest_and_model_exist() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = temp.path().join("models");
+        std::fs::create_dir_all(root.join("qwen3-4b-instruct-2507")).expect("create model dir");
+        std::fs::write(root.join("README.md"), "placeholder").expect("write readme");
+        std::fs::write(
+            root.join("manifest.json"),
+            r#"{
+              "version": "phase2",
+              "source": "tests",
+              "expectedPaths": ["README.md", "qwen3-4b-instruct-2507"],
+              "status": "staged"
+            }"#,
+        )
+        .expect("write manifest");
+
+        let item = bundled_model_item(Some(temp.path()));
+        assert_eq!(item.state, SetupItemStateDto::Ready);
+    }
+}

--- a/apps/codehelper/src-tauri/src/setup/provision.rs
+++ b/apps/codehelper/src-tauri/src/setup/provision.rs
@@ -1,0 +1,145 @@
+use super::python::prepare_bundled_python;
+use super::state::SetupState;
+use super::status::collect_setup_status;
+use std::path::Path;
+
+pub async fn prepare_setup(state: &SetupState) -> SetupResult {
+    let result = prepare_setup_inner(state);
+    {
+        let mut cache = state.cache().await;
+        cache.last_error = result.err();
+    }
+    collect_setup_status(state).await
+}
+
+type SetupResult = smolpc_assistant_types::SetupStatusDto;
+
+fn prepare_setup_inner(state: &SetupState) -> Result<(), String> {
+    let setup_root = state
+        .setup_root()
+        .ok_or_else(|| "Tauri app-local-data directory is unavailable".to_string())?;
+    prepare_setup_directories(&setup_root)?;
+    prepare_bundled_python(state.resource_dir(), state.app_local_data_dir())?;
+    Ok(())
+}
+
+fn prepare_setup_directories(setup_root: &Path) -> Result<(), String> {
+    for relative in ["python", "state", "logs"] {
+        let path = setup_root.join(relative);
+        std::fs::create_dir_all(&path)
+            .map_err(|error| format!("Failed to create setup directory {}: {error}", path.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::prepare_setup;
+    use crate::setup::state::SetupState;
+    use smolpc_assistant_types::SetupItemStateDto;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn prepare_setup_creates_app_local_directories_and_python_runtime() {
+        let resource_temp = TempDir::new().expect("resource temp");
+        let app_temp = TempDir::new().expect("app temp");
+        let python_root = resource_temp.path().join("python");
+        let models_root = resource_temp.path().join("models");
+        std::fs::create_dir_all(python_root.join("payload").join("bin")).expect("python payload");
+        std::fs::create_dir_all(&models_root).expect("models root");
+        std::fs::write(python_root.join("README.md"), "placeholder").expect("readme");
+        std::fs::write(python_root.join("payload").join("bin").join("python"), "python")
+            .expect("runtime file");
+        std::fs::write(
+            python_root.join("manifest.json"),
+            r#"{
+              "version": "phase2",
+              "source": "tests",
+              "expectedPaths": ["README.md", "payload"],
+              "status": "staged"
+            }"#,
+        )
+        .expect("manifest");
+        std::fs::write(
+            models_root.join("manifest.json"),
+            r#"{
+              "version": "phase2",
+              "source": "tests",
+              "expectedPaths": ["qwen3-4b-instruct-2507"],
+              "status": "placeholder"
+            }"#,
+        )
+        .expect("manifest");
+
+        let state = SetupState::new(
+            Some(resource_temp.path().to_path_buf()),
+            Some(app_temp.path().to_path_buf()),
+        );
+
+        let status = prepare_setup(&state).await;
+        assert!(app_temp.path().join("setup").join("python").exists());
+        assert!(app_temp.path().join("setup").join("state").exists());
+        assert!(app_temp.path().join("setup").join("logs").exists());
+        assert!(
+            app_temp
+                .path()
+                .join("setup")
+                .join("python")
+                .join("payload")
+                .join("bin")
+                .join("python")
+                .exists()
+        );
+        let python = status
+            .items
+            .iter()
+            .find(|item| item.id == "bundled_python")
+            .expect("python item");
+        assert_eq!(python.state, SetupItemStateDto::Ready);
+    }
+
+    #[tokio::test]
+    async fn prepare_setup_does_not_touch_external_user_profile_roots() {
+        let resource_temp = TempDir::new().expect("resource temp");
+        let app_temp = TempDir::new().expect("app temp");
+        let external_temp = TempDir::new().expect("external temp");
+        let gimp_profile = external_temp.path().join("gimp-profile");
+        let blender_profile = external_temp.path().join("blender-profile");
+
+        let python_root = resource_temp.path().join("python");
+        let models_root = resource_temp.path().join("models");
+        std::fs::create_dir_all(python_root.join("payload")).expect("python payload");
+        std::fs::create_dir_all(&models_root).expect("models root");
+        std::fs::write(python_root.join("README.md"), "placeholder").expect("readme");
+        std::fs::write(python_root.join("payload").join("python"), "python").expect("runtime");
+        std::fs::write(
+            python_root.join("manifest.json"),
+            r#"{
+              "version": "phase2",
+              "source": "tests",
+              "expectedPaths": ["README.md", "payload"],
+              "status": "staged"
+            }"#,
+        )
+        .expect("manifest");
+        std::fs::write(
+            models_root.join("manifest.json"),
+            r#"{
+              "version": "phase2",
+              "source": "tests",
+              "expectedPaths": ["qwen3-4b-instruct-2507"],
+              "status": "placeholder"
+            }"#,
+        )
+        .expect("manifest");
+
+        let state = SetupState::new(
+            Some(resource_temp.path().to_path_buf()),
+            Some(app_temp.path().to_path_buf()),
+        );
+        let _ = prepare_setup(&state).await;
+
+        assert!(!gimp_profile.exists());
+        assert!(!blender_profile.exists());
+    }
+}

--- a/apps/codehelper/src-tauri/src/setup/python.rs
+++ b/apps/codehelper/src-tauri/src/setup/python.rs
@@ -1,0 +1,224 @@
+use super::manifests::{load_manifest, missing_expected_paths, resource_root};
+use super::types::SETUP_ITEM_BUNDLED_PYTHON;
+use smolpc_assistant_types::{SetupItemDto, SetupItemStateDto};
+use std::path::{Path, PathBuf};
+
+const PREPARED_VERSION_FILE: &str = ".prepared-version";
+const README_FILE: &str = "README.md";
+const MANIFEST_FILE: &str = "manifest.json";
+
+pub fn bundled_python_item(
+    resource_dir: Option<&Path>,
+    app_local_data_dir: Option<&Path>,
+) -> SetupItemDto {
+    match resource_root(resource_dir, "python") {
+        Ok(root) => match load_manifest(&root) {
+            Ok(manifest) => {
+                let prepared_root = prepared_python_root(app_local_data_dir);
+                let missing = missing_expected_paths(&root, &manifest);
+
+                if prepared_version_matches(prepared_root.as_deref(), &manifest.version) {
+                    return SetupItemDto {
+                        id: SETUP_ITEM_BUNDLED_PYTHON.to_string(),
+                        label: "Bundled Python".to_string(),
+                        state: SetupItemStateDto::Ready,
+                        detail: prepared_root
+                            .map(|path| format!("Bundled Python is prepared at {}", path.display())),
+                        required: true,
+                        can_prepare: false,
+                    };
+                }
+
+                if !missing.is_empty() {
+                    return SetupItemDto {
+                        id: SETUP_ITEM_BUNDLED_PYTHON.to_string(),
+                        label: "Bundled Python".to_string(),
+                        state: SetupItemStateDto::NotPrepared,
+                        detail: Some(format!(
+                            "Bundled Python payload is not staged yet. Missing {}",
+                            missing.join(", ")
+                        )),
+                        required: true,
+                        can_prepare: false,
+                    };
+                }
+
+                SetupItemDto {
+                    id: SETUP_ITEM_BUNDLED_PYTHON.to_string(),
+                    label: "Bundled Python".to_string(),
+                    state: SetupItemStateDto::NotPrepared,
+                    detail: Some(
+                        "Bundled Python payload is staged and can be prepared into app-local setup state"
+                            .to_string(),
+                    ),
+                    required: true,
+                    can_prepare: app_local_data_dir.is_some(),
+                }
+            }
+            Err(error) => SetupItemDto {
+                id: SETUP_ITEM_BUNDLED_PYTHON.to_string(),
+                label: "Bundled Python".to_string(),
+                state: SetupItemStateDto::Missing,
+                detail: Some(error),
+                required: true,
+                can_prepare: false,
+            },
+        },
+        Err(error) => SetupItemDto {
+            id: SETUP_ITEM_BUNDLED_PYTHON.to_string(),
+            label: "Bundled Python".to_string(),
+            state: SetupItemStateDto::Missing,
+            detail: Some(error),
+            required: true,
+            can_prepare: false,
+        },
+    }
+}
+
+pub fn prepare_bundled_python(
+    resource_dir: Option<&Path>,
+    app_local_data_dir: Option<&Path>,
+) -> Result<(), String> {
+    let root = resource_root(resource_dir, "python")?;
+    let manifest = load_manifest(&root)?;
+    let missing = missing_expected_paths(&root, &manifest);
+    if !missing.is_empty() {
+        return Err(format!(
+            "Bundled Python payload is not staged yet. Missing {}",
+            missing.join(", ")
+        ));
+    }
+
+    let prepared_root = prepared_python_root(app_local_data_dir)
+        .ok_or_else(|| "Tauri app-local-data directory is unavailable".to_string())?;
+    std::fs::create_dir_all(&prepared_root).map_err(|error| {
+        format!(
+            "Failed to create bundled Python setup directory {}: {error}",
+            prepared_root.display()
+        )
+    })?;
+
+    copy_payload_entries(&root, &prepared_root)?;
+    std::fs::write(prepared_root.join(PREPARED_VERSION_FILE), manifest.version).map_err(|error| {
+        format!(
+            "Failed to write prepared Python version marker in {}: {error}",
+            prepared_root.display()
+        )
+    })?;
+
+    Ok(())
+}
+
+pub fn prepared_python_root(app_local_data_dir: Option<&Path>) -> Option<PathBuf> {
+    app_local_data_dir.map(|path| path.join("setup").join("python"))
+}
+
+fn prepared_version_matches(root: Option<&Path>, version: &str) -> bool {
+    let Some(root) = root else {
+        return false;
+    };
+    let marker = root.join(PREPARED_VERSION_FILE);
+    std::fs::read_to_string(marker)
+        .map(|value| value.trim() == version)
+        .unwrap_or(false)
+}
+
+fn copy_payload_entries(source_root: &Path, target_root: &Path) -> Result<(), String> {
+    for entry in std::fs::read_dir(source_root)
+        .map_err(|error| format!("Failed to read Python payload root {}: {error}", source_root.display()))?
+    {
+        let entry = entry.map_err(|error| format!("Failed to inspect Python payload entry: {error}"))?;
+        let path = entry.path();
+        let name = entry.file_name();
+        if name.to_str() == Some(MANIFEST_FILE) || name.to_str() == Some(README_FILE) {
+            continue;
+        }
+        let target = target_root.join(name);
+        copy_path_recursively(&path, &target)?;
+    }
+    Ok(())
+}
+
+fn copy_path_recursively(source: &Path, target: &Path) -> Result<(), String> {
+    let metadata = std::fs::metadata(source)
+        .map_err(|error| format!("Failed to stat {}: {error}", source.display()))?;
+    if metadata.is_dir() {
+        std::fs::create_dir_all(target)
+            .map_err(|error| format!("Failed to create directory {}: {error}", target.display()))?;
+        for entry in std::fs::read_dir(source)
+            .map_err(|error| format!("Failed to read directory {}: {error}", source.display()))?
+        {
+            let entry =
+                entry.map_err(|error| format!("Failed to inspect directory entry: {error}"))?;
+            copy_path_recursively(&entry.path(), &target.join(entry.file_name()))?;
+        }
+    } else {
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent).map_err(|error| {
+                format!("Failed to create parent directory {}: {error}", parent.display())
+            })?;
+        }
+        std::fs::copy(source, target).map_err(|error| {
+            format!(
+                "Failed to copy {} to {}: {error}",
+                source.display(),
+                target.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{bundled_python_item, prepare_bundled_python};
+    use smolpc_assistant_types::SetupItemStateDto;
+    use tempfile::TempDir;
+
+    #[test]
+    fn bundled_python_item_reports_not_prepared_when_payload_missing() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = temp.path().join("python");
+        std::fs::create_dir_all(&root).expect("python root");
+        std::fs::write(root.join("README.md"), "placeholder").expect("readme");
+        std::fs::write(
+            root.join("manifest.json"),
+            r#"{
+              "version": "phase2",
+              "source": "tests",
+              "expectedPaths": ["README.md", "payload"],
+              "status": "placeholder"
+            }"#,
+        )
+        .expect("manifest");
+
+        let item = bundled_python_item(Some(temp.path()), Some(temp.path()));
+        assert_eq!(item.state, SetupItemStateDto::NotPrepared);
+    }
+
+    #[test]
+    fn prepare_bundled_python_copies_staged_payload() {
+        let resource_temp = TempDir::new().expect("resource temp");
+        let app_temp = TempDir::new().expect("app temp");
+        let root = resource_temp.path().join("python");
+        std::fs::create_dir_all(root.join("payload").join("bin")).expect("payload");
+        std::fs::write(root.join("README.md"), "placeholder").expect("readme");
+        std::fs::write(root.join("payload").join("bin").join("python"), "python").expect("binary");
+        std::fs::write(
+            root.join("manifest.json"),
+            r#"{
+              "version": "phase2",
+              "source": "tests",
+              "expectedPaths": ["README.md", "payload"],
+              "status": "staged"
+            }"#,
+        )
+        .expect("manifest");
+
+        prepare_bundled_python(Some(resource_temp.path()), Some(app_temp.path())).expect("prepare");
+
+        let prepared_root = app_temp.path().join("setup").join("python");
+        assert!(prepared_root.join("payload").join("bin").join("python").exists());
+        assert!(prepared_root.join(".prepared-version").exists());
+    }
+}

--- a/apps/codehelper/src-tauri/src/setup/state.rs
+++ b/apps/codehelper/src-tauri/src/setup/state.rs
@@ -1,0 +1,49 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+#[derive(Debug, Default)]
+pub struct SetupCache {
+    pub resolved_host_apps: HashMap<String, PathBuf>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct SetupState {
+    resource_dir: Option<PathBuf>,
+    app_local_data_dir: Option<PathBuf>,
+    cache: Arc<Mutex<SetupCache>>,
+}
+
+impl Default for SetupState {
+    fn default() -> Self {
+        Self::new(None, None)
+    }
+}
+
+impl SetupState {
+    pub fn new(resource_dir: Option<PathBuf>, app_local_data_dir: Option<PathBuf>) -> Self {
+        Self {
+            resource_dir,
+            app_local_data_dir,
+            cache: Arc::new(Mutex::new(SetupCache::default())),
+        }
+    }
+
+    pub fn resource_dir(&self) -> Option<&Path> {
+        self.resource_dir.as_deref()
+    }
+
+    pub fn app_local_data_dir(&self) -> Option<&Path> {
+        self.app_local_data_dir.as_deref()
+    }
+
+    pub fn setup_root(&self) -> Option<PathBuf> {
+        self.app_local_data_dir().map(|path| path.join("setup"))
+    }
+
+    pub async fn cache(&self) -> tokio::sync::MutexGuard<'_, SetupCache> {
+        self.cache.lock().await
+    }
+}

--- a/apps/codehelper/src-tauri/src/setup/status.rs
+++ b/apps/codehelper/src-tauri/src/setup/status.rs
@@ -1,0 +1,181 @@
+use super::host_apps::{detect_all, HostAppDetection};
+use super::launch::phase2_launch_detail;
+use super::models::bundled_model_item;
+use super::python::bundled_python_item;
+use super::state::SetupState;
+use super::types::{
+    SETUP_ITEM_ENGINE_RUNTIME, SETUP_ITEM_HOST_BLENDER, SETUP_ITEM_HOST_GIMP,
+    SETUP_ITEM_HOST_LIBREOFFICE,
+};
+use smolpc_assistant_types::{
+    SetupItemDto, SetupItemStateDto, SetupOverallStateDto, SetupStatusDto,
+};
+
+pub async fn collect_setup_status(state: &SetupState) -> SetupStatusDto {
+    let detections = {
+        let mut cache = state.cache().await;
+        let detections = detect_all(&cache.resolved_host_apps);
+        cache.resolved_host_apps = detections
+            .iter()
+            .filter_map(|detection| {
+                detection
+                    .path
+                    .as_ref()
+                    .map(|path| (detection.id.to_string(), path.clone()))
+            })
+            .collect();
+        detections
+    };
+
+    let mut items = Vec::new();
+    items.push(engine_runtime_item(state));
+    items.push(bundled_model_item(state.resource_dir()));
+    items.push(bundled_python_item(
+        state.resource_dir(),
+        state.app_local_data_dir(),
+    ));
+    items.extend(detections.into_iter().map(host_detection_item));
+
+    let last_error = {
+        let cache = state.cache().await;
+        cache.last_error.clone()
+    };
+
+    SetupStatusDto {
+        overall_state: overall_state_for_items(&items, last_error.is_some()),
+        items,
+        last_error,
+    }
+}
+
+fn engine_runtime_item(state: &SetupState) -> SetupItemDto {
+    match state.setup_root() {
+        Some(setup_root) => SetupItemDto {
+            id: SETUP_ITEM_ENGINE_RUNTIME.to_string(),
+            label: "Engine runtime".to_string(),
+            state: SetupItemStateDto::Ready,
+            detail: Some(format!(
+                "Shared engine runtime contract resolves through {}. {}",
+                setup_root.display(),
+                phase2_launch_detail()
+            )),
+            required: true,
+            can_prepare: false,
+        },
+        None => SetupItemDto {
+            id: SETUP_ITEM_ENGINE_RUNTIME.to_string(),
+            label: "Engine runtime".to_string(),
+            state: SetupItemStateDto::Error,
+            detail: Some("Tauri app-local-data directory is unavailable, so setup roots cannot be created".to_string()),
+            required: true,
+            can_prepare: false,
+        },
+    }
+}
+
+fn host_detection_item(detection: HostAppDetection) -> SetupItemDto {
+    let is_detected = detection.path.is_some();
+    let detail = match detection.path.as_ref() {
+        Some(path) => Some(format!("{} detected at {}", detection.label, path.display())),
+        None => Some(format!(
+            "{} is not installed or could not be detected yet. Phase 2 only reports host-app presence; it does not launch or repair installs.",
+            detection.label
+        )),
+    };
+
+    let required = matches!(
+        detection.id,
+        SETUP_ITEM_HOST_GIMP | SETUP_ITEM_HOST_BLENDER | SETUP_ITEM_HOST_LIBREOFFICE
+    );
+
+    SetupItemDto {
+        id: detection.id.to_string(),
+        label: detection.label.to_string(),
+        state: if is_detected {
+            SetupItemStateDto::Ready
+        } else {
+            SetupItemStateDto::Missing
+        },
+        detail,
+        required,
+        can_prepare: false,
+    }
+}
+
+fn overall_state_for_items(items: &[SetupItemDto], has_last_error: bool) -> SetupOverallStateDto {
+    if has_last_error
+        || items
+            .iter()
+            .any(|item| item.required && item.state == SetupItemStateDto::Error)
+    {
+        return SetupOverallStateDto::Error;
+    }
+
+    if items
+        .iter()
+        .any(|item| item.required && item.state != SetupItemStateDto::Ready)
+    {
+        SetupOverallStateDto::NeedsAttention
+    } else {
+        SetupOverallStateDto::Ready
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::collect_setup_status;
+    use crate::setup::state::SetupState;
+    use smolpc_assistant_types::{SetupItemStateDto, SetupOverallStateDto};
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn collect_setup_status_returns_all_required_items() {
+        let resource_temp = TempDir::new().expect("resource temp");
+        std::fs::create_dir_all(resource_temp.path().join("python")).expect("python root");
+        std::fs::create_dir_all(resource_temp.path().join("models")).expect("models root");
+
+        let app_temp = TempDir::new().expect("app temp");
+        let state = SetupState::new(
+            Some(resource_temp.path().to_path_buf()),
+            Some(app_temp.path().to_path_buf()),
+        );
+
+        let status = collect_setup_status(&state).await;
+        assert_eq!(status.items.len(), 6);
+        assert!(status.items.iter().any(|item| item.id == "engine_runtime"));
+        assert!(status.items.iter().any(|item| item.id == "bundled_model"));
+        assert!(status.items.iter().any(|item| item.id == "bundled_python"));
+    }
+
+    #[tokio::test]
+    async fn missing_python_manifest_is_reported_honestly() {
+        let resource_temp = TempDir::new().expect("resource temp");
+        std::fs::create_dir_all(resource_temp.path().join("python")).expect("python root");
+        std::fs::create_dir_all(resource_temp.path().join("models")).expect("models root");
+        std::fs::write(
+            resource_temp.path().join("models").join("manifest.json"),
+            r#"{
+              "version": "phase2",
+              "source": "tests",
+              "expectedPaths": ["qwen3-4b-instruct-2507"],
+              "status": "placeholder"
+            }"#,
+        )
+        .expect("manifest");
+
+        let app_temp = TempDir::new().expect("app temp");
+        let state = SetupState::new(
+            Some(resource_temp.path().to_path_buf()),
+            Some(app_temp.path().to_path_buf()),
+        );
+
+        let status = collect_setup_status(&state).await;
+        let python = status
+            .items
+            .iter()
+            .find(|item| item.id == "bundled_python")
+            .expect("python item");
+        assert_eq!(python.state, SetupItemStateDto::Missing);
+        assert_eq!(status.overall_state, SetupOverallStateDto::NeedsAttention);
+    }
+}

--- a/apps/codehelper/src-tauri/src/setup/types.rs
+++ b/apps/codehelper/src-tauri/src/setup/types.rs
@@ -1,0 +1,39 @@
+use std::path::{Path, PathBuf};
+
+pub const DEFAULT_BUNDLED_MODEL_ID: &str = "qwen3-4b-instruct-2507";
+
+pub const SETUP_ITEM_ENGINE_RUNTIME: &str = "engine_runtime";
+pub const SETUP_ITEM_BUNDLED_MODEL: &str = "bundled_model";
+pub const SETUP_ITEM_BUNDLED_PYTHON: &str = "bundled_python";
+pub const SETUP_ITEM_HOST_GIMP: &str = "host_gimp";
+pub const SETUP_ITEM_HOST_BLENDER: &str = "host_blender";
+pub const SETUP_ITEM_HOST_LIBREOFFICE: &str = "host_libreoffice";
+
+#[allow(dead_code)]
+pub trait OwnedIntegration {
+    fn id(&self) -> &'static str;
+    fn resource_root(&self, resource_dir: &Path) -> PathBuf;
+}
+
+#[allow(dead_code)]
+pub trait Provisioner {
+    fn id(&self) -> &'static str;
+    fn prepare(&self, resource_dir: &Path, app_local_data_dir: &Path) -> Result<(), String>;
+}
+
+#[allow(dead_code)]
+pub trait HostAppLocator {
+    fn id(&self) -> &'static str;
+    fn detect(&self) -> Option<PathBuf>;
+}
+
+#[allow(dead_code)]
+pub trait RuntimeSupervisor {
+    fn id(&self) -> &'static str;
+    fn status(&self) -> String;
+}
+
+#[allow(dead_code)]
+pub trait BundledPythonRuntime {
+    fn prepared_root(&self, app_local_data_dir: &Path) -> PathBuf;
+}

--- a/apps/codehelper/src-tauri/tauri.conf.json
+++ b/apps/codehelper/src-tauri/tauri.conf.json
@@ -38,8 +38,11 @@
       "libs/*",
       "libs/openvino",
       "binaries/*",
+      "resources/gimp",
       "resources/blender",
-      "resources/libreoffice"
+      "resources/libreoffice",
+      "resources/python",
+      "resources/models"
     ]
   }
 }

--- a/apps/codehelper/src/App.svelte
+++ b/apps/codehelper/src/App.svelte
@@ -7,6 +7,8 @@
 	import HardwarePanel from '$lib/components/HardwarePanel.svelte';
 	import ModelInfoPanel from '$lib/components/ModelInfoPanel.svelte';
 	import KeyboardShortcutsOverlay from '$lib/components/KeyboardShortcutsOverlay.svelte';
+	import SetupBanner from '$lib/components/setup/SetupBanner.svelte';
+	import SetupPanel from '$lib/components/setup/SetupPanel.svelte';
 	import WorkspaceHeader from '$lib/components/layout/WorkspaceHeader.svelte';
 	import WorkspaceControls from '$lib/components/layout/WorkspaceControls.svelte';
 	import ConversationView from '$lib/components/chat/ConversationView.svelte';
@@ -16,6 +18,7 @@
 	import { settingsStore } from '$lib/stores/settings.svelte';
 	import { inferenceStore } from '$lib/stores/inference.svelte';
 	import { hardwareStore } from '$lib/stores/hardware.svelte';
+	import { setupStore } from '$lib/stores/setup.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
 	import { applyTheme, watchSystemTheme } from '$lib/utils/theme';
 	import type { Message } from '$lib/types/chat';
@@ -41,6 +44,7 @@
 	let currentUnifiedMode = $state<AppMode | null>(null);
 	let bottomOffset = $state(0);
 	let showShortcutsOverlay = $state(false);
+	let showSetupPanel = $state(false);
 	const NON_CODE_DISABLED_REASON =
 		'This mode is visible in the unified shell, but chat execution is not wired yet.';
 	const LIBREOFFICE_DISABLED_REASON =
@@ -91,6 +95,9 @@
 	const modeSubtitle = $derived(activeModeConfig?.subtitle ?? 'Unified assistant workspace');
 	const modeSuggestions = $derived(activeModeConfig?.suggestions ?? []);
 	const showContextControls = $derived(activeModeConfig?.capabilities.showContextControls ?? false);
+	const setupStatus = $derived(setupStore.status);
+	const setupNeedsAttention = $derived(setupStore.initialized && setupStore.needsAttention);
+	const setupError = $derived(setupStore.error);
 	const canExport = $derived(
 		Boolean(activeModeConfig?.capabilities.showExport) && messages.length > 0
 	);
@@ -1132,6 +1139,10 @@ Teaching rules:
 		bottomOffset = Math.max(0, windowHeight - visualViewportHeight);
 	}
 
+	function openSetupPanel() {
+		showSetupPanel = true;
+	}
+
 	onMount(() => {
 		calculateBottomOffset();
 
@@ -1159,6 +1170,7 @@ Teaching rules:
 
 		async function initApp() {
 			await modeStore.initialize();
+			void setupStore.initialize();
 			await initInference();
 			hardwareStore.getCached();
 			await modeStore.refreshModeStatus();
@@ -1254,7 +1266,11 @@ Teaching rules:
 			onExportChat={handleExportChat}
 		/>
 
-		<WorkspaceControls {showContextControls} />
+		<WorkspaceControls {showContextControls} {setupNeedsAttention} onOpenSetup={openSetupPanel} />
+
+		{#if setupNeedsAttention}
+			<SetupBanner status={setupStatus} error={setupError} onOpen={openSetupPanel} />
+		{/if}
 
 		<ConversationView
 			mode={activeMode}
@@ -1296,6 +1312,16 @@ Teaching rules:
 	<BenchmarkPanel visible={showBenchmarkPanel} onClose={() => uiStore.closeOverlay()} />
 	<HardwarePanel visible={showHardwarePanel} onClose={() => uiStore.closeOverlay()} />
 	<ModelInfoPanel visible={showModelInfoPanel} onClose={() => uiStore.closeOverlay()} />
+	<SetupPanel
+		visible={showSetupPanel}
+		status={setupStatus}
+		error={setupError}
+		loading={setupStore.loading}
+		preparing={setupStore.preparing}
+		onRefresh={() => setupStore.refresh()}
+		onPrepare={() => setupStore.prepare()}
+		onClose={() => (showSetupPanel = false)}
+	/>
 	<KeyboardShortcutsOverlay
 		open={showShortcutsOverlay}
 		onClose={() => (showShortcutsOverlay = false)}

--- a/apps/codehelper/src/lib/api/unified.ts
+++ b/apps/codehelper/src/lib/api/unified.ts
@@ -7,6 +7,7 @@ import type {
 } from '$lib/types/assistant';
 import type { AppMode, ModeConfigDto } from '$lib/types/mode';
 import type { ModeStatusDto } from '$lib/types/provider';
+import type { SetupStatusDto } from '$lib/types/setup';
 
 export async function listModes(): Promise<ModeConfigDto[]> {
 	return invoke<ModeConfigDto[]>('list_modes');
@@ -39,4 +40,12 @@ export async function assistantCancel(): Promise<void> {
 
 export async function undoModeAction(mode: AppMode): Promise<void> {
 	return invoke<void>('mode_undo', { mode });
+}
+
+export async function getSetupStatus(): Promise<SetupStatusDto> {
+	return invoke<SetupStatusDto>('setup_status');
+}
+
+export async function prepareSetup(): Promise<SetupStatusDto> {
+	return invoke<SetupStatusDto>('setup_prepare');
 }

--- a/apps/codehelper/src/lib/components/layout/WorkspaceControls.svelte
+++ b/apps/codehelper/src/lib/components/layout/WorkspaceControls.svelte
@@ -1,12 +1,16 @@
 <script lang="ts">
 	import ContextToggle from '$lib/components/ContextToggle.svelte';
 	import ThemeSelector from '$lib/components/ThemeSelector.svelte';
+	import { Button } from '$lib/components/ui/button';
+	import { Wrench } from '@lucide/svelte';
 
 	interface Props {
 		showContextControls?: boolean;
+		setupNeedsAttention?: boolean;
+		onOpenSetup?: () => void;
 	}
 
-	let { showContextControls = true }: Props = $props();
+	let { showContextControls = true, setupNeedsAttention = false, onOpenSetup }: Props = $props();
 </script>
 
 <section class="workspace-controls" aria-label="Session controls">
@@ -16,6 +20,13 @@
 		</div>
 	{/if}
 	<div class="workspace-controls__row workspace-controls__row--compact">
+		<Button variant="outline" class="workspace-controls__setup" onclick={() => onOpenSetup?.()}>
+			<Wrench class="h-4 w-4" />
+			<span>Setup</span>
+			{#if setupNeedsAttention}
+				<span class="workspace-controls__badge">Needs attention</span>
+			{/if}
+		</Button>
 		<ThemeSelector />
 	</div>
 </section>
@@ -49,6 +60,24 @@
 
 	.workspace-controls__row--compact {
 		margin-left: auto;
+	}
+
+	:global(.workspace-controls__setup) {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.45rem;
+	}
+
+	.workspace-controls__badge {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.12rem 0.42rem;
+		border-radius: 999px;
+		font-size: 0.65rem;
+		font-weight: 700;
+		color: color-mix(in srgb, var(--color-primary) 72%, var(--color-foreground));
+		background: color-mix(in srgb, var(--brand-soft) 74%, transparent);
+		border: 1px solid color-mix(in srgb, var(--color-primary) 18%, transparent);
 	}
 
 	@media (max-width: 768px) {

--- a/apps/codehelper/src/lib/components/setup/SetupBanner.svelte
+++ b/apps/codehelper/src/lib/components/setup/SetupBanner.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+	import type { SetupStatusDto } from '$lib/types/setup';
+
+	interface Props {
+		status: SetupStatusDto | null;
+		error?: string | null;
+		onOpen: () => void;
+	}
+
+	let { status, error = null, onOpen }: Props = $props();
+
+	const headline = $derived(
+		error
+			? 'Setup check failed'
+			: status?.overallState === 'error'
+				? 'Setup needs repair'
+				: 'Setup needs attention'
+	);
+	const detail = $derived(
+		error ??
+			status?.lastError ??
+			status?.items.find((item) => item.state !== 'ready')?.detail ??
+			'Bundled assets or host-app prerequisites still need review.'
+	);
+</script>
+
+<aside class="setup-banner" aria-live="polite">
+	<div class="setup-banner__copy">
+		<span class="setup-banner__eyebrow">{headline}</span>
+		<p>{detail}</p>
+	</div>
+	<Button variant="outline" onclick={onOpen}>Open setup</Button>
+</aside>
+
+<style>
+	.setup-banner {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.85rem;
+		padding: 0.85rem 1rem;
+		border-bottom: 1px solid color-mix(in srgb, var(--color-primary) 14%, var(--outline-soft));
+		background:
+			linear-gradient(
+				180deg,
+				color-mix(in srgb, var(--brand-soft) 78%, transparent),
+				color-mix(in srgb, var(--surface-widget) 96%, black)
+			),
+			var(--surface-widget);
+	}
+
+	.setup-banner__copy {
+		display: grid;
+		gap: 0.22rem;
+		min-width: 0;
+	}
+
+	.setup-banner__eyebrow {
+		font-size: 0.68rem;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: color-mix(in srgb, var(--color-primary) 68%, var(--color-foreground));
+	}
+
+	.setup-banner__copy p {
+		font-size: 0.8rem;
+		color: var(--color-muted-foreground);
+	}
+
+	@media (max-width: 720px) {
+		.setup-banner {
+			flex-direction: column;
+			align-items: stretch;
+		}
+	}
+</style>

--- a/apps/codehelper/src/lib/components/setup/SetupPanel.svelte
+++ b/apps/codehelper/src/lib/components/setup/SetupPanel.svelte
@@ -1,0 +1,279 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { AlertCircle, RefreshCw, ShieldCheck, Wrench, X } from '@lucide/svelte';
+	import { Button } from '$lib/components/ui/button';
+	import type { SetupItemDto, SetupStatusDto } from '$lib/types/setup';
+
+	interface Props {
+		visible: boolean;
+		status: SetupStatusDto | null;
+		error?: string | null;
+		loading?: boolean;
+		preparing?: boolean;
+		onRefresh: () => void;
+		onPrepare: () => void;
+		onClose?: () => void;
+	}
+
+	let {
+		visible,
+		status,
+		error = null,
+		loading = false,
+		preparing = false,
+		onRefresh,
+		onPrepare,
+		onClose
+	}: Props = $props();
+
+	onMount(() => {
+		function handleKeydown(event: KeyboardEvent) {
+			if (event.key === 'Escape' && visible) {
+				onClose?.();
+			}
+		}
+
+		window.addEventListener('keydown', handleKeydown);
+		return () => window.removeEventListener('keydown', handleKeydown);
+	});
+
+	function stateLabel(item: SetupItemDto): string {
+		return item.state.replaceAll('_', ' ');
+	}
+</script>
+
+{#if visible}
+	<div class="setup-panel">
+		<div class="setup-panel__header">
+			<h3 class="setup-panel__title">
+				<Wrench class="h-4.5 w-4.5" />
+				Setup & Provisioning
+			</h3>
+			<div class="setup-panel__actions">
+				<Button
+					variant="ghost"
+					size="icon"
+					onclick={onRefresh}
+					disabled={loading || preparing}
+					aria-label="Refresh setup status"
+					title="Refresh setup status"
+				>
+					<RefreshCw class={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+				</Button>
+				<Button
+					variant="ghost"
+					size="icon"
+					onclick={() => onClose?.()}
+					aria-label="Close setup panel"
+				>
+					<X class="h-4 w-4" />
+				</Button>
+			</div>
+		</div>
+
+		<div class="setup-panel__content">
+			{#if error}
+				<div class="setup-panel__error">
+					<AlertCircle class="h-4 w-4" />
+					<span>{error}</span>
+				</div>
+			{/if}
+
+			<div class="setup-panel__summary">
+				<div>
+					<div class="setup-panel__summary-label">Overall state</div>
+					<div class="setup-panel__summary-value">
+						{status?.overallState?.replaceAll('_', ' ') ?? (error ? 'error' : 'loading')}
+					</div>
+				</div>
+				<Button variant="outline" onclick={onPrepare} disabled={preparing}>
+					{preparing ? 'Preparing…' : 'Prepare'}
+				</Button>
+			</div>
+
+			<div class="setup-panel__items">
+				{#each status?.items ?? [] as item (item.id)}
+					<section class="setup-panel__item">
+						<div class="setup-panel__item-top">
+							<div>
+								<div class="setup-panel__item-label">{item.label}</div>
+								<div class="setup-panel__item-id">{item.id}</div>
+							</div>
+							<div class={`setup-panel__state setup-panel__state--${item.state}`}>
+								{stateLabel(item)}
+							</div>
+						</div>
+						{#if item.detail}
+							<p class="setup-panel__item-detail">{item.detail}</p>
+						{/if}
+						<div class="setup-panel__item-meta">
+							<span>{item.required ? 'Required' : 'Optional'}</span>
+							<span>{item.canPrepare ? 'Prepare-enabled' : 'Prepare not needed here'}</span>
+						</div>
+					</section>
+				{/each}
+			</div>
+
+			<div class="setup-panel__note">
+				<ShieldCheck class="h-4 w-4" />
+				<span>
+					Phase 2 only validates manifests, prepares app-local setup state, and reports host-app
+					detection. It does not launch or provision external host apps yet.
+				</span>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.setup-panel {
+		position: fixed;
+		right: 1rem;
+		top: 5.75rem;
+		z-index: 56;
+		width: min(30rem, calc(100vw - 1.6rem));
+		max-height: min(78vh, 44rem);
+		overflow-y: auto;
+		border-radius: calc(var(--radius-xl) + 6px);
+		border: 1px solid var(--outline-soft);
+		background:
+			linear-gradient(
+				180deg,
+				color-mix(in srgb, var(--surface-floating) 96%, black),
+				color-mix(in srgb, var(--surface-subtle) 97%, black)
+			),
+			var(--surface-floating);
+		box-shadow: var(--shadow-strong);
+		backdrop-filter: blur(14px);
+	}
+
+	.setup-panel__header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 0.85rem 0.9rem;
+		border-bottom: 1px solid var(--outline-soft);
+	}
+
+	.setup-panel__title {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.95rem;
+		font-weight: 700;
+	}
+
+	.setup-panel__actions {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3rem;
+	}
+
+	.setup-panel__content {
+		display: grid;
+		gap: 0.9rem;
+		padding: 0.9rem;
+	}
+
+	.setup-panel__error,
+	.setup-panel__note,
+	.setup-panel__summary,
+	.setup-panel__item {
+		border: 1px solid var(--outline-soft);
+		border-radius: var(--radius-lg);
+		background: color-mix(in srgb, var(--surface-widget) 96%, black);
+	}
+
+	.setup-panel__error,
+	.setup-panel__note {
+		display: flex;
+		align-items: flex-start;
+		gap: 0.55rem;
+		padding: 0.75rem;
+		font-size: 0.78rem;
+		color: var(--color-muted-foreground);
+	}
+
+	.setup-panel__error {
+		border-color: color-mix(in srgb, #d9534f 34%, var(--outline-soft));
+	}
+
+	.setup-panel__summary {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		padding: 0.8rem;
+	}
+
+	.setup-panel__summary-label,
+	.setup-panel__item-id,
+	.setup-panel__item-meta {
+		font-size: 0.72rem;
+		color: var(--color-muted-foreground);
+	}
+
+	.setup-panel__summary-value,
+	.setup-panel__item-label {
+		font-size: 0.9rem;
+		font-weight: 650;
+	}
+
+	.setup-panel__items {
+		display: grid;
+		gap: 0.75rem;
+	}
+
+	.setup-panel__item {
+		padding: 0.8rem;
+		display: grid;
+		gap: 0.5rem;
+	}
+
+	.setup-panel__item-top {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 0.75rem;
+	}
+
+	.setup-panel__state {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.22rem 0.55rem;
+		border-radius: 999px;
+		font-size: 0.68rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		border: 1px solid var(--outline-soft);
+	}
+
+	.setup-panel__state--ready {
+		color: #1f7a3d;
+		background: color-mix(in srgb, #1f7a3d 12%, transparent);
+	}
+
+	.setup-panel__state--missing,
+	.setup-panel__state--not_prepared,
+	.setup-panel__state--error {
+		color: color-mix(in srgb, #c46b00 80%, var(--color-foreground));
+		background: color-mix(in srgb, #c46b00 12%, transparent);
+	}
+
+	.setup-panel__state--error {
+		color: #b83b36;
+		background: color-mix(in srgb, #b83b36 12%, transparent);
+	}
+
+	.setup-panel__item-detail {
+		font-size: 0.78rem;
+		color: var(--color-foreground);
+	}
+
+	.setup-panel__item-meta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.6rem;
+	}
+</style>

--- a/apps/codehelper/src/lib/stores/setup.svelte.ts
+++ b/apps/codehelper/src/lib/stores/setup.svelte.ts
@@ -1,0 +1,80 @@
+import { getSetupStatus, prepareSetup } from '$lib/api/unified';
+import type { SetupStatusDto } from '$lib/types/setup';
+
+function toErrorMessage(cause: unknown): string {
+	return cause instanceof Error ? cause.message : String(cause);
+}
+
+let status = $state<SetupStatusDto | null>(null);
+let loading = $state(false);
+let preparing = $state(false);
+let initialized = $state(false);
+let error = $state<string | null>(null);
+
+export const setupStore = {
+	get status() {
+		return status;
+	},
+	get items() {
+		return status?.items ?? [];
+	},
+	get loading() {
+		return loading;
+	},
+	get preparing() {
+		return preparing;
+	},
+	get initialized() {
+		return initialized;
+	},
+	get error() {
+		return error ?? status?.lastError ?? null;
+	},
+	get overallState() {
+		return status?.overallState ?? (error ? 'error' : null);
+	},
+	get needsAttention() {
+		return this.overallState !== null && this.overallState !== 'ready';
+	},
+
+	async initialize(): Promise<void> {
+		if (initialized || loading) {
+			return;
+		}
+
+		loading = true;
+		error = null;
+		try {
+			status = await getSetupStatus();
+		} catch (cause) {
+			error = toErrorMessage(cause);
+		} finally {
+			initialized = true;
+			loading = false;
+		}
+	},
+
+	async refresh(): Promise<void> {
+		loading = true;
+		error = null;
+		try {
+			status = await getSetupStatus();
+		} catch (cause) {
+			error = toErrorMessage(cause);
+		} finally {
+			loading = false;
+		}
+	},
+
+	async prepare(): Promise<void> {
+		preparing = true;
+		error = null;
+		try {
+			status = await prepareSetup();
+		} catch (cause) {
+			error = toErrorMessage(cause);
+		} finally {
+			preparing = false;
+		}
+	}
+};

--- a/apps/codehelper/src/lib/types/setup.ts
+++ b/apps/codehelper/src/lib/types/setup.ts
@@ -1,0 +1,17 @@
+export type SetupItemState = 'ready' | 'missing' | 'not_prepared' | 'error';
+export type SetupOverallState = 'ready' | 'needs_attention' | 'error';
+
+export interface SetupItemDto {
+	id: string;
+	label: string;
+	state: SetupItemState;
+	detail: string | null;
+	required: boolean;
+	canPrepare: boolean;
+}
+
+export interface SetupStatusDto {
+	overallState: SetupOverallState;
+	items: SetupItemDto[];
+	lastError: string | null;
+}

--- a/crates/smolpc-assistant-types/src/lib.rs
+++ b/crates/smolpc-assistant-types/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod assistant;
 pub mod mode;
 pub mod provider;
+pub mod setup;
 pub mod stream;
 
 pub use assistant::{AssistantMessageDto, AssistantResponseDto, AssistantSendRequestDto};
 pub use mode::{AppMode, ModeCapabilitiesDto, ModeConfigDto, ProviderKind};
 pub use provider::{ModeStatusDto, ProviderStateDto, ToolDefinitionDto, ToolExecutionResultDto};
+pub use setup::{SetupItemDto, SetupItemStateDto, SetupOverallStateDto, SetupStatusDto};
 pub use stream::AssistantStreamEventDto;

--- a/crates/smolpc-assistant-types/src/setup.rs
+++ b/crates/smolpc-assistant-types/src/setup.rs
@@ -1,0 +1,37 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SetupItemStateDto {
+    Ready,
+    Missing,
+    NotPrepared,
+    Error,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SetupItemDto {
+    pub id: String,
+    pub label: String,
+    pub state: SetupItemStateDto,
+    pub detail: Option<String>,
+    pub required: bool,
+    pub can_prepare: bool,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SetupOverallStateDto {
+    Ready,
+    NeedsAttention,
+    Error,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SetupStatusDto {
+    pub overall_state: SetupOverallStateDto,
+    pub items: Vec<SetupItemDto>,
+    pub last_error: Option<String>,
+}

--- a/crates/smolpc-assistant-types/tests/contracts.rs
+++ b/crates/smolpc-assistant-types/tests/contracts.rs
@@ -1,6 +1,7 @@
 use smolpc_assistant_types::{
     AppMode, AssistantResponseDto, AssistantStreamEventDto, ModeCapabilitiesDto, ModeConfigDto,
-    ProviderKind, ToolExecutionResultDto,
+    ProviderKind, SetupItemDto, SetupItemStateDto, SetupOverallStateDto, SetupStatusDto,
+    ToolExecutionResultDto,
 };
 
 #[test]
@@ -67,4 +68,26 @@ fn assistant_response_uses_tool_results_key() {
     let value = serde_json::to_value(response).expect("serialize response");
     assert!(value.get("toolResults").is_some());
     assert!(value.get("tool_results").is_none());
+}
+
+#[test]
+fn setup_status_uses_expected_wire_keys_and_values() {
+    let dto = SetupStatusDto {
+        overall_state: SetupOverallStateDto::NeedsAttention,
+        items: vec![SetupItemDto {
+            id: "bundled_python".to_string(),
+            label: "Bundled Python".to_string(),
+            state: SetupItemStateDto::NotPrepared,
+            detail: Some("Packaged payload not staged".to_string()),
+            required: true,
+            can_prepare: true,
+        }],
+        last_error: None,
+    };
+
+    let value = serde_json::to_value(dto).expect("serialize setup status");
+    assert_eq!(value["overallState"], "needs_attention");
+    assert_eq!(value["items"][0]["id"], "bundled_python");
+    assert_eq!(value["items"][0]["state"], "not_prepared");
+    assert_eq!(value["items"][0]["canPrepare"], true);
 }


### PR DESCRIPTION
## Summary\n- add the Phase 2 setup subsystem, setup commands, and app-level setup UI\n- add tracked resource manifests plus Python/model staging hooks for the self-contained line\n- keep existing Code, GIMP, Blender, Writer, Slides, and Calc behavior unchanged\n\n## Testing\n- cargo check -p smolpc-code-helper\n- cargo test -p smolpc-code-helper --lib\n- cargo test -p smolpc-engine-client\n- cargo test -p smolpc-assistant-types\n- npm ci\n- npm run check --workspace apps/codehelper\n- node apps/codehelper/scripts/self-contained/validate-resource-manifests.mjs\n- per-file npx prettier --check on changed frontend/json/script files