### PR TITLE
feat: self-contained blender provisioning

### DIFF
--- a/apps/codehelper/src-tauri/resources/blender/README.md
+++ b/apps/codehelper/src-tauri/resources/blender/README.md
@@ -1,7 +1,6 @@
 # Blender Bundled Resource Root
 
-This directory already contains bundled Blender-side resources used by the
-unified app.
+This directory contains bundled Blender-side resources owned by the unified app.
 
-Phase 2 adds the tracked resource manifest here so later self-contained phases
-can version and provision Blender-owned assets explicitly.
+Phase 4 adds the pinned addon snapshot at `addon/blender_helper_http.py` while
+keeping the existing `rag_system/` payload bundled for scene-aware tutoring.

--- a/apps/codehelper/src-tauri/resources/blender/addon/blender_helper_http.py
+++ b/apps/codehelper/src-tauri/resources/blender/addon/blender_helper_http.py
@@ -1,0 +1,571 @@
+"""
+Blender Learning Assistant - HTTP Client Version
+
+Educational addon that helps students learn Blender through:
+- Scene-aware Q&A
+- Smart suggestions based on current work
+
+Connects to the local Blender Learning Assistant bridge for AI-powered guidance.
+"""
+
+import bpy
+import traceback
+import time
+
+bl_info = {
+    "name": "Blender Learning Assistant",
+    "author": "SmolPC",
+    "version": (7, 0, 0),
+    "blender": (3, 0, 0),
+    "category": "3D View",
+    "description": "Educational assistant for learning Blender (offline)",
+}
+
+
+# ============================================================================
+# Scene Data Collection
+# ============================================================================
+
+def gather_scene_info():
+    """Collect current scene state for educational assistant."""
+    try:
+        scene_data = {
+            'object_count': len(bpy.context.scene.objects),
+            'objects': [],
+            'selected_objects': [obj.name for obj in bpy.context.selected_objects],
+            'active_object': bpy.context.active_object.name if bpy.context.active_object else None,
+            'mode': bpy.context.mode,
+            'render_engine': bpy.context.scene.render.engine
+        }
+
+        # Gather detailed object info
+        for obj in bpy.context.scene.objects:
+            obj_info = {
+                'name': obj.name,
+                'type': obj.type,
+                'modifiers': [
+                    {'name': m.name, 'type': m.type}
+                    for m in obj.modifiers
+                ],
+                'material_count': len(obj.material_slots)
+            }
+            scene_data['objects'].append(obj_info)
+
+        return scene_data
+
+    except Exception as e:
+        print(f"Error gathering scene info: {e}")
+        return {'error': str(e)}
+
+
+# ============================================================================
+# Bridge Token Auth
+# ============================================================================
+
+def _read_bridge_token():
+    """Read the bridge auth token written by the Tauri app."""
+    import os
+    local_app_data = os.environ.get('LOCALAPPDATA', '')
+    if not local_app_data:
+        return None
+    token_path = os.path.join(local_app_data, 'SmolPC', 'engine-runtime', 'bridge-token.txt')
+    try:
+        with open(token_path, 'r') as f:
+            return f.read().strip() or None
+    except (OSError, IOError):
+        return None
+
+
+def _auth_headers():
+    """Return Authorization header dict if a bridge token is available."""
+    token = _read_bridge_token()
+    if token:
+        return {'Authorization': f'Bearer {token}'}
+    return {}
+
+
+# ============================================================================
+# HTTP Client Functions
+# ============================================================================
+
+def ask_question(question, server_url="http://127.0.0.1:5179"):
+    """Ask an educational question through the local assistant bridge."""
+    import requests
+
+    try:
+        scene_context = gather_scene_info()
+
+        response = requests.post(
+            f"{server_url}/ask",
+            json={
+                'question': question,
+                'scene_context': scene_context
+            },
+            headers=_auth_headers(),
+            timeout=60
+        )
+
+        response.raise_for_status()
+        data = response.json()
+
+        return {
+            'answer': data.get('answer', ''),
+            'contexts_used': data.get('contexts_used', 0),
+            'error': None
+        }
+
+    except requests.exceptions.ConnectionError:
+        return {
+            'answer': None,
+            'error': 'Cannot connect to Blender Learning Assistant. Open the desktop app and try again.'
+        }
+    except requests.exceptions.Timeout:
+        return {
+            'answer': None,
+            'error': 'Request timed out.'
+        }
+    except Exception as e:
+        return {
+            'answer': None,
+            'error': f'Error: {str(e)}'
+        }
+
+
+def get_suggestions(server_url="http://127.0.0.1:5179"):
+    """Get learning suggestions based on current scene."""
+    import requests
+
+    try:
+        scene_data = gather_scene_info()
+
+        response = requests.post(
+            f"{server_url}/scene_analysis",
+            json={
+                'goal': 'learning blender',
+                'scene_data': scene_data
+            },
+            headers=_auth_headers(),
+            timeout=60
+        )
+
+        response.raise_for_status()
+        data = response.json()
+
+        return {
+            'suggestions': data.get('suggestions', []),
+            'error': None
+        }
+
+    except requests.exceptions.ConnectionError:
+        return {
+            'suggestions': None,
+            'error': 'Cannot connect to Blender Learning Assistant.'
+        }
+    except Exception as e:
+        return {
+            'suggestions': None,
+            'error': f'Error: {str(e)}'
+        }
+
+
+def update_scene_data(server_url="http://127.0.0.1:5179"):
+    """Send current scene data to server for caching."""
+    import requests
+
+    try:
+        scene_data = gather_scene_info()
+
+        response = requests.post(
+            f"{server_url}/scene/update",
+            json={'scene_data': scene_data},
+            headers=_auth_headers(),
+            timeout=0.5
+        )
+
+        response.raise_for_status()
+        return {'success': True, 'error': None}
+
+    except requests.exceptions.ConnectionError:
+        return {'success': False, 'error': 'Server not running'}
+    except Exception as e:
+        return {'success': False, 'error': str(e)}
+
+
+def check_server_health(server_url="http://127.0.0.1:5179", timeout=5):
+    """Check if the Blender Learning Assistant bridge is running."""
+    import requests
+
+    try:
+        response = requests.get(f"{server_url}/health", timeout=timeout)
+        response.raise_for_status()
+        data = response.json()
+
+        return {
+            'running': True,
+            'rag_enabled': data.get('rag_enabled', False),
+            'rag_docs': data.get('rag_docs', 0),
+            'error': None,
+            'last_updated': time.time()
+        }
+
+    except requests.exceptions.ConnectionError:
+        return {
+            'running': False,
+            'error': 'Server not running',
+            'last_updated': time.time()
+        }
+    except Exception as e:
+        return {
+            'running': False,
+            'error': str(e),
+            'last_updated': time.time()
+        }
+
+
+# ============================================================================
+# Blender Operators
+# ============================================================================
+
+class BLENDERHELPER_OT_ask_question(bpy.types.Operator):
+    """Ask a question about Blender"""
+    bl_idname = "blenderhelper.ask_question"
+    bl_label = "Ask Question"
+
+    def execute(self, context):
+        question = context.scene.blenderhelper_question
+
+        if not question.strip():
+            self.report({'ERROR'}, "Please enter a question")
+            return {'CANCELLED'}
+
+        try:
+            self.report({'INFO'}, f"Asking: {question}")
+
+            # Call assistant bridge
+            result = ask_question(question)
+
+            if result['error']:
+                self.report({'ERROR'}, result['error'])
+                return {'CANCELLED'}
+
+            answer = result['answer']
+
+            if not answer:
+                self.report({'ERROR'}, "No answer received")
+                return {'CANCELLED'}
+
+            # Store answer
+            context.scene.blenderhelper_answer = answer
+
+            # Show in console
+            contexts = result.get('contexts_used', 0)
+            print("\n" + "="*60)
+            print(f"Question: {question}")
+            print("="*60)
+            print(f"Answer ({contexts} docs used):\n")
+            print(answer)
+            print("="*60 + "\n")
+
+            self.report({'INFO'}, "Answer ready. Check the panel or console.")
+            return {'FINISHED'}
+
+        except Exception as e:
+            error_msg = str(e)
+            self.report({'ERROR'}, f"Failed: {error_msg}")
+            print(f"[ERROR] {error_msg}")
+            traceback.print_exc()
+            return {'CANCELLED'}
+
+
+class BLENDERHELPER_OT_get_suggestions(bpy.types.Operator):
+    """Get learning suggestions based on current scene"""
+    bl_idname = "blenderhelper.get_suggestions"
+    bl_label = "Get Suggestions"
+
+    def execute(self, context):
+        try:
+            self.report({'INFO'}, "Analyzing your scene...")
+
+            # Get suggestions
+            result = get_suggestions()
+
+            if result['error']:
+                self.report({'ERROR'}, result['error'])
+                return {'CANCELLED'}
+
+            suggestions = result['suggestions']
+
+            if not suggestions:
+                self.report({'ERROR'}, "No suggestions received")
+                return {'CANCELLED'}
+
+            if isinstance(suggestions, list):
+                suggestions_text = "\n".join(suggestions)
+            else:
+                suggestions_text = str(suggestions)
+
+            # Store suggestions
+            context.scene.blenderhelper_suggestions = suggestions_text
+
+            # Show in console
+            print("\n" + "="*60)
+            print("Learning Suggestions:")
+            print("="*60)
+            print(suggestions_text)
+            print("="*60 + "\n")
+
+            self.report({'INFO'}, "Got suggestions. Check the panel.")
+            return {'FINISHED'}
+
+        except Exception as e:
+            error_msg = str(e)
+            self.report({'ERROR'}, f"Failed: {error_msg}")
+            print(f"[ERROR] {error_msg}")
+            traceback.print_exc()
+            return {'CANCELLED'}
+
+
+class BLENDERHELPER_OT_show_answer(bpy.types.Operator):
+    """Show answer in a popup"""
+    bl_idname = "blenderhelper.show_answer"
+    bl_label = "View Answer"
+
+    def execute(self, context):
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(self, width=600)
+
+    def draw(self, context):
+        layout = self.layout
+        answer = context.scene.blenderhelper_answer
+
+        if not answer:
+            layout.label(text="No answer yet. Ask a question first!")
+            return
+
+        # Word wrap the answer
+        box = layout.box()
+        max_chars_per_line = 70
+        words = answer.split()
+        current_line = ""
+
+        for word in words:
+            if len(current_line) + len(word) + 1 <= max_chars_per_line:
+                current_line += word + " "
+            else:
+                if current_line:
+                    box.label(text=current_line.strip())
+                current_line = word + " "
+
+        if current_line:
+            box.label(text=current_line.strip())
+
+
+class BLENDERHELPER_OT_test_server(bpy.types.Operator):
+    """Test connection to Blender Learning Assistant"""
+    bl_idname = "blenderhelper.test_server"
+    bl_label = "Test Server"
+
+    def execute(self, context):
+        health = check_server_health()
+
+        if health['running']:
+            if health['rag_enabled']:
+                msg = f"Bridge running. RAG: {health['rag_docs']} docs"
+            else:
+                msg = "Bridge running (RAG disabled)"
+            self.report({'INFO'}, msg)
+        else:
+            self.report({'ERROR'}, f"Bridge not running: {health['error']}")
+            print("\nOpen Blender Learning Assistant desktop app, then retry.")
+
+        return {'FINISHED'}
+
+
+# ============================================================================
+# UI Panel
+# ============================================================================
+
+class BLENDERHELPER_PT_panel(bpy.types.Panel):
+    """Main panel for Blender Learning Assistant"""
+    bl_label = "Learning Assistant"
+    bl_idname = "BLENDERHELPER_PT_panel"
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category = 'Learn'
+
+    def draw(self, context):
+        layout = self.layout
+        scene = context.scene
+
+        # Scene Overview
+        box = layout.box()
+        box.label(text="Current Scene:", icon='SCENE_DATA')
+
+        scene_info = gather_scene_info()
+        box.label(text=f"Objects: {scene_info.get('object_count', 0)}")
+
+        active = scene_info.get('active_object')
+        if active:
+            box.label(text=f"Active: {active}")
+
+        box.label(text=f"Mode: {scene_info.get('mode', 'OBJECT')}")
+
+        # Ask Question Section
+        layout.separator()
+        box = layout.box()
+        box.label(text="Ask a Question:", icon='QUESTION')
+        box.prop(scene, "blenderhelper_question", text="")
+
+        row = box.row(align=True)
+        row.scale_y = 1.3
+        row.operator("blenderhelper.ask_question", text="Ask", icon='VIEWZOOM')
+        row.operator("blenderhelper.show_answer", text="View Answer", icon='TEXT')
+
+        # Suggestions Section
+        layout.separator()
+        box = layout.box()
+        box.label(text="What to Try Next:", icon='LIGHT')
+
+        row = box.row()
+        row.scale_y = 1.3
+        row.operator("blenderhelper.get_suggestions", text="Get Suggestions", icon='LIGHTPROBE_GRID')
+
+        # Show suggestions if available
+        suggestions = scene.blenderhelper_suggestions
+        if suggestions:
+            suggestion_box = box.box()
+            # Show first few lines
+            lines = suggestions.split('\n')[:5]
+            for line in lines:
+                if line.strip():
+                    suggestion_box.label(text=line[:60])
+            if len(lines) > 5:
+                suggestion_box.label(text="... (see console for more)")
+
+        # Server Status
+        layout.separator()
+        box = layout.box()
+        box.label(text="System Status:", icon='SETTINGS')
+
+        # Read cached server health (non-blocking - safe for UI thread)
+        health = get_cached_server_health()
+
+        if health['running']:
+            box.label(text="Bridge: Running", icon='CHECKMARK')
+
+            if health['rag_enabled']:
+                box.label(text=f"   Docs: {health['rag_docs']}")
+        else:
+            box.label(text="Bridge: Not running", icon='ERROR')
+            box.label(text="   Open desktop app")
+
+        # Test button
+        row = box.row()
+        row.operator("blenderhelper.test_server", text="Test Connection", icon='PLUGIN')
+
+
+# ============================================================================
+# Scene Data Sync Timer
+# ============================================================================
+
+# Global cache for server health status (updated by timer, read by UI)
+_server_health_cache = {
+    'running': False,
+    'rag_enabled': False,
+    'rag_docs': 0,
+    'error': 'Not checked yet',
+    'last_updated': 0
+}
+
+
+def sync_scene_timer():
+    """Periodic timer to send scene data to server and update health cache."""
+    global _server_health_cache
+
+    # Update health cache (non-blocking for UI)
+    health = check_server_health(timeout=0.5)
+    _server_health_cache = {**_server_health_cache, **health}
+
+    # Only sync scene if server is running
+    if health['running']:
+        update_scene_data()
+
+    # Re-register timer (every 5 seconds)
+    return 5.0
+
+
+def get_cached_server_health():
+    """Get cached server health status (non-blocking, safe for UI thread)."""
+    global _server_health_cache
+    return _server_health_cache.copy()
+
+
+# ============================================================================
+# Registration
+# ============================================================================
+
+classes = [
+    BLENDERHELPER_OT_ask_question,
+    BLENDERHELPER_OT_get_suggestions,
+    BLENDERHELPER_OT_show_answer,
+    BLENDERHELPER_OT_test_server,
+    BLENDERHELPER_PT_panel,
+]
+
+
+def register():
+    # Register properties
+    bpy.types.Scene.blenderhelper_question = bpy.props.StringProperty(
+        name="Question",
+        description="Ask a question about Blender",
+        default="What is a modifier?"
+    )
+
+    bpy.types.Scene.blenderhelper_answer = bpy.props.StringProperty(
+        name="Answer",
+        description="Last answer from learning assistant",
+        default=""
+    )
+
+    bpy.types.Scene.blenderhelper_suggestions = bpy.props.StringProperty(
+        name="Suggestions",
+        description="Learning suggestions based on current scene",
+        default=""
+    )
+
+    # Register classes
+    for cls in classes:
+        bpy.utils.register_class(cls)
+
+    # Start scene data sync timer
+    if not bpy.app.timers.is_registered(sync_scene_timer):
+        bpy.app.timers.register(sync_scene_timer, first_interval=2.0)
+
+    print("\n" + "="*60)
+    print("Blender Learning Assistant loaded successfully!")
+    print("="*60)
+    print("Start the Blender Learning Assistant desktop app")
+    print("Find addon in: 3D Viewport > Sidebar (N) > Learn")
+    print("Scene sync: Active (updates every 5 seconds)")
+    print("="*60 + "\n")
+
+
+def unregister():
+    # Stop scene sync timer
+    if bpy.app.timers.is_registered(sync_scene_timer):
+        bpy.app.timers.unregister(sync_scene_timer)
+
+    # Unregister classes
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)
+
+    # Remove properties
+    del bpy.types.Scene.blenderhelper_question
+    del bpy.types.Scene.blenderhelper_answer
+    del bpy.types.Scene.blenderhelper_suggestions
+
+
+if __name__ == "__main__":
+    register()

--- a/apps/codehelper/src-tauri/resources/blender/manifest.json
+++ b/apps/codehelper/src-tauri/resources/blender/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "phase2-foundation-placeholder",
-  "source": "in-repo blender resources",
-  "expectedPaths": ["README.md", "rag_system"],
+  "version": "phase4-blender-addon-payload",
+  "source": "in-repo blender resources and addon snapshot",
+  "expectedPaths": ["README.md", "rag_system", "addon/blender_helper_http.py"],
   "status": "tracked"
 }

--- a/apps/codehelper/src-tauri/src/modes/blender/provider.rs
+++ b/apps/codehelper/src-tauri/src/modes/blender/provider.rs
@@ -3,12 +3,15 @@ use super::rag::{RagContext, RagIndex};
 use super::state::{shared_scene_cache, SceneCache, SceneSnapshot};
 use crate::assistant::MODE_UNDO_NOT_SUPPORTED_IN_FOUNDATION;
 use crate::modes::provider::{provider_state, ToolProvider};
+use crate::setup::blender::{ensure_blender_addon_prepared, BlenderAddonPrepareOutcome};
+use crate::setup::host_apps::{detect_blender, HostAppDetection};
+use crate::setup::launch::{launch_blender_if_needed, BlenderLaunchOutcome};
 use async_trait::async_trait;
 use serde_json::json;
 use smolpc_assistant_types::{
     AppMode, ProviderStateDto, ToolDefinitionDto, ToolExecutionResultDto,
 };
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::{Mutex as AsyncMutex, RwLock};
 
@@ -19,6 +22,7 @@ struct RuntimeState {
     rag_index: RagIndex,
     last_error: Option<String>,
     bridge_attempted: bool,
+    detected_blender_path: Option<PathBuf>,
 }
 
 impl Default for RuntimeState {
@@ -29,6 +33,7 @@ impl Default for RuntimeState {
             rag_index: RagIndex::disabled("Retrieval not loaded yet".to_string()),
             last_error: None,
             bridge_attempted: false,
+            detected_blender_path: None,
         }
     }
 }
@@ -37,27 +42,55 @@ impl Default for RuntimeState {
 pub struct BlenderProvider {
     config: BridgeConfig,
     resource_dir: Option<PathBuf>,
+    app_local_data_dir: Option<PathBuf>,
     scene_cache: Arc<RwLock<SceneCache>>,
     state: AsyncMutex<RuntimeState>,
+    connect_lock: AsyncMutex<()>,
+    host_blender_override: Option<PathBuf>,
 }
 
 impl Default for BlenderProvider {
     fn default() -> Self {
-        Self::new(None)
+        Self::new(None, None)
     }
 }
 
 impl BlenderProvider {
-    pub fn new(resource_dir: Option<PathBuf>) -> Self {
-        Self::with_config(BridgeConfig::default(), resource_dir)
+    pub fn new(resource_dir: Option<PathBuf>, app_local_data_dir: Option<PathBuf>) -> Self {
+        Self::with_config(BridgeConfig::default(), resource_dir, app_local_data_dir)
     }
 
-    pub fn with_config(config: BridgeConfig, resource_dir: Option<PathBuf>) -> Self {
+    pub fn with_config(
+        config: BridgeConfig,
+        resource_dir: Option<PathBuf>,
+        app_local_data_dir: Option<PathBuf>,
+    ) -> Self {
         Self {
             config,
             resource_dir,
+            app_local_data_dir,
             scene_cache: shared_scene_cache(),
             state: AsyncMutex::new(RuntimeState::default()),
+            connect_lock: AsyncMutex::new(()),
+            host_blender_override: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_host_override(
+        config: BridgeConfig,
+        resource_dir: Option<PathBuf>,
+        app_local_data_dir: Option<PathBuf>,
+        host_blender_override: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            config,
+            resource_dir,
+            app_local_data_dir,
+            scene_cache: shared_scene_cache(),
+            state: AsyncMutex::new(RuntimeState::default()),
+            connect_lock: AsyncMutex::new(()),
+            host_blender_override,
         }
     }
 
@@ -104,17 +137,48 @@ impl BlenderProvider {
         provider_state(mode, status, state.last_error.as_deref(), true, false)
     }
 
+    fn host_detection(&self, cached: Option<&Path>) -> HostAppDetection {
+        if let Some(path) = self.host_blender_override.as_deref() {
+            let resolved = path.exists().then(|| path.to_path_buf());
+            let detail = resolved
+                .as_ref()
+                .map(|value| format!("Blender detected at {}", value.display()))
+                .or_else(|| {
+                    Some(format!(
+                        "Blender is not installed or could not be detected yet. Expected {}.",
+                        path.display()
+                    ))
+                });
+
+            return HostAppDetection {
+                id: "host_blender",
+                label: "Blender",
+                path: resolved,
+                detail,
+            };
+        }
+
+        detect_blender(cached)
+    }
+
     async fn current_snapshot(&self) -> SceneSnapshot {
         self.scene_cache.read().await.snapshot()
     }
 
-    async fn detail_for_connected_state(&self, rag_index: &RagIndex) -> Option<String> {
-        let snapshot = self.current_snapshot().await;
+    fn detail_for_snapshot(
+        snapshot: &SceneSnapshot,
+        rag_index: &RagIndex,
+        prefix: Option<String>,
+    ) -> Option<String> {
         let mut details = Vec::new();
 
-        if let Some(message) = snapshot.message {
-            details.push(message);
-        } else if let Some(scene_data) = snapshot.scene_data {
+        if let Some(prefix) = prefix {
+            details.push(prefix);
+        }
+
+        if let Some(message) = snapshot.message.as_ref() {
+            details.push(message.clone());
+        } else if let Some(scene_data) = snapshot.scene_data.as_ref() {
             details.push(format!(
                 "Live scene available with {} object(s); active object: {}.",
                 scene_data.object_count,
@@ -137,6 +201,70 @@ impl BlenderProvider {
             None
         } else {
             Some(details.join(" · "))
+        }
+    }
+
+    fn missing_blender_detail(detection: &HostAppDetection) -> String {
+        detection.detail.clone().unwrap_or_else(|| {
+            "Blender is not installed or could not be detected yet. Install Blender to use scene-aware Blender mode."
+                .to_string()
+        })
+    }
+
+    fn provision_error_detail(error: &str) -> String {
+        format!("Unable to provision the bundled Blender addon automatically. {error}")
+    }
+
+    fn launch_error_detail(blender_path: &Path, error: &str) -> String {
+        format!(
+            "The Blender addon is provisioned, but the app could not launch Blender at {}. {error}",
+            blender_path.display()
+        )
+    }
+
+    fn connection_note(
+        snapshot: &SceneSnapshot,
+        blender_path: &Path,
+        prepare_outcome: &BlenderAddonPrepareOutcome,
+        launch_outcome: BlenderLaunchOutcome,
+    ) -> Option<String> {
+        if snapshot.connected {
+            return match prepare_outcome {
+                BlenderAddonPrepareOutcome::Prepared(_) => Some(format!(
+                    "Bundled Blender addon was provisioned for {}.",
+                    blender_path.display()
+                )),
+                BlenderAddonPrepareOutcome::AlreadyReady(_) => None,
+            };
+        }
+
+        let mut notes = Vec::new();
+        match prepare_outcome {
+            BlenderAddonPrepareOutcome::Prepared(_) => notes.push(format!(
+                "Bundled Blender addon was provisioned and enabled for {}.",
+                blender_path.display()
+            )),
+            BlenderAddonPrepareOutcome::AlreadyReady(_) => notes.push(format!(
+                "Bundled Blender addon is provisioned for {}.",
+                blender_path.display()
+            )),
+        }
+
+        match launch_outcome {
+            BlenderLaunchOutcome::Launched => notes.push(
+                "Blender was launched automatically. Waiting for the addon to publish live scene data."
+                    .to_string(),
+            ),
+            BlenderLaunchOutcome::AlreadyRunning => notes.push(
+                "Blender is already running. If this session started before the addon was provisioned, reopen Blender once so the addon can load."
+                    .to_string(),
+            ),
+        }
+
+        if notes.is_empty() {
+            None
+        } else {
+            Some(notes.join(" "))
         }
     }
 
@@ -199,8 +327,68 @@ impl BlenderProvider {
 
         Ok(Self::bridge_connected_state(
             mode,
-            self.detail_for_connected_state(&state.rag_index).await,
+            Self::detail_for_snapshot(&self.current_snapshot().await, &state.rag_index, None),
         ))
+    }
+
+    async fn ensure_provider_ready(&self, mode: AppMode) -> ProviderStateDto {
+        let _connect_guard = self.connect_lock.lock().await;
+
+        let cached_blender_path = {
+            let mut state = self.state.lock().await;
+            if let Err(_) = self.ensure_bridge_started(mode, &mut state).await {
+                return Self::disconnected_state(mode, &state);
+            }
+            state.detected_blender_path.clone()
+        };
+
+        let detection = self.host_detection(cached_blender_path.as_deref());
+        let Some(blender_path) = detection.path.clone() else {
+            let detail = Self::missing_blender_detail(&detection);
+            let mut state = self.state.lock().await;
+            state.detected_blender_path = None;
+            state.last_error = Some(detail.clone());
+            return provider_state(mode, "disconnected", Some(detail.as_str()), true, false);
+        };
+
+        let prepare_outcome = match ensure_blender_addon_prepared(
+            self.resource_dir.as_deref(),
+            self.app_local_data_dir.as_deref(),
+            &blender_path,
+        ) {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                let detail = Self::provision_error_detail(&error);
+                let mut state = self.state.lock().await;
+                state.detected_blender_path = Some(blender_path);
+                state.last_error = Some(detail.clone());
+                return provider_state(mode, "error", Some(detail.as_str()), true, false);
+            }
+        };
+
+        let launch_outcome = match launch_blender_if_needed(&blender_path) {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                let detail = Self::launch_error_detail(&blender_path, &error);
+                let mut state = self.state.lock().await;
+                state.detected_blender_path = Some(blender_path);
+                state.last_error = Some(detail.clone());
+                return provider_state(mode, "error", Some(detail.as_str()), true, false);
+            }
+        };
+
+        let snapshot = self.current_snapshot().await;
+        let rag_index = {
+            let mut state = self.state.lock().await;
+            state.detected_blender_path = Some(blender_path.clone());
+            state.tools = Self::default_tools();
+            state.last_error = None;
+            state.rag_index.clone()
+        };
+
+        let note =
+            Self::connection_note(&snapshot, &blender_path, &prepare_outcome, launch_outcome);
+        Self::bridge_connected_state(mode, Self::detail_for_snapshot(&snapshot, &rag_index, note))
     }
 
     fn scene_tool_result(snapshot: SceneSnapshot) -> ToolExecutionResultDto {
@@ -254,16 +442,11 @@ impl BlenderProvider {
 #[async_trait]
 impl ToolProvider for BlenderProvider {
     async fn connect_if_needed(&self, mode: AppMode) -> Result<ProviderStateDto, String> {
-        let mut state = self.state.lock().await;
-        self.ensure_bridge_started(mode, &mut state).await
+        Ok(self.ensure_provider_ready(mode).await)
     }
 
     async fn status(&self, mode: AppMode) -> Result<ProviderStateDto, String> {
-        let mut state = self.state.lock().await;
-        match self.ensure_bridge_started(mode, &mut state).await {
-            Ok(provider_state) => Ok(provider_state),
-            Err(_) => Ok(Self::disconnected_state(mode, &state)),
-        }
+        Ok(self.ensure_provider_ready(mode).await)
     }
 
     async fn list_tools(&self, _mode: AppMode) -> Result<Vec<ToolDefinitionDto>, String> {
@@ -321,6 +504,7 @@ impl ToolProvider for BlenderProvider {
         }
         state.tools.clear();
         state.rag_index = self.load_rag_index();
+        state.last_error = None;
         Ok(())
     }
 }
@@ -333,20 +517,130 @@ mod tests {
     use crate::modes::provider::ToolProvider;
     use serde_json::json;
     use smolpc_assistant_types::AppMode;
-    use tempfile::tempdir;
+    use std::path::{Path, PathBuf};
+    use std::sync::{Mutex as StdMutex, OnceLock};
+    use tempfile::{tempdir, TempDir};
     use tokio::net::TcpListener;
+    use tokio::time::{sleep, Duration};
 
-    #[tokio::test]
-    async fn connected_state_includes_tool_definitions_when_bridge_starts() {
-        let provider = BlenderProvider::with_config(
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    fn write_blender_resources(root: &Path, metadata_contents: Option<&str>) {
+        let blender_root = root.join("blender");
+        std::fs::create_dir_all(blender_root.join("addon")).expect("addon dir");
+        std::fs::create_dir_all(blender_root.join("rag_system").join("simple_db"))
+            .expect("rag dir");
+        std::fs::write(blender_root.join("README.md"), "phase4 blender resources").expect("readme");
+        std::fs::write(
+            blender_root.join("addon").join("blender_helper_http.py"),
+            "# blender addon snapshot\n",
+        )
+        .expect("addon");
+        std::fs::write(
+            blender_root.join("manifest.json"),
+            r#"{
+              "version": "phase4-blender",
+              "source": "tests",
+              "expectedPaths": ["README.md", "rag_system", "addon/blender_helper_http.py"],
+              "status": "tracked"
+            }"#,
+        )
+        .expect("manifest");
+
+        if let Some(metadata_contents) = metadata_contents {
+            std::fs::write(
+                blender_root
+                    .join("rag_system")
+                    .join("simple_db")
+                    .join("metadata.json"),
+                metadata_contents,
+            )
+            .expect("metadata");
+        }
+    }
+
+    #[cfg(unix)]
+    fn write_fake_blender_script(root: &Path, addon_dir: &Path, log_path: &Path) -> PathBuf {
+        let blender_path = root.join("fake-blender");
+        let script = format!(
+            r#"#!/bin/sh
+ARGS="$*"
+TOKEN_PATH="${{LOCALAPPDATA}}/SmolPC/engine-runtime/bridge-token.txt"
+if printf '%s' "$ARGS" | grep -q "smolpc_blender_addon_dir_probe"; then
+  if [ -f "$TOKEN_PATH" ]; then printf 'token_present\n' >> "{log_path}"; else printf 'token_missing\n' >> "{log_path}"; fi
+  echo '{{"status":"ok","addonDir":"{addon_dir}"}}'
+  exit 0
+fi
+if printf '%s' "$ARGS" | grep -q "smolpc_blender_addon_enable"; then
+  if [ -f "$TOKEN_PATH" ]; then printf 'token_present\n' >> "{log_path}"; else printf 'token_missing\n' >> "{log_path}"; fi
+  printf 'enabled\n' >> "{log_path}"
+  echo '{{"status":"ok","loaded":true,"module":"blender_helper_http"}}'
+  exit 0
+fi
+printf 'launched\n' >> "{log_path}"
+exit 0
+"#,
+            addon_dir = addon_dir.display(),
+            log_path = log_path.display(),
+        );
+        std::fs::write(&blender_path, script).expect("script");
+        let mut permissions = std::fs::metadata(&blender_path)
+            .expect("metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&blender_path, permissions).expect("chmod");
+        blender_path
+    }
+
+    fn env_lock() -> &'static StdMutex<()> {
+        static LOCK: OnceLock<StdMutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| StdMutex::new(()))
+    }
+
+    #[cfg(unix)]
+    fn provider_with_fake_blender(
+        resource_temp: &TempDir,
+        app_temp: &TempDir,
+        blender_path: PathBuf,
+    ) -> BlenderProvider {
+        BlenderProvider::with_host_override(
             BridgeConfig {
                 host: "127.0.0.1".to_string(),
                 port: 0,
             },
-            None,
+            Some(resource_temp.path().to_path_buf()),
+            Some(app_temp.path().to_path_buf()),
+            Some(blender_path),
+        )
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn connected_state_includes_tool_definitions_when_bridge_starts() {
+        let _env_guard = env_lock().lock().unwrap_or_else(|error| error.into_inner());
+        let resource_temp = TempDir::new().expect("resource temp");
+        let app_temp = TempDir::new().expect("app temp");
+        let host_temp = TempDir::new().expect("host temp");
+        write_blender_resources(resource_temp.path(), None);
+        let log_path = host_temp.path().join("fake-blender.log");
+        let blender_path = write_fake_blender_script(
+            host_temp.path(),
+            &host_temp.path().join("addons"),
+            &log_path,
         );
+        let previous_local_app_data = std::env::var_os("LOCALAPPDATA");
+        std::env::set_var("LOCALAPPDATA", host_temp.path());
+
+        let provider = provider_with_fake_blender(&resource_temp, &app_temp, blender_path);
 
         let state = provider.status(AppMode::Blender).await.expect("status");
+        sleep(Duration::from_millis(75)).await;
+        match previous_local_app_data {
+            Some(value) => std::env::set_var("LOCALAPPDATA", value),
+            None => std::env::remove_var("LOCALAPPDATA"),
+        }
+
         assert_eq!(state.state, "connected");
 
         let tools = provider.list_tools(AppMode::Blender).await.expect("tools");
@@ -355,7 +649,7 @@ mod tests {
         assert!(state
             .detail
             .expect("detail")
-            .contains("No live Blender scene data"));
+            .contains("Bundled Blender addon"));
     }
 
     #[tokio::test]
@@ -369,6 +663,7 @@ mod tests {
                 host: "127.0.0.1".to_string(),
                 port,
             },
+            None,
             None,
         );
 
@@ -385,6 +680,7 @@ mod tests {
                 port: 0,
             },
             None,
+            None,
         );
 
         let result = provider
@@ -400,23 +696,17 @@ mod tests {
     #[tokio::test]
     async fn retrieve_rag_context_returns_results_when_metadata_is_loaded() {
         let temp_dir = tempdir().expect("temp dir");
-        let rag_dir = temp_dir
-            .path()
-            .join("resources")
-            .join("blender")
-            .join("rag_system")
-            .join("simple_db");
-        std::fs::create_dir_all(&rag_dir).expect("rag dir");
-        std::fs::write(
-            rag_dir.join("metadata.json"),
-            serde_json::to_string(&vec![json!({
-                "text": "Use the bevel modifier to soften edges",
-                "signature": "bpy.types.BevelModifier",
-                "url": "/bpy.types.BevelModifier.html"
-            })])
-            .expect("metadata json"),
-        )
-        .expect("write metadata");
+        write_blender_resources(
+            temp_dir.path(),
+            Some(
+                &serde_json::to_string(&vec![json!({
+                    "text": "Use the bevel modifier to soften edges",
+                    "signature": "bpy.types.BevelModifier",
+                    "url": "/bpy.types.BevelModifier.html"
+                })])
+                .expect("metadata json"),
+            ),
+        );
 
         let provider = BlenderProvider::with_config(
             BridgeConfig {
@@ -424,6 +714,7 @@ mod tests {
                 port: 0,
             },
             Some(temp_dir.path().to_path_buf()),
+            None,
         );
 
         let result = provider
@@ -439,27 +730,31 @@ mod tests {
         assert_eq!(result.payload["contexts"].as_array().map(Vec::len), Some(1));
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn retrieval_load_failure_degrades_gracefully() {
-        let temp_dir = tempdir().expect("temp dir");
-        let rag_dir = temp_dir
-            .path()
-            .join("resources")
-            .join("blender")
-            .join("rag_system")
-            .join("simple_db");
-        std::fs::create_dir_all(&rag_dir).expect("rag dir");
-        std::fs::write(rag_dir.join("metadata.json"), "not valid json").expect("write metadata");
-
-        let provider = BlenderProvider::with_config(
-            BridgeConfig {
-                host: "127.0.0.1".to_string(),
-                port: 0,
-            },
-            Some(temp_dir.path().to_path_buf()),
+        let _env_guard = env_lock().lock().unwrap_or_else(|error| error.into_inner());
+        let resource_temp = TempDir::new().expect("resource temp");
+        let app_temp = TempDir::new().expect("app temp");
+        let host_temp = TempDir::new().expect("host temp");
+        write_blender_resources(resource_temp.path(), Some("not valid json"));
+        let log_path = host_temp.path().join("fake-blender.log");
+        let blender_path = write_fake_blender_script(
+            host_temp.path(),
+            &host_temp.path().join("addons"),
+            &log_path,
         );
+        let previous_local_app_data = std::env::var_os("LOCALAPPDATA");
+        std::env::set_var("LOCALAPPDATA", host_temp.path());
+
+        let provider = provider_with_fake_blender(&resource_temp, &app_temp, blender_path);
 
         let state = provider.status(AppMode::Blender).await.expect("status");
+        sleep(Duration::from_millis(75)).await;
+        match previous_local_app_data {
+            Some(value) => std::env::set_var("LOCALAPPDATA", value),
+            None => std::env::remove_var("LOCALAPPDATA"),
+        }
         assert_eq!(state.state, "connected");
         assert!(state
             .detail
@@ -467,15 +762,24 @@ mod tests {
             .contains("retrieval is unavailable"));
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn status_reports_live_scene_detail_when_scene_cache_has_data() {
-        let provider = BlenderProvider::with_config(
-            BridgeConfig {
-                host: "127.0.0.1".to_string(),
-                port: 0,
-            },
-            None,
+        let _env_guard = env_lock().lock().unwrap_or_else(|error| error.into_inner());
+        let resource_temp = TempDir::new().expect("resource temp");
+        let app_temp = TempDir::new().expect("app temp");
+        let host_temp = TempDir::new().expect("host temp");
+        write_blender_resources(resource_temp.path(), None);
+        let log_path = host_temp.path().join("fake-blender.log");
+        let blender_path = write_fake_blender_script(
+            host_temp.path(),
+            &host_temp.path().join("addons"),
+            &log_path,
         );
+        let previous_local_app_data = std::env::var_os("LOCALAPPDATA");
+        std::env::set_var("LOCALAPPDATA", host_temp.path());
+
+        let provider = provider_with_fake_blender(&resource_temp, &app_temp, blender_path);
 
         provider
             .status(AppMode::Blender)
@@ -493,22 +797,37 @@ mod tests {
         }
 
         let state = provider.status(AppMode::Blender).await.expect("status");
+        sleep(Duration::from_millis(75)).await;
+        match previous_local_app_data {
+            Some(value) => std::env::set_var("LOCALAPPDATA", value),
+            None => std::env::remove_var("LOCALAPPDATA"),
+        }
         let detail = state.detail.expect("detail");
         assert!(detail.contains("Live scene available"));
         assert!(detail.contains("active object: Cube"));
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn reconnect_restores_tool_definitions_after_disconnect() {
-        let provider = BlenderProvider::with_config(
-            BridgeConfig {
-                host: "127.0.0.1".to_string(),
-                port: 0,
-            },
-            None,
+        let _env_guard = env_lock().lock().unwrap_or_else(|error| error.into_inner());
+        let resource_temp = TempDir::new().expect("resource temp");
+        let app_temp = TempDir::new().expect("app temp");
+        let host_temp = TempDir::new().expect("host temp");
+        write_blender_resources(resource_temp.path(), None);
+        let log_path = host_temp.path().join("fake-blender.log");
+        let blender_path = write_fake_blender_script(
+            host_temp.path(),
+            &host_temp.path().join("addons"),
+            &log_path,
         );
+        let previous_local_app_data = std::env::var_os("LOCALAPPDATA");
+        std::env::set_var("LOCALAPPDATA", host_temp.path());
+
+        let provider = provider_with_fake_blender(&resource_temp, &app_temp, blender_path);
 
         provider.status(AppMode::Blender).await.expect("status");
+        sleep(Duration::from_millis(75)).await;
         assert_eq!(
             provider
                 .list_tools(AppMode::Blender)
@@ -540,5 +859,61 @@ mod tests {
                 .len(),
             2
         );
+        sleep(Duration::from_millis(75)).await;
+
+        match previous_local_app_data {
+            Some(value) => std::env::set_var("LOCALAPPDATA", value),
+            None => std::env::remove_var("LOCALAPPDATA"),
+        }
+    }
+
+    #[tokio::test]
+    async fn status_reports_missing_when_blender_host_is_unavailable() {
+        let provider = BlenderProvider::with_host_override(
+            BridgeConfig {
+                host: "127.0.0.1".to_string(),
+                port: 0,
+            },
+            None,
+            None,
+            Some(PathBuf::from("/definitely/missing/blender")),
+        );
+
+        let state = provider.status(AppMode::Blender).await.expect("status");
+        assert_eq!(state.state, "disconnected");
+        assert!(state
+            .detail
+            .expect("detail")
+            .contains("could not be detected"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn provider_starts_bridge_before_provisioning_the_addon() {
+        let _env_guard = env_lock().lock().unwrap_or_else(|error| error.into_inner());
+        let resource_temp = TempDir::new().expect("resource temp");
+        let app_temp = TempDir::new().expect("app temp");
+        let host_temp = TempDir::new().expect("host temp");
+        write_blender_resources(resource_temp.path(), None);
+        let log_path = host_temp.path().join("fake-blender.log");
+        let blender_path = write_fake_blender_script(
+            host_temp.path(),
+            &host_temp.path().join("addons"),
+            &log_path,
+        );
+        let previous_local_app_data = std::env::var_os("LOCALAPPDATA");
+        std::env::set_var("LOCALAPPDATA", host_temp.path());
+
+        let provider = provider_with_fake_blender(&resource_temp, &app_temp, blender_path);
+        let _ = provider.status(AppMode::Blender).await.expect("status");
+        sleep(Duration::from_millis(75)).await;
+
+        match previous_local_app_data {
+            Some(value) => std::env::set_var("LOCALAPPDATA", value),
+            None => std::env::remove_var("LOCALAPPDATA"),
+        }
+
+        let log = std::fs::read_to_string(&log_path).expect("log");
+        assert!(log.contains("token_present"));
     }
 }

--- a/apps/codehelper/src-tauri/src/modes/registry.rs
+++ b/apps/codehelper/src-tauri/src/modes/registry.rs
@@ -33,7 +33,10 @@ impl ModeProviderRegistry {
         Self {
             code: Arc::new(CodeProvider),
             gimp: Arc::new(GimpProvider::default()),
-            blender: Arc::new(BlenderProvider::new(resource_dir.clone())),
+            blender: Arc::new(BlenderProvider::new(
+                resource_dir.clone(),
+                app_local_data_dir.clone(),
+            )),
             libreoffice: Arc::new(LibreOfficeProvider::new(resource_dir, app_local_data_dir)),
         }
     }

--- a/apps/codehelper/src-tauri/src/setup/blender.rs
+++ b/apps/codehelper/src-tauri/src/setup/blender.rs
@@ -1,0 +1,659 @@
+use super::manifests::{load_manifest, missing_expected_paths, resource_root};
+use super::types::SETUP_ITEM_BLENDER_ADDON;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use smolpc_assistant_types::{SetupItemDto, SetupItemStateDto};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub const BLENDER_ADDON_MODULE_ID: &str = "blender_helper_http";
+pub const BLENDER_ADDON_VERSION: &str = "7.0.0";
+
+const BLENDER_RESOURCE_ROOT: &str = "blender";
+const BLENDER_ADDON_RELATIVE_PATH: &str = "addon/blender_helper_http.py";
+const BLENDER_ADDON_MARKER_FILE: &str = "blender-addon.json";
+const BLENDER_ADDON_DIR_PROBE_KIND: &str = "smolpc_blender_addon_dir_probe";
+const BLENDER_ADDON_ENABLE_KIND: &str = "smolpc_blender_addon_enable";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BlenderAddonPrepareOutcome {
+    AlreadyReady(BlenderAddonMarker),
+    Prepared(BlenderAddonMarker),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BlenderAddonMarker {
+    pub addon_version: String,
+    pub addon_module_id: String,
+    pub provision_target_path: String,
+    pub source_resource_path: String,
+    pub timestamp: u64,
+}
+
+pub fn blender_addon_item(
+    resource_dir: Option<&Path>,
+    app_local_data_dir: Option<&Path>,
+    blender_path: Option<&Path>,
+) -> SetupItemDto {
+    let label = "Blender addon".to_string();
+
+    let Some(blender_path) = blender_path else {
+        return SetupItemDto {
+            id: SETUP_ITEM_BLENDER_ADDON.to_string(),
+            label,
+            state: SetupItemStateDto::Missing,
+            detail: Some(
+                "Blender is not installed or could not be detected yet, so the bundled addon cannot be provisioned."
+                    .to_string(),
+            ),
+            required: true,
+            can_prepare: false,
+        };
+    };
+
+    let addon_source = match resolve_addon_source(resource_dir) {
+        Ok(path) => path,
+        Err(error) => {
+            return SetupItemDto {
+                id: SETUP_ITEM_BLENDER_ADDON.to_string(),
+                label,
+                state: SetupItemStateDto::Missing,
+                detail: Some(error),
+                required: true,
+                can_prepare: false,
+            };
+        }
+    };
+
+    let Some(app_local_data_dir) = app_local_data_dir else {
+        return SetupItemDto {
+            id: SETUP_ITEM_BLENDER_ADDON.to_string(),
+            label,
+            state: SetupItemStateDto::Error,
+            detail: Some(
+                "Tauri app-local-data directory is unavailable, so the Blender addon provision marker cannot be stored."
+                    .to_string(),
+            ),
+            required: true,
+            can_prepare: false,
+        };
+    };
+
+    match read_marker(Some(app_local_data_dir)) {
+        Ok(Some(marker)) if marker_matches_current_source(&marker, &addon_source) => {
+            let target_path = PathBuf::from(&marker.provision_target_path);
+            if target_path.exists() {
+                SetupItemDto {
+                    id: SETUP_ITEM_BLENDER_ADDON.to_string(),
+                    label,
+                    state: SetupItemStateDto::Ready,
+                    detail: Some(format!(
+                        "Bundled Blender addon {BLENDER_ADDON_VERSION} is provisioned at {} for Blender at {}.",
+                        target_path.display(),
+                        blender_path.display()
+                    )),
+                    required: true,
+                    can_prepare: false,
+                }
+            } else {
+                SetupItemDto {
+                    id: SETUP_ITEM_BLENDER_ADDON.to_string(),
+                    label,
+                    state: SetupItemStateDto::NotPrepared,
+                    detail: Some(format!(
+                        "Blender addon marker exists, but the provisioned addon file is missing at {}. Run Prepare to repair it.",
+                        target_path.display()
+                    )),
+                    required: true,
+                    can_prepare: true,
+                }
+            }
+        }
+        Ok(Some(_)) => SetupItemDto {
+            id: SETUP_ITEM_BLENDER_ADDON.to_string(),
+            label,
+            state: SetupItemStateDto::NotPrepared,
+            detail: Some(
+                "Blender addon provisioning is out of date and needs to be repaired from the bundled resource snapshot."
+                    .to_string(),
+            ),
+            required: true,
+            can_prepare: true,
+        },
+        Ok(None) => SetupItemDto {
+            id: SETUP_ITEM_BLENDER_ADDON.to_string(),
+            label,
+            state: SetupItemStateDto::NotPrepared,
+            detail: Some(format!(
+                "Blender detected at {}. The bundled addon snapshot is staged and can be provisioned automatically.",
+                blender_path.display()
+            )),
+            required: true,
+            can_prepare: true,
+        },
+        Err(error) => SetupItemDto {
+            id: SETUP_ITEM_BLENDER_ADDON.to_string(),
+            label,
+            state: SetupItemStateDto::NotPrepared,
+            detail: Some(format!(
+                "Blender addon provision state is invalid and needs repair. {error}"
+            )),
+            required: true,
+            can_prepare: true,
+        },
+    }
+}
+
+pub fn ensure_blender_addon_prepared(
+    resource_dir: Option<&Path>,
+    app_local_data_dir: Option<&Path>,
+    blender_path: &Path,
+) -> Result<BlenderAddonPrepareOutcome, String> {
+    let addon_source = resolve_addon_source(resource_dir)?;
+    if let Some(marker) = read_marker(app_local_data_dir)? {
+        let target_path = PathBuf::from(&marker.provision_target_path);
+        if marker_matches_current_source(&marker, &addon_source) && target_path.exists() {
+            return Ok(BlenderAddonPrepareOutcome::AlreadyReady(marker));
+        }
+    }
+
+    let addon_dir = probe_blender_addon_dir(blender_path)?;
+    std::fs::create_dir_all(&addon_dir).map_err(|error| {
+        format!(
+            "Failed to create the Blender addon directory {}: {error}",
+            addon_dir.display()
+        )
+    })?;
+
+    let target_path = addon_dir.join(format!("{BLENDER_ADDON_MODULE_ID}.py"));
+    std::fs::copy(&addon_source, &target_path).map_err(|error| {
+        format!(
+            "Failed to copy the bundled Blender addon from {} to {}: {error}",
+            addon_source.display(),
+            target_path.display()
+        )
+    })?;
+
+    enable_blender_addon(blender_path)?;
+
+    let marker = BlenderAddonMarker {
+        addon_version: BLENDER_ADDON_VERSION.to_string(),
+        addon_module_id: BLENDER_ADDON_MODULE_ID.to_string(),
+        provision_target_path: target_path.to_string_lossy().to_string(),
+        source_resource_path: addon_source.to_string_lossy().to_string(),
+        timestamp: now_unix_seconds(),
+    };
+    write_marker(app_local_data_dir, &marker)?;
+
+    Ok(BlenderAddonPrepareOutcome::Prepared(marker))
+}
+
+pub fn provision_marker_path(app_local_data_dir: Option<&Path>) -> Option<PathBuf> {
+    app_local_data_dir.map(|base| {
+        base.join("setup")
+            .join("state")
+            .join(BLENDER_ADDON_MARKER_FILE)
+    })
+}
+
+fn resolve_addon_source(resource_dir: Option<&Path>) -> Result<PathBuf, String> {
+    let root = resource_root(resource_dir, BLENDER_RESOURCE_ROOT)?;
+    let manifest = load_manifest(&root)?;
+    let missing = missing_expected_paths(&root, &manifest);
+    if !missing.is_empty() {
+        return Err(format!(
+            "Bundled Blender resources are incomplete. Missing {}",
+            missing.join(", ")
+        ));
+    }
+
+    let addon_source = root.join(BLENDER_ADDON_RELATIVE_PATH);
+    if addon_source.is_file() {
+        Ok(addon_source)
+    } else {
+        Err(format!(
+            "Bundled Blender addon snapshot is missing: {}",
+            addon_source.display()
+        ))
+    }
+}
+
+fn read_marker(app_local_data_dir: Option<&Path>) -> Result<Option<BlenderAddonMarker>, String> {
+    let Some(path) = provision_marker_path(app_local_data_dir) else {
+        return Ok(None);
+    };
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let raw = std::fs::read_to_string(&path).map_err(|error| {
+        format!(
+            "Failed to read Blender addon marker {}: {error}",
+            path.display()
+        )
+    })?;
+    serde_json::from_str(&raw).map(Some).map_err(|error| {
+        format!(
+            "Failed to parse Blender addon marker {}: {error}",
+            path.display()
+        )
+    })
+}
+
+fn write_marker(
+    app_local_data_dir: Option<&Path>,
+    marker: &BlenderAddonMarker,
+) -> Result<(), String> {
+    let path = provision_marker_path(app_local_data_dir)
+        .ok_or_else(|| "Tauri app-local-data directory is unavailable".to_string())?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "Failed to create Blender addon marker directory {}: {error}",
+                parent.display()
+            )
+        })?;
+    }
+    let raw = serde_json::to_string_pretty(marker)
+        .map_err(|error| format!("Failed to serialize Blender addon marker: {error}"))?;
+    std::fs::write(&path, raw).map_err(|error| {
+        format!(
+            "Failed to write Blender addon marker {}: {error}",
+            path.display()
+        )
+    })
+}
+
+fn marker_matches_current_source(marker: &BlenderAddonMarker, addon_source: &Path) -> bool {
+    marker.addon_version == BLENDER_ADDON_VERSION
+        && marker.addon_module_id == BLENDER_ADDON_MODULE_ID
+        && marker.source_resource_path == addon_source.to_string_lossy()
+}
+
+fn probe_blender_addon_dir(blender_path: &Path) -> Result<PathBuf, String> {
+    let value = run_blender_background_json(
+        blender_path,
+        &build_addon_dir_probe_expr(),
+        "probe the Blender addon directory",
+    )?;
+    let object = value
+        .as_object()
+        .ok_or_else(|| "Blender addon directory probe did not return a JSON object.".to_string())?;
+    let status = object
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("error");
+    if status != "ok" {
+        let error = object
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("Blender did not report an addon directory.");
+        return Err(format!("Blender addon directory probe failed. {error}"));
+    }
+    let addon_dir = object
+        .get("addonDir")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "Blender did not report a usable addon directory path.".to_string())?;
+    Ok(PathBuf::from(addon_dir))
+}
+
+fn enable_blender_addon(blender_path: &Path) -> Result<(), String> {
+    let value = run_blender_background_json(
+        blender_path,
+        &build_enable_addon_expr(),
+        "enable the Blender addon",
+    )?;
+    let object = value
+        .as_object()
+        .ok_or_else(|| "Blender addon enable command did not return a JSON object.".to_string())?;
+    let status = object
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("error");
+    if status != "ok" {
+        let error = object
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("Blender did not confirm addon enablement.");
+        return Err(format!("Blender addon enable command failed. {error}"));
+    }
+    if object.get("loaded").and_then(Value::as_bool) != Some(true) {
+        return Err(
+            "Blender reported the addon enable command, but the addon is not loaded yet."
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn run_blender_background_json(
+    blender_path: &Path,
+    python_expr: &str,
+    action: &str,
+) -> Result<Value, String> {
+    let output = Command::new(blender_path)
+        .arg("--background")
+        .arg("--python-expr")
+        .arg(python_expr)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|error| format!("Failed to start Blender to {action}: {error}"))?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let parsed = parse_last_json_line(&stdout).or_else(|| parse_last_json_line(&stderr));
+
+    if !output.status.success() {
+        let detail = parsed
+            .as_ref()
+            .and_then(json_error_detail)
+            .or_else(|| non_empty_output_detail(&stderr))
+            .or_else(|| non_empty_output_detail(&stdout))
+            .unwrap_or_else(|| "Blender did not return a detailed error.".to_string());
+        return Err(format!("Failed to {action}. {detail}"));
+    }
+
+    parsed.ok_or_else(|| {
+        format!("Blender completed the {action} step but did not return the expected JSON payload.")
+    })
+}
+
+fn parse_last_json_line(output: &str) -> Option<Value> {
+    output.lines().rev().find_map(|line| {
+        let line = line.trim();
+        if line.starts_with('{') && line.ends_with('}') {
+            serde_json::from_str::<Value>(line).ok()
+        } else {
+            None
+        }
+    })
+}
+
+fn json_error_detail(value: &Value) -> Option<String> {
+    value
+        .get("error")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn non_empty_output_detail(output: &str) -> Option<String> {
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn build_addon_dir_probe_expr() -> String {
+    format!(
+        r#"import bpy, json
+try:
+    addon_dir = bpy.utils.user_resource("SCRIPTS", path="addons", create=True)
+    print(json.dumps({{"status": "ok", "kind": "{BLENDER_ADDON_DIR_PROBE_KIND}", "addonDir": addon_dir}}))
+except Exception as exc:
+    print(json.dumps({{"status": "error", "kind": "{BLENDER_ADDON_DIR_PROBE_KIND}", "error": str(exc)}}))
+    raise"#
+    )
+}
+
+fn build_enable_addon_expr() -> String {
+    format!(
+        r#"import addon_utils, bpy, json
+module = "{BLENDER_ADDON_MODULE_ID}"
+try:
+    addon_utils.enable(module, default_set=True)
+    default, loaded = addon_utils.check(module)
+    if hasattr(bpy.ops.wm, "save_userpref"):
+        bpy.ops.wm.save_userpref()
+    if not loaded:
+        raise RuntimeError(f"{{module}} is not loaded after enable")
+    print(json.dumps({{"status": "ok", "kind": "{BLENDER_ADDON_ENABLE_KIND}", "module": module, "loaded": loaded, "default": default}}))
+except Exception as exc:
+    print(json.dumps({{"status": "error", "kind": "{BLENDER_ADDON_ENABLE_KIND}", "error": str(exc)}}))
+    raise"#
+    )
+}
+
+fn now_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        blender_addon_item, ensure_blender_addon_prepared, provision_marker_path,
+        BlenderAddonPrepareOutcome, BLENDER_ADDON_VERSION,
+    };
+    use smolpc_assistant_types::SetupItemStateDto;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    fn write_blender_resources(root: &Path) {
+        let blender_root = root.join("blender");
+        std::fs::create_dir_all(blender_root.join("addon")).expect("addon dir");
+        std::fs::create_dir_all(blender_root.join("rag_system")).expect("rag dir");
+        std::fs::write(blender_root.join("README.md"), "phase4 blender resources").expect("readme");
+        std::fs::write(
+            blender_root.join("addon").join("blender_helper_http.py"),
+            "# blender addon snapshot\n",
+        )
+        .expect("addon");
+        std::fs::write(
+            blender_root.join("manifest.json"),
+            r#"{
+              "version": "phase4-blender",
+              "source": "tests",
+              "expectedPaths": ["README.md", "rag_system", "addon/blender_helper_http.py"],
+              "status": "tracked"
+            }"#,
+        )
+        .expect("manifest");
+    }
+
+    #[cfg(unix)]
+    fn write_fake_blender_script(
+        root: &Path,
+        addon_dir: &Path,
+        enable_log: &Path,
+        probe_should_fail: bool,
+        enable_should_fail: bool,
+    ) -> std::path::PathBuf {
+        let blender_path = root.join("fake-blender");
+        let script = format!(
+            r#"#!/bin/sh
+ARGS="$*"
+if printf '%s' "$ARGS" | grep -q "smolpc_blender_addon_dir_probe"; then
+  if [ "{probe_should_fail}" = "true" ]; then
+    echo "probe failed" >&2
+    exit 2
+  fi
+  echo '{{"status":"ok","addonDir":"{addon_dir}"}}'
+  exit 0
+fi
+if printf '%s' "$ARGS" | grep -q "smolpc_blender_addon_enable"; then
+  if [ "{enable_should_fail}" = "true" ]; then
+    echo '{{"status":"error","error":"enable failed"}}'
+    exit 2
+  fi
+  printf 'enabled\n' >> "{enable_log}"
+  echo '{{"status":"ok","loaded":true,"module":"blender_helper_http"}}'
+  exit 0
+fi
+printf 'launched\n' >> "{enable_log}.launch"
+exit 0
+"#,
+            addon_dir = addon_dir.display(),
+            enable_log = enable_log.display(),
+        );
+        std::fs::write(&blender_path, script).expect("write blender script");
+        let mut permissions = std::fs::metadata(&blender_path)
+            .expect("metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&blender_path, permissions).expect("chmod");
+        blender_path
+    }
+
+    #[test]
+    fn blender_addon_item_reports_not_prepared_when_blender_is_installed() {
+        let resource_temp = TempDir::new().expect("resource temp");
+        let app_temp = TempDir::new().expect("app temp");
+        write_blender_resources(resource_temp.path());
+
+        let item = blender_addon_item(
+            Some(resource_temp.path()),
+            Some(app_temp.path()),
+            Some(Path::new("/fake/blender")),
+        );
+
+        assert_eq!(item.state, SetupItemStateDto::NotPrepared);
+        assert!(item.can_prepare);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_blender_addon_prepared_copies_addon_and_writes_marker() {
+        let resource_temp = TempDir::new().expect("resource temp");
+        let app_temp = TempDir::new().expect("app temp");
+        let host_temp = TempDir::new().expect("host temp");
+        write_blender_resources(resource_temp.path());
+
+        let addon_dir = host_temp.path().join("addons");
+        let enable_log = host_temp.path().join("enable.log");
+        let blender_path =
+            write_fake_blender_script(host_temp.path(), &addon_dir, &enable_log, false, false);
+
+        let outcome = ensure_blender_addon_prepared(
+            Some(resource_temp.path()),
+            Some(app_temp.path()),
+            &blender_path,
+        )
+        .expect("prepare blender addon");
+
+        assert!(matches!(outcome, BlenderAddonPrepareOutcome::Prepared(_)));
+        assert!(addon_dir.join("blender_helper_http.py").exists());
+        assert!(enable_log.exists());
+        assert!(provision_marker_path(Some(app_temp.path()))
+            .expect("marker path")
+            .exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn probe_failure_returns_honest_error() {
+        let resource_temp = TempDir::new().expect("resource temp");
+        let app_temp = TempDir::new().expect("app temp");
+        let host_temp = TempDir::new().expect("host temp");
+        write_blender_resources(resource_temp.path());
+
+        let addon_dir = host_temp.path().join("addons");
+        let enable_log = host_temp.path().join("enable.log");
+        let blender_path =
+            write_fake_blender_script(host_temp.path(), &addon_dir, &enable_log, true, false);
+
+        let error = ensure_blender_addon_prepared(
+            Some(resource_temp.path()),
+            Some(app_temp.path()),
+            &blender_path,
+        )
+        .expect_err("probe should fail");
+
+        assert!(error.contains("probe the Blender addon directory"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn enable_failure_returns_honest_error() {
+        let resource_temp = TempDir::new().expect("resource temp");
+        let app_temp = TempDir::new().expect("app temp");
+        let host_temp = TempDir::new().expect("host temp");
+        write_blender_resources(resource_temp.path());
+
+        let addon_dir = host_temp.path().join("addons");
+        let enable_log = host_temp.path().join("enable.log");
+        let blender_path =
+            write_fake_blender_script(host_temp.path(), &addon_dir, &enable_log, false, true);
+
+        let error = ensure_blender_addon_prepared(
+            Some(resource_temp.path()),
+            Some(app_temp.path()),
+            &blender_path,
+        )
+        .expect_err("enable should fail");
+
+        assert!(error.contains("enable the Blender addon"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn existing_marker_short_circuits_reprovisioning() {
+        let resource_temp = TempDir::new().expect("resource temp");
+        let app_temp = TempDir::new().expect("app temp");
+        let host_temp = TempDir::new().expect("host temp");
+        write_blender_resources(resource_temp.path());
+
+        let addon_dir = host_temp.path().join("addons");
+        std::fs::create_dir_all(&addon_dir).expect("addon dir");
+        let target = addon_dir.join("blender_helper_http.py");
+        std::fs::write(&target, "# addon").expect("target");
+        let marker_path = provision_marker_path(Some(app_temp.path())).expect("marker path");
+        if let Some(parent) = marker_path.parent() {
+            std::fs::create_dir_all(parent).expect("marker parent");
+        }
+        std::fs::write(
+            &marker_path,
+            format!(
+                r#"{{
+                  "addonVersion": "{BLENDER_ADDON_VERSION}",
+                  "addonModuleId": "blender_helper_http",
+                  "provisionTargetPath": "{}",
+                  "sourceResourcePath": "{}",
+                  "timestamp": 1
+                }}"#,
+                target.display(),
+                resource_temp
+                    .path()
+                    .join("blender")
+                    .join("addon")
+                    .join("blender_helper_http.py")
+                    .display()
+            ),
+        )
+        .expect("marker");
+
+        let addon_dir_for_probe = host_temp.path().join("unused");
+        let enable_log = host_temp.path().join("enable.log");
+        let blender_path = write_fake_blender_script(
+            host_temp.path(),
+            &addon_dir_for_probe,
+            &enable_log,
+            false,
+            false,
+        );
+
+        let outcome = ensure_blender_addon_prepared(
+            Some(resource_temp.path()),
+            Some(app_temp.path()),
+            &blender_path,
+        )
+        .expect("prepare");
+
+        assert!(matches!(
+            outcome,
+            BlenderAddonPrepareOutcome::AlreadyReady(_)
+        ));
+        assert!(!enable_log.exists());
+    }
+}

--- a/apps/codehelper/src-tauri/src/setup/host_apps.rs
+++ b/apps/codehelper/src-tauri/src/setup/host_apps.rs
@@ -19,20 +19,39 @@ struct HostAppSpec {
     standard_paths: Vec<PathBuf>,
 }
 
+#[allow(dead_code)]
 pub fn detect_all(cached: &HashMap<String, PathBuf>) -> Vec<HostAppDetection> {
+    detect_all_with_policy(cached, true)
+}
+
+pub fn detect_all_with_policy(
+    cached: &HashMap<String, PathBuf>,
+    allow_system_lookup: bool,
+) -> Vec<HostAppDetection> {
     all_specs()
         .into_iter()
-        .map(|spec| detect_host_app(&spec, cached.get(spec.id)))
+        .map(|spec| detect_host_app_with_policy(&spec, cached.get(spec.id), allow_system_lookup))
         .collect()
 }
 
 fn detect_host_app(spec: &HostAppSpec, cached: Option<&PathBuf>) -> HostAppDetection {
-    let resolved = cached
-        .filter(|path| path.exists())
-        .cloned()
-        .or_else(|| lookup_windows_app_paths(spec))
-        .or_else(|| lookup_standard_paths(spec))
-        .or_else(|| lookup_on_path(spec));
+    detect_host_app_with_policy(spec, cached, true)
+}
+
+fn detect_host_app_with_policy(
+    spec: &HostAppSpec,
+    cached: Option<&PathBuf>,
+    allow_system_lookup: bool,
+) -> HostAppDetection {
+    let resolved = cached.filter(|path| path.exists()).cloned().or_else(|| {
+        if allow_system_lookup {
+            lookup_windows_app_paths(spec)
+                .or_else(|| lookup_standard_paths(spec))
+                .or_else(|| lookup_on_path(spec))
+        } else {
+            None
+        }
+    });
 
     let detail = resolved
         .as_ref()
@@ -233,6 +252,22 @@ fn lookup_windows_app_paths(_spec: &HostAppSpec) -> Option<PathBuf> {
 pub fn detect_libreoffice(cached: Option<&Path>) -> HostAppDetection {
     let cached = cached.map(Path::to_path_buf);
     detect_host_app(&libreoffice_spec(), cached.as_ref())
+}
+
+pub fn detect_blender(cached: Option<&Path>) -> HostAppDetection {
+    detect_blender_with_policy(cached, true)
+}
+
+pub fn detect_blender_with_policy(
+    cached: Option<&Path>,
+    allow_system_lookup: bool,
+) -> HostAppDetection {
+    let cached = cached.map(Path::to_path_buf);
+    let spec = all_specs()
+        .into_iter()
+        .find(|candidate| candidate.id == SETUP_ITEM_HOST_BLENDER)
+        .expect("blender spec");
+    detect_host_app_with_policy(&spec, cached.as_ref(), allow_system_lookup)
 }
 
 #[allow(dead_code)]

--- a/apps/codehelper/src-tauri/src/setup/launch.rs
+++ b/apps/codehelper/src-tauri/src/setup/launch.rs
@@ -1,9 +1,111 @@
-#[allow(dead_code)]
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use sysinfo::{ProcessesToUpdate, System};
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum LaunchReadiness {
-    Deferred,
+pub enum BlenderLaunchOutcome {
+    AlreadyRunning,
+    Launched,
 }
 
-pub fn phase2_launch_detail() -> &'static str {
-    "Host-app launch orchestration is deferred until later self-contained phases."
+pub fn setup_launch_detail() -> &'static str {
+    "Host-app launch remains mode-driven. Blender may auto-launch on first use once its addon is provisioned."
+}
+
+pub fn is_matching_blender_process_running(blender_path: &Path) -> bool {
+    let mut system = System::new_all();
+    system.refresh_processes(ProcessesToUpdate::All, true);
+    system
+        .processes()
+        .values()
+        .any(|process| executable_matches(process.exe(), blender_path))
+}
+
+pub fn launch_blender_if_needed(blender_path: &Path) -> Result<BlenderLaunchOutcome, String> {
+    maybe_launch_blender_with(
+        blender_path,
+        is_matching_blender_process_running(blender_path),
+        |path| {
+            Command::new(path)
+                .spawn()
+                .map(|_| ())
+                .map_err(|error| format!("Failed to launch Blender at {}: {error}", path.display()))
+        },
+    )
+}
+
+fn maybe_launch_blender_with<F>(
+    blender_path: &Path,
+    already_running: bool,
+    launch: F,
+) -> Result<BlenderLaunchOutcome, String>
+where
+    F: FnOnce(&Path) -> Result<(), String>,
+{
+    if already_running {
+        return Ok(BlenderLaunchOutcome::AlreadyRunning);
+    }
+
+    launch(blender_path)?;
+    Ok(BlenderLaunchOutcome::Launched)
+}
+
+fn executable_matches(candidate: Option<&Path>, target: &Path) -> bool {
+    let Some(candidate) = candidate else {
+        return false;
+    };
+
+    if path_identity(candidate) == path_identity(target) {
+        return true;
+    }
+
+    candidate.file_name() == target.file_name()
+}
+
+fn path_identity(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{executable_matches, maybe_launch_blender_with, BlenderLaunchOutcome};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    #[test]
+    fn maybe_launch_blender_with_skips_spawn_when_process_is_running() {
+        let called = Arc::new(AtomicBool::new(false));
+        let called_clone = Arc::clone(&called);
+
+        let outcome = maybe_launch_blender_with(Path::new("/fake/blender"), true, move |_| {
+            called_clone.store(true, Ordering::SeqCst);
+            Ok(())
+        })
+        .expect("launch outcome");
+
+        assert_eq!(outcome, BlenderLaunchOutcome::AlreadyRunning);
+        assert!(!called.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn maybe_launch_blender_with_spawns_when_process_is_absent() {
+        let called = Arc::new(AtomicBool::new(false));
+        let called_clone = Arc::clone(&called);
+
+        let outcome = maybe_launch_blender_with(Path::new("/fake/blender"), false, move |_| {
+            called_clone.store(true, Ordering::SeqCst);
+            Ok(())
+        })
+        .expect("launch outcome");
+
+        assert_eq!(outcome, BlenderLaunchOutcome::Launched);
+        assert!(called.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn executable_matches_accepts_exact_target_path() {
+        let target = PathBuf::from("/tmp/fake-blender");
+        assert!(executable_matches(Some(target.as_path()), target.as_path()));
+    }
 }

--- a/apps/codehelper/src-tauri/src/setup/mod.rs
+++ b/apps/codehelper/src-tauri/src/setup/mod.rs
@@ -1,3 +1,4 @@
+pub mod blender;
 pub mod host_apps;
 pub mod launch;
 pub mod manifests;

--- a/apps/codehelper/src-tauri/src/setup/provision.rs
+++ b/apps/codehelper/src-tauri/src/setup/provision.rs
@@ -1,10 +1,21 @@
+use super::blender::ensure_blender_addon_prepared;
+use super::host_apps::detect_blender_with_policy;
 use super::python::prepare_bundled_python;
 use super::state::SetupState;
 use super::status::collect_setup_status;
+use super::types::SETUP_ITEM_HOST_BLENDER;
 use std::path::Path;
+use std::path::PathBuf;
 
 pub async fn prepare_setup(state: &SetupState) -> SetupResult {
-    let result = prepare_setup_inner(state);
+    let cached_blender_path = {
+        let cache = state.cache().await;
+        cache
+            .resolved_host_apps
+            .get(SETUP_ITEM_HOST_BLENDER)
+            .cloned()
+    };
+    let result = prepare_setup_inner(state, cached_blender_path.as_ref());
     {
         let mut cache = state.cache().await;
         cache.last_error = result.err();
@@ -14,20 +25,38 @@ pub async fn prepare_setup(state: &SetupState) -> SetupResult {
 
 type SetupResult = smolpc_assistant_types::SetupStatusDto;
 
-fn prepare_setup_inner(state: &SetupState) -> Result<(), String> {
+fn prepare_setup_inner(
+    state: &SetupState,
+    cached_blender_path: Option<&PathBuf>,
+) -> Result<(), String> {
     let setup_root = state
         .setup_root()
         .ok_or_else(|| "Tauri app-local-data directory is unavailable".to_string())?;
     prepare_setup_directories(&setup_root)?;
     prepare_bundled_python(state.resource_dir(), state.app_local_data_dir())?;
+    let blender_detection = detect_blender_with_policy(
+        cached_blender_path.map(PathBuf::as_path),
+        state.allow_system_host_detection(),
+    );
+    if let Some(blender_path) = blender_detection.path.as_deref() {
+        let _ = ensure_blender_addon_prepared(
+            state.resource_dir(),
+            state.app_local_data_dir(),
+            blender_path,
+        )?;
+    }
     Ok(())
 }
 
 fn prepare_setup_directories(setup_root: &Path) -> Result<(), String> {
     for relative in ["python", "state", "logs"] {
         let path = setup_root.join(relative);
-        std::fs::create_dir_all(&path)
-            .map_err(|error| format!("Failed to create setup directory {}: {error}", path.display()))?;
+        std::fs::create_dir_all(&path).map_err(|error| {
+            format!(
+                "Failed to create setup directory {}: {error}",
+                path.display()
+            )
+        })?;
     }
     Ok(())
 }
@@ -36,8 +65,68 @@ fn prepare_setup_directories(setup_root: &Path) -> Result<(), String> {
 mod tests {
     use super::prepare_setup;
     use crate::setup::state::SetupState;
+    use crate::setup::types::SETUP_ITEM_HOST_BLENDER;
     use smolpc_assistant_types::SetupItemStateDto;
+    use std::path::Path;
     use tempfile::TempDir;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    fn write_blender_resources(root: &Path) {
+        let blender_root = root.join("blender");
+        std::fs::create_dir_all(blender_root.join("addon")).expect("addon dir");
+        std::fs::create_dir_all(blender_root.join("rag_system")).expect("rag dir");
+        std::fs::write(blender_root.join("README.md"), "phase4 blender resources").expect("readme");
+        std::fs::write(
+            blender_root.join("addon").join("blender_helper_http.py"),
+            "# addon snapshot\n",
+        )
+        .expect("addon");
+        std::fs::write(
+            blender_root.join("manifest.json"),
+            r#"{
+              "version": "phase4-blender",
+              "source": "tests",
+              "expectedPaths": ["README.md", "rag_system", "addon/blender_helper_http.py"],
+              "status": "tracked"
+            }"#,
+        )
+        .expect("manifest");
+    }
+
+    #[cfg(unix)]
+    fn write_fake_blender_script(
+        root: &Path,
+        addon_dir: &Path,
+        enable_log: &Path,
+    ) -> std::path::PathBuf {
+        let blender_path = root.join("fake-blender");
+        let script = format!(
+            r#"#!/bin/sh
+ARGS="$*"
+if printf '%s' "$ARGS" | grep -q "smolpc_blender_addon_dir_probe"; then
+  echo '{{"status":"ok","addonDir":"{addon_dir}"}}'
+  exit 0
+fi
+if printf '%s' "$ARGS" | grep -q "smolpc_blender_addon_enable"; then
+  printf 'enabled\n' >> "{enable_log}"
+  echo '{{"status":"ok","loaded":true,"module":"blender_helper_http"}}'
+  exit 0
+fi
+exit 0
+"#,
+            addon_dir = addon_dir.display(),
+            enable_log = enable_log.display(),
+        );
+        std::fs::write(&blender_path, script).expect("script");
+        let mut permissions = std::fs::metadata(&blender_path)
+            .expect("metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&blender_path, permissions).expect("chmod");
+        blender_path
+    }
 
     #[tokio::test]
     async fn prepare_setup_creates_app_local_directories_and_python_runtime() {
@@ -48,8 +137,11 @@ mod tests {
         std::fs::create_dir_all(python_root.join("payload").join("bin")).expect("python payload");
         std::fs::create_dir_all(&models_root).expect("models root");
         std::fs::write(python_root.join("README.md"), "placeholder").expect("readme");
-        std::fs::write(python_root.join("payload").join("bin").join("python"), "python")
-            .expect("runtime file");
+        std::fs::write(
+            python_root.join("payload").join("bin").join("python"),
+            "python",
+        )
+        .expect("runtime file");
         std::fs::write(
             python_root.join("manifest.json"),
             r#"{
@@ -71,25 +163,24 @@ mod tests {
         )
         .expect("manifest");
 
-        let state = SetupState::new(
+        let state = SetupState::with_host_detection(
             Some(resource_temp.path().to_path_buf()),
             Some(app_temp.path().to_path_buf()),
+            false,
         );
 
         let status = prepare_setup(&state).await;
         assert!(app_temp.path().join("setup").join("python").exists());
         assert!(app_temp.path().join("setup").join("state").exists());
         assert!(app_temp.path().join("setup").join("logs").exists());
-        assert!(
-            app_temp
-                .path()
-                .join("setup")
-                .join("python")
-                .join("payload")
-                .join("bin")
-                .join("python")
-                .exists()
-        );
+        assert!(app_temp
+            .path()
+            .join("setup")
+            .join("python")
+            .join("payload")
+            .join("bin")
+            .join("python")
+            .exists());
         let python = status
             .items
             .iter()
@@ -133,13 +224,87 @@ mod tests {
         )
         .expect("manifest");
 
-        let state = SetupState::new(
+        let state = SetupState::with_host_detection(
             Some(resource_temp.path().to_path_buf()),
             Some(app_temp.path().to_path_buf()),
+            false,
         );
         let _ = prepare_setup(&state).await;
 
         assert!(!gimp_profile.exists());
         assert!(!blender_profile.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn prepare_setup_provisions_blender_addon_when_blender_is_detected() {
+        let resource_temp = TempDir::new().expect("resource temp");
+        let app_temp = TempDir::new().expect("app temp");
+        let host_temp = TempDir::new().expect("host temp");
+
+        let python_root = resource_temp.path().join("python");
+        let models_root = resource_temp.path().join("models");
+        std::fs::create_dir_all(python_root.join("payload").join("bin")).expect("python payload");
+        std::fs::create_dir_all(&models_root).expect("models root");
+        std::fs::write(python_root.join("README.md"), "placeholder").expect("readme");
+        std::fs::write(
+            python_root.join("payload").join("bin").join("python"),
+            "python",
+        )
+        .expect("runtime file");
+        std::fs::write(
+            python_root.join("manifest.json"),
+            r#"{
+              "version": "phase2",
+              "source": "tests",
+              "expectedPaths": ["README.md", "payload"],
+              "status": "staged"
+            }"#,
+        )
+        .expect("manifest");
+        std::fs::write(
+            models_root.join("manifest.json"),
+            r#"{
+              "version": "phase2",
+              "source": "tests",
+              "expectedPaths": ["qwen3-4b-instruct-2507"],
+              "status": "placeholder"
+            }"#,
+        )
+        .expect("manifest");
+        write_blender_resources(resource_temp.path());
+
+        let addon_dir = host_temp.path().join("addons");
+        let enable_log = host_temp.path().join("enable.log");
+        let blender_path = write_fake_blender_script(host_temp.path(), &addon_dir, &enable_log);
+
+        let state = SetupState::with_host_detection(
+            Some(resource_temp.path().to_path_buf()),
+            Some(app_temp.path().to_path_buf()),
+            false,
+        );
+        {
+            let mut cache = state.cache().await;
+            cache
+                .resolved_host_apps
+                .insert(SETUP_ITEM_HOST_BLENDER.to_string(), blender_path);
+        }
+
+        let status = prepare_setup(&state).await;
+        let blender_addon = status
+            .items
+            .iter()
+            .find(|item| item.id == "blender_addon")
+            .expect("blender addon item");
+
+        assert_eq!(blender_addon.state, SetupItemStateDto::Ready);
+        assert!(addon_dir.join("blender_helper_http.py").exists());
+        assert!(enable_log.exists());
+        assert!(app_temp
+            .path()
+            .join("setup")
+            .join("state")
+            .join("blender-addon.json")
+            .exists());
     }
 }

--- a/apps/codehelper/src-tauri/src/setup/state.rs
+++ b/apps/codehelper/src-tauri/src/setup/state.rs
@@ -13,6 +13,7 @@ pub struct SetupCache {
 pub struct SetupState {
     resource_dir: Option<PathBuf>,
     app_local_data_dir: Option<PathBuf>,
+    allow_system_host_detection: bool,
     cache: Arc<Mutex<SetupCache>>,
 }
 
@@ -24,9 +25,18 @@ impl Default for SetupState {
 
 impl SetupState {
     pub fn new(resource_dir: Option<PathBuf>, app_local_data_dir: Option<PathBuf>) -> Self {
+        Self::with_host_detection(resource_dir, app_local_data_dir, true)
+    }
+
+    pub fn with_host_detection(
+        resource_dir: Option<PathBuf>,
+        app_local_data_dir: Option<PathBuf>,
+        allow_system_host_detection: bool,
+    ) -> Self {
         Self {
             resource_dir,
             app_local_data_dir,
+            allow_system_host_detection,
             cache: Arc::new(Mutex::new(SetupCache::default())),
         }
     }
@@ -41,6 +51,10 @@ impl SetupState {
 
     pub fn setup_root(&self) -> Option<PathBuf> {
         self.app_local_data_dir().map(|path| path.join("setup"))
+    }
+
+    pub fn allow_system_host_detection(&self) -> bool {
+        self.allow_system_host_detection
     }
 
     pub async fn cache(&self) -> tokio::sync::MutexGuard<'_, SetupCache> {

--- a/apps/codehelper/src-tauri/src/setup/status.rs
+++ b/apps/codehelper/src-tauri/src/setup/status.rs
@@ -1,5 +1,6 @@
-use super::host_apps::{detect_all, HostAppDetection};
-use super::launch::phase2_launch_detail;
+use super::blender::blender_addon_item;
+use super::host_apps::{detect_all_with_policy, HostAppDetection};
+use super::launch::setup_launch_detail;
 use super::models::bundled_model_item;
 use super::python::bundled_python_item;
 use super::state::SetupState;
@@ -14,7 +15,10 @@ use smolpc_assistant_types::{
 pub async fn collect_setup_status(state: &SetupState) -> SetupStatusDto {
     let detections = {
         let mut cache = state.cache().await;
-        let detections = detect_all(&cache.resolved_host_apps);
+        let detections = detect_all_with_policy(
+            &cache.resolved_host_apps,
+            state.allow_system_host_detection(),
+        );
         cache.resolved_host_apps = detections
             .iter()
             .filter_map(|detection| {
@@ -34,7 +38,23 @@ pub async fn collect_setup_status(state: &SetupState) -> SetupStatusDto {
         state.resource_dir(),
         state.app_local_data_dir(),
     ));
-    items.extend(detections.into_iter().map(host_detection_item));
+    let blender_detection = detections
+        .iter()
+        .find(|detection| detection.id == SETUP_ITEM_HOST_BLENDER)
+        .cloned();
+    for detection in detections {
+        let is_blender = detection.id == SETUP_ITEM_HOST_BLENDER;
+        items.push(host_detection_item(detection));
+        if is_blender {
+            items.push(blender_addon_item(
+                state.resource_dir(),
+                state.app_local_data_dir(),
+                blender_detection
+                    .as_ref()
+                    .and_then(|value| value.path.as_deref()),
+            ));
+        }
+    }
 
     let last_error = {
         let cache = state.cache().await;
@@ -57,7 +77,7 @@ fn engine_runtime_item(state: &SetupState) -> SetupItemDto {
             detail: Some(format!(
                 "Shared engine runtime contract resolves through {}. {}",
                 setup_root.display(),
-                phase2_launch_detail()
+                setup_launch_detail()
             )),
             required: true,
             can_prepare: false,
@@ -66,7 +86,10 @@ fn engine_runtime_item(state: &SetupState) -> SetupItemDto {
             id: SETUP_ITEM_ENGINE_RUNTIME.to_string(),
             label: "Engine runtime".to_string(),
             state: SetupItemStateDto::Error,
-            detail: Some("Tauri app-local-data directory is unavailable, so setup roots cannot be created".to_string()),
+            detail: Some(
+                "Tauri app-local-data directory is unavailable, so setup roots cannot be created"
+                    .to_string(),
+            ),
             required: true,
             can_prepare: false,
         },
@@ -78,7 +101,7 @@ fn host_detection_item(detection: HostAppDetection) -> SetupItemDto {
     let detail = match detection.path.as_ref() {
         Some(path) => Some(format!("{} detected at {}", detection.label, path.display())),
         None => Some(format!(
-            "{} is not installed or could not be detected yet. Phase 2 only reports host-app presence; it does not launch or repair installs.",
+            "{} is not installed or could not be detected yet. Setup reports host-app presence and provider-owned repair state; interactive launch remains mode-driven.",
             detection.label
         )),
     };
@@ -125,6 +148,7 @@ fn overall_state_for_items(items: &[SetupItemDto], has_last_error: bool) -> Setu
 mod tests {
     use super::collect_setup_status;
     use crate::setup::state::SetupState;
+    use crate::setup::types::SETUP_ITEM_BLENDER_ADDON;
     use smolpc_assistant_types::{SetupItemStateDto, SetupOverallStateDto};
     use tempfile::TempDir;
 
@@ -135,16 +159,21 @@ mod tests {
         std::fs::create_dir_all(resource_temp.path().join("models")).expect("models root");
 
         let app_temp = TempDir::new().expect("app temp");
-        let state = SetupState::new(
+        let state = SetupState::with_host_detection(
             Some(resource_temp.path().to_path_buf()),
             Some(app_temp.path().to_path_buf()),
+            false,
         );
 
         let status = collect_setup_status(&state).await;
-        assert_eq!(status.items.len(), 6);
+        assert_eq!(status.items.len(), 7);
         assert!(status.items.iter().any(|item| item.id == "engine_runtime"));
         assert!(status.items.iter().any(|item| item.id == "bundled_model"));
         assert!(status.items.iter().any(|item| item.id == "bundled_python"));
+        assert!(status
+            .items
+            .iter()
+            .any(|item| item.id == SETUP_ITEM_BLENDER_ADDON));
     }
 
     #[tokio::test]
@@ -164,9 +193,10 @@ mod tests {
         .expect("manifest");
 
         let app_temp = TempDir::new().expect("app temp");
-        let state = SetupState::new(
+        let state = SetupState::with_host_detection(
             Some(resource_temp.path().to_path_buf()),
             Some(app_temp.path().to_path_buf()),
+            false,
         );
 
         let status = collect_setup_status(&state).await;

--- a/apps/codehelper/src-tauri/src/setup/types.rs
+++ b/apps/codehelper/src-tauri/src/setup/types.rs
@@ -7,6 +7,7 @@ pub const SETUP_ITEM_BUNDLED_MODEL: &str = "bundled_model";
 pub const SETUP_ITEM_BUNDLED_PYTHON: &str = "bundled_python";
 pub const SETUP_ITEM_HOST_GIMP: &str = "host_gimp";
 pub const SETUP_ITEM_HOST_BLENDER: &str = "host_blender";
+pub const SETUP_ITEM_BLENDER_ADDON: &str = "blender_addon";
 pub const SETUP_ITEM_HOST_LIBREOFFICE: &str = "host_libreoffice";
 
 #[allow(dead_code)]

--- a/apps/codehelper/src/lib/components/setup/SetupPanel.svelte
+++ b/apps/codehelper/src/lib/components/setup/SetupPanel.svelte
@@ -117,8 +117,9 @@
 			<div class="setup-panel__note">
 				<ShieldCheck class="h-4 w-4" />
 				<span>
-					Phase 2 only validates manifests, prepares app-local setup state, and reports host-app
-					detection. It does not launch or provision external host apps yet.
+					Setup validates bundled manifests, prepares app-local runtime state, and can repair
+					provider-owned integrations. Interactive host apps still launch only when a mode needs
+					them.
 				</span>
 			</div>
 		</div>


### PR DESCRIPTION
## Summary\n- bundle the Blender addon snapshot under unified resources\n- provision and enable the addon through background Blender CLI execution\n- auto-launch Blender on first use and surface Blender addon readiness in setup status\n\n## Validation\n- cargo check -p smolpc-code-helper\n- cargo test -p smolpc-code-helper --lib\n- cargo test -p smolpc-engine-client\n- npm run check --workspace apps/codehelper\n- node apps/codehelper/scripts/self-contained/validate-resource-manifests.mjs