### PR TITLE
docs(self-contained): tighten phase 2 setup references

### DIFF
--- a/docs/unified-assistant-self-contained-spec/ARCHITECTURE.md
+++ b/docs/unified-assistant-self-contained-spec/ARCHITECTURE.md
@@ -190,7 +190,7 @@ Those roots are now part of the implementation contract on
 
 ## 8. Mode-Specific Architecture
 
-### 7.1 Code
+### 8.1 Code
 
 - no external host app
 - engine + bundled model only

--- a/docs/unified-assistant-self-contained-spec/README.md
+++ b/docs/unified-assistant-self-contained-spec/README.md
@@ -94,6 +94,10 @@ Never branch new self-contained work from the frozen demo branches.
 4. [SETUP_SPEC.md](SETUP_SPEC.md)
 5. [SELF_CONTAINED_PLAN.md](SELF_CONTAINED_PLAN.md)
 
+`SETUP_SPEC.md` is intentionally cross-listed in both architecture and workflow
+reading orders because it defines both the technical setup contract and the
+phase-boundary rules for how that setup surface evolves.
+
 ### Historical carried-over references
 
 These documents were carried forward from the frozen demo-spec line. They remain

--- a/docs/unified-assistant-self-contained-spec/SETUP_SPEC.md
+++ b/docs/unified-assistant-self-contained-spec/SETUP_SPEC.md
@@ -94,6 +94,9 @@ interface SetupStatusDto {
 }
 ```
 
+`detail` should be non-null whenever the app needs to explain why an item is
+missing, not prepared, or in error. It may be `null` for clean ready states.
+
 ## 5. Locked Phase 2 Setup Item Ids
 
 Phase 2 uses these item ids and no others:


### PR DESCRIPTION
## Summary\n- fix the Phase 2 architecture section numbering\n- clarify why SETUP_SPEC is intentionally cross-listed in the README\n- define the intended  semantics\n\n## Testing\n- npx prettier --check docs/unified-assistant-self-contained-spec/*.md\n- per-file npx prettier --check on changed docs