### PR TITLE
Phase 3: use bundled Python for LibreOffice packaged mode

### DIFF
--- a/apps/codehelper/src-tauri/resources/libreoffice/mcp_server/main.py
+++ b/apps/codehelper/src-tauri/resources/libreoffice/mcp_server/main.py
@@ -18,6 +18,7 @@ STARTUP_TIMEOUT_SECONDS = 20.0
 STARTUP_POLL_INTERVAL_SECONDS = 0.2
 SHUTDOWN_TIMEOUT_SECONDS = 5.0
 HELPER_AUTH_TOKEN_ENV = "SMOLPC_LIBREOFFICE_HELPER_AUTH_TOKEN"
+OFFICE_PATH_ENV = "SMOLPC_LIBREOFFICE_OFFICE_PATH"
 
 office_process: Optional[subprocess.Popen] = None
 helper_process: Optional[subprocess.Popen] = None
@@ -75,6 +76,14 @@ def register_shutdown_handlers() -> None:
 
 
 def get_office_path() -> str:
+    configured_path = os.environ.get(OFFICE_PATH_ENV)
+    if configured_path:
+        if os.path.exists(configured_path):
+            return configured_path
+        raise FileNotFoundError(
+            f"Configured LibreOffice executable from {OFFICE_PATH_ENV} does not exist: {configured_path}"
+        )
+
     system = platform.system().lower()
     if system == "windows":
         possible_paths = [
@@ -101,16 +110,6 @@ def get_office_path() -> str:
 
 
 def get_python_path() -> str:
-    system = platform.system().lower()
-    if system == "windows":
-        possible_paths = [
-            r"C:\Program Files\Collabora Office\program\python.exe",
-            r"C:\Program Files (x86)\Collabora Office\program\python.exe",
-            r"C:\Program Files\LibreOffice\program\python.exe",
-        ]
-        for path in possible_paths:
-            if os.path.exists(path):
-                return path
     return sys.executable
 
 

--- a/apps/codehelper/src-tauri/resources/python/README.md
+++ b/apps/codehelper/src-tauri/resources/python/README.md
@@ -1,10 +1,16 @@
-# Bundled Python Placeholder
+# Bundled Python Payload Contract
 
 This directory defines the packaged resource contract for the app-private
 Python runtime used by the self-contained line.
 
-Phase 2 tracks the manifest and staging contract here, but it does not commit
-the final large runtime payload into git history.
+Phase 3 locks the delivery source to:
+
+- the official Windows x64 CPython embeddable distribution from `python.org`
+- a pinned `uv` Windows binary from Astral
+- provider-owned wheel/runtime inputs staged into `payload/`
+
+The final large runtime payload still stays out of git history. Packaging-stage
+scripts populate `payload/` at build time.
 
 Expected future staged contents:
 

--- a/apps/codehelper/src-tauri/resources/python/manifest.json
+++ b/apps/codehelper/src-tauri/resources/python/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "phase2-foundation-placeholder",
-  "source": "self-contained staging contract",
+  "version": "phase3-bundled-python-placeholder",
+  "source": "python.org embeddable CPython + Astral uv staging contract",
   "expectedPaths": ["README.md", "payload"],
   "status": "placeholder"
 }

--- a/apps/codehelper/src-tauri/src/modes/libreoffice/provider.rs
+++ b/apps/codehelper/src-tauri/src/modes/libreoffice/provider.rs
@@ -7,6 +7,7 @@ use crate::assistant::MODE_UNDO_NOT_SUPPORTED_IN_FOUNDATION;
 use crate::modes::provider::{
     provider_state, ToolProvider, FOUNDATION_PROVIDER_EXECUTION_NOT_IMPLEMENTED,
 };
+use crate::setup::host_apps::detect_libreoffice;
 use async_trait::async_trait;
 use smolpc_assistant_types::{
     AppMode, ProviderStateDto, ToolDefinitionDto, ToolExecutionResultDto,
@@ -99,14 +100,20 @@ impl LibreOfficeProvider {
     }
 
     fn friendly_runtime_error(error: &str) -> String {
+        if error.contains("Bundled Python is not prepared yet") {
+            return format!(
+                "LibreOffice runtime is not ready yet. Prepare bundled Python from the setup panel before using Writer or Slides. {error}"
+            );
+        }
+
         if error.contains("spawn stdio MCP command") {
             return format!(
-                "Unable to start the LibreOffice MCP runtime. Make sure Python 3 is available or a bundled .venv exists. {error}"
+                "Unable to start the LibreOffice MCP runtime. Bundled Python should be prepared first, and LibreOffice or Collabora must be installed. {error}"
             );
         }
 
         format!(
-            "LibreOffice runtime failed. Make sure Python 3 and LibreOffice or Collabora are installed. {error}"
+            "LibreOffice runtime failed. Make sure bundled Python is prepared and LibreOffice or Collabora is installed. {error}"
         )
     }
 
@@ -152,7 +159,7 @@ impl LibreOfficeProvider {
         ))
     }
 
-    fn validate_layout(
+    fn validate_runtime_prerequisites(
         &self,
     ) -> Result<
         (
@@ -163,8 +170,16 @@ impl LibreOfficeProvider {
     > {
         let layout =
             resolve_mcp_server_layout(self.resource_dir.as_deref(), self.resolution_options)?;
-        let runtime =
-            LibreOfficeRuntimeConfig::from_layout(&layout, self.app_local_data_dir.as_deref());
+        let office_detection = detect_libreoffice(None);
+        let office_path = office_detection.path.ok_or_else(|| {
+            "LibreOffice or Collabora is not installed or could not be detected yet.".to_string()
+        })?;
+        let runtime = LibreOfficeRuntimeConfig::from_layout(
+            &layout,
+            self.app_local_data_dir.as_deref(),
+            self.resolution_options.allow_system_python_fallback,
+            Some(office_path),
+        )?;
         Ok((layout, runtime))
     }
 
@@ -179,7 +194,7 @@ impl LibreOfficeProvider {
             }
         }
 
-        let (layout, runtime) = self.validate_layout()?;
+        let (layout, runtime) = self.validate_runtime_prerequisites()?;
         {
             let mut state = self.state.lock().await;
             state.scaffold_dir = Some(layout.mcp_server_dir.clone());
@@ -226,7 +241,7 @@ impl LibreOfficeProvider {
             Ok(profile) => profile,
             Err(error) => return provider_state(mode, "error", Some(error.as_str()), true, false),
         };
-        let (layout, runtime) = match self.validate_layout() {
+        let (layout, runtime) = match self.validate_runtime_prerequisites() {
             Ok(value) => value,
             Err(error) => {
                 let mut state = self.state.lock().await;
@@ -303,7 +318,7 @@ impl ToolProvider for LibreOfficeProvider {
     async fn status(&self, mode: AppMode) -> Result<ProviderStateDto, String> {
         let mut state = self.state.lock().await;
 
-        match self.validate_layout() {
+        match self.validate_runtime_prerequisites() {
             Ok((layout, _runtime)) => {
                 state.scaffold_dir = Some(layout.mcp_server_dir);
             }
@@ -478,6 +493,7 @@ for line in sys.stdin:
             Some(tempdir.path().to_path_buf()),
             ResourceResolutionOptions {
                 allow_dev_fallback: false,
+                allow_system_python_fallback: true,
             },
         );
 
@@ -496,6 +512,7 @@ for line in sys.stdin:
             Some(tempdir.path().to_path_buf()),
             ResourceResolutionOptions {
                 allow_dev_fallback: false,
+                allow_system_python_fallback: true,
             },
         );
 
@@ -516,6 +533,7 @@ for line in sys.stdin:
             Some(tempdir.path().to_path_buf()),
             ResourceResolutionOptions {
                 allow_dev_fallback: false,
+                allow_system_python_fallback: true,
             },
         );
 
@@ -540,6 +558,7 @@ for line in sys.stdin:
             Some(tempdir.path().to_path_buf()),
             ResourceResolutionOptions {
                 allow_dev_fallback: false,
+                allow_system_python_fallback: true,
             },
         );
 
@@ -559,6 +578,7 @@ for line in sys.stdin:
             Some(tempdir.path().to_path_buf()),
             ResourceResolutionOptions {
                 allow_dev_fallback: false,
+                allow_system_python_fallback: true,
             },
         );
 
@@ -578,6 +598,7 @@ for line in sys.stdin:
             Some(tempdir.path().to_path_buf()),
             ResourceResolutionOptions {
                 allow_dev_fallback: false,
+                allow_system_python_fallback: true,
             },
         ));
 

--- a/apps/codehelper/src-tauri/src/modes/libreoffice/resources.rs
+++ b/apps/codehelper/src-tauri/src/modes/libreoffice/resources.rs
@@ -3,12 +3,14 @@ use std::path::{Path, PathBuf};
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ResourceResolutionOptions {
     pub allow_dev_fallback: bool,
+    pub allow_system_python_fallback: bool,
 }
 
 impl Default for ResourceResolutionOptions {
     fn default() -> Self {
         Self {
             allow_dev_fallback: cfg!(debug_assertions),
+            allow_system_python_fallback: cfg!(debug_assertions),
         }
     }
 }
@@ -136,6 +138,7 @@ mod tests {
             Some(tempdir.path()),
             ResourceResolutionOptions {
                 allow_dev_fallback: false,
+                allow_system_python_fallback: true,
             },
         )
         .expect("resolve layout");
@@ -162,6 +165,7 @@ mod tests {
             Some(tempdir.path()),
             ResourceResolutionOptions {
                 allow_dev_fallback: false,
+                allow_system_python_fallback: true,
             },
         )
         .expect_err("missing readme should fail");

--- a/apps/codehelper/src-tauri/src/modes/libreoffice/runtime.rs
+++ b/apps/codehelper/src-tauri/src/modes/libreoffice/runtime.rs
@@ -1,4 +1,5 @@
 use super::resources::LibreOfficeResourceLayout;
+use crate::setup::python::resolve_prepared_python_command;
 use smolpc_mcp_client::{McpSession, StdioTransportConfig};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -7,8 +8,9 @@ pub const LIBREOFFICE_HELPER_SOCKET_ADDR: &str = "localhost:8765";
 pub const LIBREOFFICE_OFFICE_SOCKET_ADDR: &str = "localhost:2002";
 const LIBREOFFICE_CLIENT_NAME: &str = "smolpc-unified-libreoffice";
 const LIBREOFFICE_CONNECT_HINT: &str =
-    "Make sure Python 3 is available and LibreOffice or Collabora is installed.";
+    "Make sure bundled Python has been prepared and LibreOffice or Collabora is installed.";
 const LIBREOFFICE_LOG_SUBDIR: &str = "libreoffice/logs";
+const LIBREOFFICE_OFFICE_PATH_ENV: &str = "SMOLPC_LIBREOFFICE_OFFICE_PATH";
 
 #[cfg(windows)]
 const DEFAULT_PYTHON_COMMAND: &str = "python";
@@ -22,6 +24,7 @@ pub struct LibreOfficeRuntimeConfig {
     pub helper_socket_addr: String,
     pub office_socket_addr: String,
     pub python_command: String,
+    pub office_path: Option<PathBuf>,
     pub log_dir: PathBuf,
 }
 
@@ -29,15 +32,22 @@ impl LibreOfficeRuntimeConfig {
     pub fn from_layout(
         layout: &LibreOfficeResourceLayout,
         app_local_data_dir: Option<&Path>,
-    ) -> Self {
-        Self {
+        allow_system_python_fallback: bool,
+        office_path: Option<PathBuf>,
+    ) -> Result<Self, String> {
+        Ok(Self {
             entrypoint: layout.main_py_path.clone(),
             working_dir: layout.mcp_server_dir.clone(),
             helper_socket_addr: LIBREOFFICE_HELPER_SOCKET_ADDR.to_string(),
             office_socket_addr: LIBREOFFICE_OFFICE_SOCKET_ADDR.to_string(),
-            python_command: resolve_python_command(&layout.mcp_server_dir),
+            python_command: resolve_python_command(
+                &layout.mcp_server_dir,
+                app_local_data_dir,
+                allow_system_python_fallback,
+            )?,
+            office_path,
             log_dir: resolve_log_dir(app_local_data_dir),
-        }
+        })
     }
 
     pub fn stdio_transport_config(&self) -> Result<StdioTransportConfig, String> {
@@ -46,6 +56,12 @@ impl LibreOfficeRuntimeConfig {
             "SMOLPC_MCP_LOG_DIR".to_string(),
             ensure_log_dir(&self.log_dir)?.to_string_lossy().to_string(),
         );
+        if let Some(office_path) = &self.office_path {
+            env.insert(
+                LIBREOFFICE_OFFICE_PATH_ENV.to_string(),
+                office_path.to_string_lossy().to_string(),
+            );
+        }
 
         Ok(StdioTransportConfig {
             command: self.python_command.clone(),
@@ -72,23 +88,43 @@ impl LibreOfficeRuntimeConfig {
 
     pub fn summary(&self) -> String {
         format!(
-            "shared LibreOffice MCP runtime over stdio via {} main.py with helper socket bridge on {} and office socket {}",
-            self.python_command, self.helper_socket_addr, self.office_socket_addr
+            "shared LibreOffice MCP runtime over stdio via {} main.py with helper socket bridge on {}, office socket {}, and host app {}",
+            self.python_command,
+            self.helper_socket_addr,
+            self.office_socket_addr,
+            self.office_path
+                .as_ref()
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|| "auto-detected LibreOffice".to_string())
         )
     }
 }
 
-fn resolve_python_command(working_dir: &Path) -> String {
-    for candidate in bundled_python_candidates(working_dir) {
-        if candidate.is_file() {
-            return candidate.to_string_lossy().to_string();
-        }
+fn resolve_python_command(
+    working_dir: &Path,
+    app_local_data_dir: Option<&Path>,
+    allow_system_python_fallback: bool,
+) -> Result<String, String> {
+    if let Some(command) = resolve_prepared_python_command(app_local_data_dir) {
+        return Ok(command);
     }
 
-    DEFAULT_PYTHON_COMMAND.to_string()
+    if allow_system_python_fallback {
+        for candidate in development_python_candidates(working_dir) {
+            if candidate.is_file() {
+                return Ok(candidate.to_string_lossy().to_string());
+            }
+        }
+
+        return Ok(DEFAULT_PYTHON_COMMAND.to_string());
+    }
+
+    Err(
+        "Bundled Python is not prepared yet. Use setup_prepare() from the setup panel before starting Writer or Slides.".to_string(),
+    )
 }
 
-fn bundled_python_candidates(working_dir: &Path) -> Vec<PathBuf> {
+fn development_python_candidates(working_dir: &Path) -> Vec<PathBuf> {
     let mut candidates = Vec::new();
     let venv_dir = working_dir.join(".venv");
 
@@ -522,8 +558,13 @@ asyncio.run(main())
             ),
         };
 
-        let runtime =
-            LibreOfficeRuntimeConfig::from_layout(&layout, Some(Path::new("/tmp/smolpc")));
+        let runtime = LibreOfficeRuntimeConfig::from_layout(
+            &layout,
+            Some(Path::new("/tmp/smolpc")),
+            true,
+            Some(PathBuf::from("/tmp/libreoffice/program/soffice")),
+        )
+        .expect("runtime");
         let config = runtime
             .stdio_transport_config()
             .expect("stdio transport config");
@@ -536,6 +577,10 @@ asyncio.run(main())
             config.args,
             vec!["/tmp/libreoffice/mcp_server/main.py".to_string()]
         );
+        assert_eq!(
+            config.env.get("SMOLPC_LIBREOFFICE_OFFICE_PATH"),
+            Some(&"/tmp/libreoffice/program/soffice".to_string())
+        );
         assert_eq!(runtime.helper_socket_addr, LIBREOFFICE_HELPER_SOCKET_ADDR);
         assert_eq!(runtime.office_socket_addr, LIBREOFFICE_OFFICE_SOCKET_ADDR);
         let expected_log_dir =
@@ -544,6 +589,31 @@ asyncio.run(main())
             config.env.get("SMOLPC_MCP_LOG_DIR"),
             Some(&expected_log_dir.to_string_lossy().to_string())
         );
+    }
+
+    #[test]
+    fn runtime_config_requires_prepared_python_when_system_fallback_disabled() {
+        let layout = LibreOfficeResourceLayout {
+            mcp_server_dir: PathBuf::from("/tmp/libreoffice/mcp_server"),
+            readme_path: PathBuf::from("/tmp/libreoffice/mcp_server/README.md"),
+            main_py_path: PathBuf::from("/tmp/libreoffice/mcp_server/main.py"),
+            libre_py_path: PathBuf::from("/tmp/libreoffice/mcp_server/libre.py"),
+            helper_py_path: PathBuf::from("/tmp/libreoffice/mcp_server/helper.py"),
+            helper_utils_py_path: PathBuf::from("/tmp/libreoffice/mcp_server/helper_utils.py"),
+            helper_test_functions_py_path: PathBuf::from(
+                "/tmp/libreoffice/mcp_server/helper_test_functions.py",
+            ),
+        };
+
+        let error = LibreOfficeRuntimeConfig::from_layout(
+            &layout,
+            Some(Path::new("/tmp/phase3-missing-python")),
+            false,
+            Some(PathBuf::from("/tmp/libreoffice/program/soffice")),
+        )
+        .expect_err("strict packaged mode should require prepared python");
+
+        assert!(error.contains("Bundled Python is not prepared yet"));
     }
 
     #[test]

--- a/apps/codehelper/src-tauri/src/setup/host_apps.rs
+++ b/apps/codehelper/src-tauri/src/setup/host_apps.rs
@@ -1,6 +1,4 @@
-use super::types::{
-    SETUP_ITEM_HOST_BLENDER, SETUP_ITEM_HOST_GIMP, SETUP_ITEM_HOST_LIBREOFFICE,
-};
+use super::types::{SETUP_ITEM_HOST_BLENDER, SETUP_ITEM_HOST_GIMP, SETUP_ITEM_HOST_LIBREOFFICE};
 use std::collections::HashMap;
 use std::env;
 use std::path::{Path, PathBuf};
@@ -36,13 +34,9 @@ fn detect_host_app(spec: &HostAppSpec, cached: Option<&PathBuf>) -> HostAppDetec
         .or_else(|| lookup_standard_paths(spec))
         .or_else(|| lookup_on_path(spec));
 
-    let detail = resolved.as_ref().map(|path| {
-        format!(
-            "{} detected at {}",
-            spec.label,
-            path.to_string_lossy()
-        )
-    });
+    let detail = resolved
+        .as_ref()
+        .map(|path| format!("{} detected at {}", spec.label, path.to_string_lossy()));
 
     HostAppDetection {
         id: spec.id,
@@ -74,17 +68,21 @@ fn all_specs() -> Vec<HostAppSpec> {
             },
             standard_paths: standard_paths_for_blender(),
         },
-        HostAppSpec {
-            id: SETUP_ITEM_HOST_LIBREOFFICE,
-            label: "LibreOffice",
-            executable_names: if cfg!(windows) {
-                &["soffice.exe"]
-            } else {
-                &["soffice"]
-            },
-            standard_paths: standard_paths_for_libreoffice(),
-        },
+        libreoffice_spec(),
     ]
+}
+
+fn libreoffice_spec() -> HostAppSpec {
+    HostAppSpec {
+        id: SETUP_ITEM_HOST_LIBREOFFICE,
+        label: "LibreOffice",
+        executable_names: if cfg!(windows) {
+            &["soffice.exe"]
+        } else {
+            &["soffice"]
+        },
+        standard_paths: standard_paths_for_libreoffice(),
+    }
 }
 
 fn program_files_candidates() -> Vec<PathBuf> {
@@ -112,7 +110,10 @@ fn standard_paths_for_gimp() -> Vec<PathBuf> {
             PathBuf::from("/opt/homebrew/bin/gimp"),
         ]
     } else {
-        vec![PathBuf::from("/usr/bin/gimp"), PathBuf::from("/usr/local/bin/gimp")]
+        vec![
+            PathBuf::from("/usr/bin/gimp"),
+            PathBuf::from("/usr/local/bin/gimp"),
+        ]
     }
 }
 
@@ -154,7 +155,9 @@ fn standard_paths_for_libreoffice() -> Vec<PathBuf> {
             .flat_map(|root| {
                 [
                     root.join("LibreOffice").join("program").join("soffice.exe"),
-                    root.join("Collabora Office").join("program").join("soffice.exe"),
+                    root.join("Collabora Office")
+                        .join("program")
+                        .join("soffice.exe"),
                 ]
             })
             .collect()
@@ -173,7 +176,10 @@ fn standard_paths_for_libreoffice() -> Vec<PathBuf> {
 }
 
 fn lookup_standard_paths(spec: &HostAppSpec) -> Option<PathBuf> {
-    spec.standard_paths.iter().find(|path| path.exists()).cloned()
+    spec.standard_paths
+        .iter()
+        .find(|path| path.exists())
+        .cloned()
 }
 
 fn lookup_on_path(spec: &HostAppSpec) -> Option<PathBuf> {
@@ -222,6 +228,11 @@ fn parse_reg_query_path(stdout: &str) -> Option<PathBuf> {
 #[cfg(not(windows))]
 fn lookup_windows_app_paths(_spec: &HostAppSpec) -> Option<PathBuf> {
     None
+}
+
+pub fn detect_libreoffice(cached: Option<&Path>) -> HostAppDetection {
+    let cached = cached.map(Path::to_path_buf);
+    detect_host_app(&libreoffice_spec(), cached.as_ref())
 }
 
 #[allow(dead_code)]

--- a/apps/codehelper/src-tauri/src/setup/python.rs
+++ b/apps/codehelper/src-tauri/src/setup/python.rs
@@ -22,8 +22,9 @@ pub fn bundled_python_item(
                         id: SETUP_ITEM_BUNDLED_PYTHON.to_string(),
                         label: "Bundled Python".to_string(),
                         state: SetupItemStateDto::Ready,
-                        detail: prepared_root
-                            .map(|path| format!("Bundled Python is prepared at {}", path.display())),
+                        detail: prepared_root.map(|path| {
+                            format!("Bundled Python is prepared at {}", path.display())
+                        }),
                         required: true,
                         can_prepare: false,
                     };
@@ -99,18 +100,29 @@ pub fn prepare_bundled_python(
     })?;
 
     copy_payload_entries(&root, &prepared_root)?;
-    std::fs::write(prepared_root.join(PREPARED_VERSION_FILE), manifest.version).map_err(|error| {
-        format!(
-            "Failed to write prepared Python version marker in {}: {error}",
-            prepared_root.display()
-        )
-    })?;
+    std::fs::write(prepared_root.join(PREPARED_VERSION_FILE), manifest.version).map_err(
+        |error| {
+            format!(
+                "Failed to write prepared Python version marker in {}: {error}",
+                prepared_root.display()
+            )
+        },
+    )?;
 
     Ok(())
 }
 
 pub fn prepared_python_root(app_local_data_dir: Option<&Path>) -> Option<PathBuf> {
     app_local_data_dir.map(|path| path.join("setup").join("python"))
+}
+
+pub fn resolve_prepared_python_command(app_local_data_dir: Option<&Path>) -> Option<String> {
+    prepared_python_root(app_local_data_dir).and_then(|root| {
+        prepared_python_candidates(&root)
+            .into_iter()
+            .find(|candidate| candidate.is_file())
+            .map(|path| path.to_string_lossy().to_string())
+    })
 }
 
 fn prepared_version_matches(root: Option<&Path>, version: &str) -> bool {
@@ -123,11 +135,44 @@ fn prepared_version_matches(root: Option<&Path>, version: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn copy_payload_entries(source_root: &Path, target_root: &Path) -> Result<(), String> {
-    for entry in std::fs::read_dir(source_root)
-        .map_err(|error| format!("Failed to read Python payload root {}: {error}", source_root.display()))?
+fn prepared_python_candidates(root: &Path) -> Vec<PathBuf> {
+    let payload_root = root.join("payload");
+    let mut candidates = Vec::new();
+
+    #[cfg(windows)]
     {
-        let entry = entry.map_err(|error| format!("Failed to inspect Python payload entry: {error}"))?;
+        candidates.extend([
+            payload_root.join("python.exe"),
+            payload_root.join("python").join("python.exe"),
+            payload_root.join("Scripts").join("python.exe"),
+            root.join("python.exe"),
+        ]);
+    }
+
+    #[cfg(not(windows))]
+    {
+        candidates.extend([
+            payload_root.join("bin").join("python3"),
+            payload_root.join("bin").join("python"),
+            payload_root.join("python").join("bin").join("python3"),
+            payload_root.join("python").join("bin").join("python"),
+            root.join("bin").join("python3"),
+            root.join("bin").join("python"),
+        ]);
+    }
+
+    candidates
+}
+
+fn copy_payload_entries(source_root: &Path, target_root: &Path) -> Result<(), String> {
+    for entry in std::fs::read_dir(source_root).map_err(|error| {
+        format!(
+            "Failed to read Python payload root {}: {error}",
+            source_root.display()
+        )
+    })? {
+        let entry =
+            entry.map_err(|error| format!("Failed to inspect Python payload entry: {error}"))?;
         let path = entry.path();
         let name = entry.file_name();
         if name.to_str() == Some(MANIFEST_FILE) || name.to_str() == Some(README_FILE) {
@@ -155,7 +200,10 @@ fn copy_path_recursively(source: &Path, target: &Path) -> Result<(), String> {
     } else {
         if let Some(parent) = target.parent() {
             std::fs::create_dir_all(parent).map_err(|error| {
-                format!("Failed to create parent directory {}: {error}", parent.display())
+                format!(
+                    "Failed to create parent directory {}: {error}",
+                    parent.display()
+                )
             })?;
         }
         std::fs::copy(source, target).map_err(|error| {
@@ -171,7 +219,7 @@ fn copy_path_recursively(source: &Path, target: &Path) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{bundled_python_item, prepare_bundled_python};
+    use super::{bundled_python_item, prepare_bundled_python, resolve_prepared_python_command};
     use smolpc_assistant_types::SetupItemStateDto;
     use tempfile::TempDir;
 
@@ -218,7 +266,24 @@ mod tests {
         prepare_bundled_python(Some(resource_temp.path()), Some(app_temp.path())).expect("prepare");
 
         let prepared_root = app_temp.path().join("setup").join("python");
-        assert!(prepared_root.join("payload").join("bin").join("python").exists());
+        assert!(prepared_root
+            .join("payload")
+            .join("bin")
+            .join("python")
+            .exists());
         assert!(prepared_root.join(".prepared-version").exists());
+    }
+
+    #[test]
+    fn resolve_prepared_python_command_detects_prepared_runtime() {
+        let app_temp = TempDir::new().expect("app temp");
+        let prepared_root = app_temp.path().join("setup").join("python").join("payload");
+        std::fs::create_dir_all(prepared_root.join("bin")).expect("python payload");
+        std::fs::write(prepared_root.join("bin").join("python3"), "python").expect("runtime");
+
+        let command =
+            resolve_prepared_python_command(Some(app_temp.path())).expect("prepared python");
+
+        assert!(command.ends_with("python3"));
     }
 }


### PR DESCRIPTION
## Summary
- switch LibreOffice packaged-mode runtime startup to the prepared bundled Python substrate
- detect and pass the LibreOffice host executable into the bundled runtime instead of relying on system Python discovery
- keep dev/test fallbacks explicit while preserving the existing Writer/Slides surface and Calc scaffolding

## Validation
- cargo check -p smolpc-code-helper
- cargo test -p smolpc-code-helper --lib
- cargo test -p smolpc-engine-client
- npm run check --workspace apps/codehelper