### PR TITLE
Docs: close out Phase 3 LibreOffice self-contained runtime

### DIFF
--- a/docs/unified-assistant-self-contained-spec/ARCHITECTURE.md
+++ b/docs/unified-assistant-self-contained-spec/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # SmolPC Unified Assistant Self-Contained Architecture
 
 **Last Updated:** 2026-03-17
-**Status:** Target architecture with Phase 2 foundation landed and Phase 3 LibreOffice ownership preflight locked
+**Status:** Target architecture with Phase 2 foundation and Phase 3 LibreOffice runtime ownership landed
 
 ## 1. Product Shape
 
@@ -111,9 +111,10 @@ Phase 2 implementation status:
 
 Phase 3 first consumer:
 
-- LibreOffice consumes the prepared bundled-Python substrate from setup state
+- LibreOffice now consumes the prepared bundled-Python substrate from setup state
 - `setup_prepare()` still remains foundation-only and does not launch LibreOffice
-- Writer and Slides use that prepared runtime at provider-use time
+- Writer and Slides now use that prepared runtime at provider-use time
+- the provider resolves LibreOffice through the shared host-app locator and passes the detected host path into the runtime
 
 ### 4.4 Mode providers
 
@@ -208,7 +209,7 @@ Those roots are now part of the implementation contract on
 - bundled runtime scripts stay in unified resources
 - packaged builds use the prepared bundled Python runtime only
 - packaged mode does not fall back to system `python` or `python3`
-- provider auto-detects `soffice` and auto-launches it when needed
+- provider auto-detects the LibreOffice host path and the bundled runtime auto-launches `soffice` when needed
 - `mode_status(writer|impress)` and `mode_refresh_tools(writer|impress)` surface bundled-Python and LibreOffice readiness honestly
 - Writer and Slides remain side-effectful single-tool-turn modes
 - Calc stays scaffold-only
@@ -258,9 +259,9 @@ On first use of a live external mode:
 5. provider reports live status and available tools
 6. assistant flow proceeds normally
 
-Phase 2 does not yet implement this full flow for every provider. Phase 3
-implements the LibreOffice slice first while leaving Blender and GIMP
-provisioning for later phases.
+Phase 2 does not yet implement this full flow for every provider. Phase 3 now
+implements the LibreOffice slice while leaving Blender and GIMP provisioning
+for later phases.
 
 ## 11. Deferred Architecture
 

--- a/docs/unified-assistant-self-contained-spec/CURRENT_STATE.md
+++ b/docs/unified-assistant-self-contained-spec/CURRENT_STATE.md
@@ -1,7 +1,7 @@
 # Current State
 
 **Last Updated:** 2026-03-17
-**Status:** Demo line frozen; Phase 2 foundation complete; Phase 3 starts on a single self-contained mainline
+**Status:** Demo line frozen; Phase 3 LibreOffice runtime ownership complete on the single self-contained mainline
 
 ## 1. Branch State
 
@@ -19,14 +19,19 @@
 | `dev/unified-assistant-self-contained`       | Sole active implementation and documentation mainline |
 | `docs/unified-assistant-self-contained-spec` | Frozen archive/reference snapshot                     |
 
-Current implementation head after Phase 2 foundation:
+Current implementation head after Phase 3 LibreOffice runtime ownership:
 
 - `dev/unified-assistant-self-contained` includes:
-  - baseline cleanup sync
-  - Phase 2 docs sync
-  - Phase 2 foundation implementation
-  - Phase 2 closeout docs sync
-  - Phase 2 docs cleanup sync
+  - Phase 3 workflow migration docs
+  - Phase 3 LibreOffice implementation
+  - current implementation head:
+    - `a4119ddd642bee18ea8c31dc29913bee869c5edf`
+  - earlier self-contained history:
+    - baseline cleanup sync
+    - Phase 2 docs sync
+    - Phase 2 foundation implementation
+    - Phase 2 closeout docs sync
+    - Phase 2 docs cleanup sync
 
 Current frozen archive snapshot:
 
@@ -75,8 +80,8 @@ The current unified app is not yet self-contained for external users.
 | ----------------------------- | ---------------------------------------------------- | ----------------------------------------------- |
 | Engine                        | App-owned and auto-started                           | Keep                                            |
 | Models                        | Not guaranteed bundled for external install          | Bundle one default model                        |
-| LibreOffice Python            | External Python still assumed in packaged mode       | Bundle app-private Python                       |
-| LibreOffice runtime bootstrap | Runtime is app-launched but not fully self-contained | Keep app-owned, remove system Python dependency |
+| LibreOffice Python            | External Python still assumed in packaged mode       | Closed on self-contained line for Writer/Slides |
+| LibreOffice runtime bootstrap | Runtime is app-launched but not fully self-contained | Keep app-owned, keep host app external          |
 | Blender addon                 | External manual addon install/enable                 | Auto-provision from bundled resources           |
 | Blender launch                | External manual app launch                           | Detect and launch automatically                 |
 | GIMP plugin/server            | External manual plugin/server setup                  | Bundle and provision automatically              |
@@ -112,7 +117,7 @@ The self-contained delivery line must ship:
 | Mode family | Current source status                                             | Self-contained ownership direction                          |
 | ----------- | ----------------------------------------------------------------- | ----------------------------------------------------------- |
 | Code        | Already owned in `apps/codehelper`                                | Keep                                                        |
-| LibreOffice | Runtime scripts already imported into unified resources           | Replace system Python dependency with bundled Python        |
+| LibreOffice | Runtime scripts already imported into unified resources           | Bundled Python now owns packaged Writer/Slides runtime path |
 | Blender     | Bridge already owned by unified app; addon still external         | Bundle and provision addon from repo source                 |
 | GIMP        | Unified provider exists, but runtime/plugin ownership is external | Vendor pinned upstream `gimp-mcp` snapshot and provision it |
 
@@ -163,6 +168,8 @@ Starting with Phase 3:
 - future self-contained docs land directly on the implementation mainline
 - `docs/unified-assistant-self-contained-spec` is archive/reference only
 
+That workflow transition is now merged and active.
+
 ## 7. Phase 2 Scope
 
 Phase 2 established the self-contained foundation only:
@@ -182,15 +189,36 @@ Phase 2 does not include:
 - host-app launch orchestration
 - Calc activation
 
-## 8. Next Official Branches
+## 8. Phase 3 Scope
+
+Phase 3 is now merged into `dev/unified-assistant-self-contained`.
+
+Phase 3 landed:
+
+- bundled-Python runtime ownership for Writer and Slides in packaged mode
+- no packaged-mode fallback to system `python` or `python3`
+- LibreOffice host detection through the setup host-app locator
+- passing the detected `soffice` path into the bundled LibreOffice runtime
+- on-demand LibreOffice host launch through the existing bundled runtime bootstrap
+- honest Writer/Slides runtime readiness errors when bundled Python or LibreOffice is unavailable
+
+Phase 3 intentionally did not land:
+
+- Blender addon provisioning
+- GIMP plugin/server provisioning
+- Blender or GIMP host-app launch orchestration
+- Calc activation
+- settings UI for manual LibreOffice path overrides
+
+## 9. Next Official Branches
 
 The next required branch sequence is:
 
-1. `codex/unified-self-contained-libreoffice-docs`
-2. `codex/unified-self-contained-libreoffice`
-3. `codex/unified-self-contained-libreoffice-status-docs`
+1. `codex/unified-self-contained-blender-docs`
+2. `codex/unified-self-contained-blender`
+3. `codex/unified-self-contained-blender-status-docs`
 
-## 9. Known Risks
+## 10. Known Risks
 
 | Risk                   | Why it matters                                                                                                   |
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------- |

--- a/docs/unified-assistant-self-contained-spec/IMPLEMENTATION_PHASES.md
+++ b/docs/unified-assistant-self-contained-spec/IMPLEMENTATION_PHASES.md
@@ -1,7 +1,7 @@
 # Self-Contained Delivery Phases
 
 **Last Updated:** 2026-03-17
-**Status:** Branch cut, cleanup, and Phase 2 foundation complete; Phase 3 docs preflight next
+**Status:** Branch cut, cleanup, foundation, and Phase 3 complete; Phase 4 docs preflight next
 
 ## Phase 0: Demo Freeze And Branch Cut
 
@@ -138,7 +138,7 @@ Starting in Phase 3:
 
 ## Phase 3: LibreOffice Self-Contained Runtime
 
-**Status:** next
+**Status:** complete
 
 **Branches**
 
@@ -161,7 +161,24 @@ Starting in Phase 3:
 - Writer and Slides work on a machine with LibreOffice installed and no Python installed
 - no manual bootstrap/runtime step remains
 
+**Closeout status**
+
+Complete on the self-contained implementation line:
+
+- Writer and Slides now consume the setup-prepared bundled Python runtime in packaged mode
+- packaged mode no longer falls back to system `python` or `python3`
+- LibreOffice host detection is now wired through the setup locator
+- the detected `soffice` path is passed into the bundled runtime
+- the bundled runtime auto-launches LibreOffice on demand
+- Calc remains scaffold-only
+
+The next official branch after Phase 3 closeout docs is:
+
+- `codex/unified-self-contained-blender-docs`
+
 ## Phase 4: Blender Self-Contained Provisioning
+
+**Status:** next
 
 **Branches**
 

--- a/docs/unified-assistant-self-contained-spec/LEARNINGS.md
+++ b/docs/unified-assistant-self-contained-spec/LEARNINGS.md
@@ -20,6 +20,8 @@
 
 - **Bundled Python is the cross-mode enabler** (2026-03-17): Removing external Python is not only a LibreOffice requirement. The managed Python runtime is also the cleanest foundation for GIMP-side runtime ownership and future packaging consistency across provider-owned resources.
 
+- **LibreOffice must not silently swap interpreters once bundled Python owns the runtime** (2026-03-17): After Phase 3, the bundled LibreOffice runtime must keep using the exact interpreter that launched `main.py`. Letting the runtime rediscover and switch to an office-bundled Python would undermine the whole packaged-mode ownership contract and make setup status misleading.
+
 - **Provenance must be documented before third-party imports land** (2026-03-17): Any vendored runtime, addon, plugin, or model payload needs a pinned source reference, license notes, and local modification tracking in `THIRD_PARTY_PROVENANCE.md` before implementation branches import it.
 
 - **Keep setup state app-level and phase-limited at first** (2026-03-17): Phase 2 stayed low-risk because it introduced setup state, detection, manifests, and a lightweight UI without changing any mode activation paths. That kept the foundation branch additive and made later runtime/provisioning phases narrower.

--- a/docs/unified-assistant-self-contained-spec/MCP_INTEGRATION.md
+++ b/docs/unified-assistant-self-contained-spec/MCP_INTEGRATION.md
@@ -1,7 +1,7 @@
 # MCP And Provider Integration For The Self-Contained Line
 
 **Last Updated:** 2026-03-17
-**Status:** Integration ownership spec with Phase 2 setup foundation landed and Phase 3 LibreOffice runtime rules locked
+**Status:** Integration ownership spec with Phase 2 setup foundation and Phase 3 LibreOffice runtime ownership landed
 
 ## 1. Scope
 
@@ -36,16 +36,16 @@ New app-level setup commands are added separately:
 | `mcp`         | GIMP, Writer, Calc, Slides | app-owned runtime or transport plus external host app |
 | `hybrid`      | Blender                    | app-owned bridge plus provisioned addon               |
 
-Phase 2 keeps the existing live provider behavior intact while adding the
-shared setup/provisioning substrate those providers will later consume.
+Phase 2 kept the existing live provider behavior intact while adding the shared
+setup/provisioning substrate those providers consume later.
 
-That substrate is now merged into the implementation line. Current mode behavior
-remains unchanged:
+That substrate is now merged into the implementation line. Current live-mode
+surfaces remain unchanged:
 
 - Code stays live as-is
 - GIMP stays live as-is
 - Blender stays live as-is
-- Writer and Slides stay live as-is
+- Writer and Slides stay live while their packaged-mode runtime ownership now uses bundled Python
 - Calc stays disabled
 
 ## 3. Stable Provider Interface
@@ -103,7 +103,7 @@ Ownership rules:
 - LibreOffice / Collabora remains separately installed
 - unified app owns Python runtime and MCP scripts
 - `setup_prepare()` prepares the app-owned Python substrate but does not launch LibreOffice
-- provider auto-detects and auto-launches `soffice` when required
+- provider auto-detects the LibreOffice host path and the bundled runtime auto-launches `soffice` when required
 - no Phase 3 settings UI or manual path override UI is added
 
 Mode rules:
@@ -221,7 +221,7 @@ Expected supervisors:
 Phase 2 introduces the shared setup state and packaged-resource validation
 needed before those provider-specific supervisors take ownership in later
 phases. Phase 3 is the first phase where one of those supervisors becomes a
-real packaged-mode runtime dependency.
+real packaged-mode runtime dependency, and that LibreOffice slice is now merged.
 
 ## 9. Non-Goals In This Line
 

--- a/docs/unified-assistant-self-contained-spec/PACKAGING.md
+++ b/docs/unified-assistant-self-contained-spec/PACKAGING.md
@@ -1,7 +1,7 @@
 # Packaging And Distribution For The Self-Contained Line
 
 **Last Updated:** 2026-03-17
-**Status:** Packaging target with Phase 2 foundation contract landed and Phase 3 LibreOffice packaging rules locked
+**Status:** Packaging target with Phase 2 foundation contract and Phase 3 LibreOffice bundled-Python ownership landed
 
 ## 1. Packaging Direction
 
@@ -47,6 +47,12 @@ The installer must not assume the user will separately install:
 
 Phase 2 adds the resource and manifest contract for `resources/models/` and
 `resources/python/`, but it does not yet ship the final packaged payloads.
+
+Phase 3 uses that contract for Writer and Slides:
+
+- packaged-mode runtime startup now resolves the prepared bundled Python runtime
+- the detected LibreOffice host path is injected into the bundled runtime
+- final staged CPython and `uv` payloads still remain packaging-time inputs rather than committed git history
 
 Phase 2 also adds tracked resource roots for:
 
@@ -99,10 +105,10 @@ Phase 2 stop-point:
 - host-app launch remains deferred
 - plugin/addon provisioning remains deferred
 
-Phase 3 exception:
+Phase 3 live state:
 
 - LibreOffice host detection becomes live for Writer and Slides
-- the provider may auto-launch LibreOffice on demand
+- the bundled LibreOffice runtime auto-launches LibreOffice on demand
 - GIMP and Blender host-app launch remain deferred
 
 ## 6. Packaging Invariants
@@ -143,7 +149,7 @@ Before calling the self-contained line ready, verify on Windows:
 1. packaged app launches without launcher help
 2. engine starts automatically
 3. bundled default model resolves and loads
-4. Writer and Slides use bundled Python only; no system Python is required
+4. Writer and Slides use bundled Python only; no system Python is required in packaged mode
 5. first Writer use launches runtime plus LibreOffice
 6. first Slides use launches runtime plus LibreOffice
 7. first Blender use provisions addon and launches Blender

--- a/docs/unified-assistant-self-contained-spec/SETUP_SPEC.md
+++ b/docs/unified-assistant-self-contained-spec/SETUP_SPEC.md
@@ -1,7 +1,7 @@
 # Setup Subsystem Spec
 
 **Last Updated:** 2026-03-17
-**Status:** Phase 2 foundation contract, now merged; single-mainline workflow does not change the setup API
+**Status:** Phase 2 foundation contract merged; Phase 3 now consumes prepared bundled Python without changing the setup API
 
 ## 1. Purpose
 
@@ -33,6 +33,12 @@ Phase 2 closeout status:
 - `setup_status` and `setup_prepare` landed
 - setup banner and setup panel landed
 - current mode behavior remained unchanged
+
+Phase 3 follow-on status:
+
+- Writer and Slides now consume the setup-prepared bundled Python runtime in packaged mode
+- setup remains app-level and foundation-only
+- `setup_status` and `setup_prepare` remain wire-compatible with the Phase 2 contract
 
 Phase 2 setup work does not include:
 
@@ -185,7 +191,7 @@ The setup surface must remain lightweight:
 
 Later phases build on this subsystem:
 
-- Phase 3: LibreOffice uses bundled Python ownership from setup
+- Phase 3: LibreOffice now uses bundled Python ownership from setup
 - Phase 4: Blender addon provisioning plugs into setup/provision state
 - Phase 5: GIMP plugin/server provisioning plugs into setup/provision state
 - Phase 6: packaged release validation uses setup status as the first-run and repair surface
@@ -194,6 +200,6 @@ The single-mainline workflow adopted after Phase 2 does not change the
 `setup_status` or `setup_prepare` wire contract. It only changes where the
 future docs PRs land.
 
-The next official branch after Phase 2 closeout is:
+The next official branch after Phase 3 closeout is:
 
-- `codex/unified-self-contained-libreoffice-docs`
+- `codex/unified-self-contained-blender-docs`

--- a/docs/unified-assistant-self-contained-spec/THIRD_PARTY_PROVENANCE.md
+++ b/docs/unified-assistant-self-contained-spec/THIRD_PARTY_PROVENANCE.md
@@ -1,7 +1,7 @@
 # Third-Party Provenance Tracker
 
 **Last Updated:** 2026-03-17
-**Status:** Required tracker before third-party runtime imports land on the self-contained line
+**Status:** Required tracker with Phase 3 bundled-Python source contract locked for LibreOffice
 
 ## Purpose
 
@@ -20,20 +20,21 @@ Required fields:
 
 ## Tracking Table
 
-| Component                                      | Current source                                                                                                  | Pin status     | License status                                                    | Import status                             | Notes                                                                                                          |
-| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | -------------- | ----------------------------------------------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| GIMP MCP/plugin runtime                        | upstream `gimp-mcp` source snapshot                                                                             | pending        | pending                                                           | not yet imported into self-contained line | Required before Phase 5 implementation                                                                         |
-| Blender addon payload                          | `apps/blender-assistant/blender_addon/blender_helper_http.py`                                                   | in-repo source | repo license review pending                                       | not yet repackaged into unified resources | Phase 4 will provision from existing repo source                                                               |
-| LibreOffice MCP runtime scripts                | imported from `origin/codex/libreoffice-port-track-a` @ `7acad1fa0eb31e32a5485069e85c021d14284455`              | pinned         | same repo lineage; formal release packaging review still required | already present in unified resources      | Imported from the same repository line; Phase 3 switches them onto bundled Python ownership                    |
-| Bundled Python runtime                         | official Windows x64 CPython embeddable distribution from `python.org`, staged into `resources/python/payload/` | source locked  | Python Software Foundation License                                | manifest/staging contract landed          | Phase 3 consumes the prepared bundled runtime for Writer/Slides; exact packaged version remains a manifest pin |
-| Bundled `uv` tooling/runtime support           | Astral `uv` Windows binary staged alongside the bundled Python payload                                          | source locked  | Apache-2.0 OR MIT                                                 | manifest/staging contract landed          | Used for packaged Python management and future offline wheel install/repair flows                              |
-| Default bundled model `qwen3-4b-instruct-2507` | current engine-supported model artifact source                                                                  | pending        | pending                                                           | manifest/staging contract landed          | Phase 2 added manifests and staging hooks; exact packaged artifact validation is still required                |
+| Component                                      | Current source                                                                                                  | Pin status     | License status                                                    | Import status                             | Notes                                                                                                                                                                 |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | -------------- | ----------------------------------------------------------------- | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GIMP MCP/plugin runtime                        | upstream `gimp-mcp` source snapshot                                                                             | pending        | pending                                                           | not yet imported into self-contained line | Required before Phase 5 implementation                                                                                                                                |
+| Blender addon payload                          | `apps/blender-assistant/blender_addon/blender_helper_http.py`                                                   | in-repo source | repo license review pending                                       | not yet repackaged into unified resources | Phase 4 will provision from existing repo source                                                                                                                      |
+| LibreOffice MCP runtime scripts                | imported from `origin/codex/libreoffice-port-track-a` @ `7acad1fa0eb31e32a5485069e85c021d14284455`              | pinned         | same repo lineage; formal release packaging review still required | already present in unified resources      | Imported from the same repository line; Phase 3 switches them onto bundled Python ownership                                                                           |
+| Bundled Python runtime                         | official Windows x64 CPython embeddable distribution from `python.org`, staged into `resources/python/payload/` | source locked  | Python Software Foundation License                                | packaged-mode contract is live            | Phase 3 runtime code now consumes the prepared bundled runtime for Writer/Slides; exact staged CPython release still needs a manifest pin when payloads are populated |
+| Bundled `uv` tooling/runtime support           | Astral `uv` Windows binary staged alongside the bundled Python payload                                          | source locked  | Apache-2.0 OR MIT                                                 | manifest/staging contract landed          | Used for packaged Python management and future offline wheel install/repair flows; exact staged binary release still needs a manifest pin when payloads are populated |
+| Default bundled model `qwen3-4b-instruct-2507` | current engine-supported model artifact source                                                                  | pending        | pending                                                           | manifest/staging contract landed          | Phase 2 added manifests and staging hooks; exact packaged artifact validation is still required                                                                       |
 
-## Phase 2 Provenance Rule
+## Phase 2-3 Provenance Rule
 
-Phase 2 may add manifests and staging hooks for bundled Python and the default
-model, but it should not silently treat those artifacts as fully cleared for
-release packaging. The tracker must stay honest about:
+Phases 2 and 3 may add manifests, staging hooks, and runtime ownership code for
+bundled Python and the default model, but they should not silently treat those
+artifacts as fully cleared for release packaging. The tracker must stay honest
+about:
 
 - exact pinned packaged artifact source
 - license review status


### PR DESCRIPTION
## Summary
- record Phase 3 as merged on the single-mainline self-contained workflow
- update current-state, architecture, MCP, packaging, setup, and provenance docs to match the bundled-Python LibreOffice runtime ownership now in code
- set the next official branch sequence to the Blender self-contained phase

## Validation
- npx prettier --check docs/unified-assistant-self-contained-spec/*.md