### PR TITLE
docs(self-contained): lock phase 5 gimp provisioning scope (merge-ready, stacked)

### DIFF
--- a/docs/unified-assistant-self-contained-spec/ARCHITECTURE.md
+++ b/docs/unified-assistant-self-contained-spec/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # SmolPC Unified Assistant Self-Contained Architecture
 
 **Last Updated:** 2026-03-17
-**Status:** Target architecture with Phase 2 foundation, Phase 3 LibreOffice runtime ownership landed, and Phase 4 Blender provisioning landed
+**Status:** Target architecture with Phase 2 foundation, Phase 3 LibreOffice runtime ownership landed, Phase 4 Blender provisioning landed, and Phase 5 GIMP provisioning preflight locked
 
 ## 1. Product Shape
 
@@ -122,6 +122,12 @@ Phase 4 consumer now live:
 - `setup_prepare()` may provision and enable the Blender addon through Blender CLI background execution
 - interactive Blender launch remains mode-driven rather than setup-panel-driven
 
+Phase 5 next consumer (preflight locked):
+
+- GIMP extends setup/provisioning state with plugin/server repair visibility
+- `setup_prepare()` may provision and repair bundled GIMP plugin/server assets
+- interactive GIMP launch remains mode-driven rather than setup-panel-driven
+
 ### 4.4 Mode providers
 
 Responsibilities:
@@ -238,10 +244,11 @@ Those roots are now part of the implementation contract on
 ### 8.4 GIMP
 
 - provider transport stays TCP on `127.0.0.1:10008`
-- self-contained line vendors a pinned `gimp-mcp` snapshot
+- self-contained line vendors a pinned `maorcc/gimp-mcp` snapshot
 - plugin/server payload becomes bundled unified-app-owned resource
 - provider provisions plugin files into the GIMP profile in Phase 5
 - provider launches both GIMP and the bundled GIMP MCP runtime when needed in Phase 5
+- provider reuses running GIMP sessions when available and must not force-restart an existing session
 
 ## 9. Boot Flow
 
@@ -274,7 +281,7 @@ On first use of a live external mode:
 
 Phase 2 does not yet implement this full flow for every provider. Phase 3
 implements the LibreOffice slice, and Phase 4 now implements the Blender slice
-while leaving GIMP provisioning for the next phase.
+while Phase 5 is the next provisioning slice for GIMP.
 
 ## 11. Deferred Architecture
 

--- a/docs/unified-assistant-self-contained-spec/CURRENT_STATE.md
+++ b/docs/unified-assistant-self-contained-spec/CURRENT_STATE.md
@@ -1,7 +1,7 @@
 # Current State
 
 **Last Updated:** 2026-03-17
-**Status:** Demo line frozen; Phase 4 complete; Phase 5 GIMP docs preflight is next on the single self-contained mainline
+**Status:** Demo line frozen; Phase 4 complete; Phase 5 GIMP docs preflight is active on the single self-contained mainline
 
 ## 1. Branch State
 
@@ -123,7 +123,7 @@ The self-contained delivery line must ship:
 | Code        | Already owned in `apps/codehelper`                                | Keep                                                        |
 | LibreOffice | Runtime scripts already imported into unified resources           | Bundled Python now owns packaged Writer/Slides runtime path |
 | Blender     | Bridge app-owned, addon snapshot bundled and provisioned by setup | Keep bundled addon provisioning and mode-driven launch flow |
-| GIMP        | Unified provider exists, but runtime/plugin ownership is external | Vendor pinned upstream `gimp-mcp` snapshot and provision it |
+| GIMP        | Unified provider exists, but runtime/plugin ownership is external | Vendor pinned upstream `maorcc/gimp-mcp` snapshot and provision it |
 
 ## 6. Phase Status
 
@@ -235,17 +235,22 @@ Phase 4 intentionally did not land:
 
 ## 10. Next Official Branches
 
-The next required branch sequence is:
+Phase 5 docs preflight branch is now active:
 
-1. `codex/unified-self-contained-gimp-docs`
-2. `codex/unified-self-contained-gimp`
-3. `codex/unified-self-contained-gimp-status-docs`
+- `codex/unified-self-contained-gimp-docs`
 
-Phase 5 preflight focus:
+The next required branches after this docs preflight merges are:
 
-- lock provenance and license notes for the pinned `gimp-mcp` snapshot before import
+1. `codex/unified-self-contained-gimp`
+2. `codex/unified-self-contained-gimp-status-docs`
+
+Phase 5 preflight lock-in focus:
+
+- lock provenance and license notes for the pinned `maorcc/gimp-mcp` snapshot before import
 - lock bundled GIMP plugin/server ownership and provisioning boundaries
 - lock auto-launch/runtime-supervision expectations for GIMP mode
+- keep GIMP transport pinned to `127.0.0.1:10008`
+- keep setup as one app-level repair surface without a GIMP-specific setup wizard
 - keep Blender, LibreOffice, Code, and Calc behavior unchanged
 
 ## 11. Known Risks

--- a/docs/unified-assistant-self-contained-spec/IMPLEMENTATION_PHASES.md
+++ b/docs/unified-assistant-self-contained-spec/IMPLEMENTATION_PHASES.md
@@ -1,7 +1,7 @@
 # Self-Contained Delivery Phases
 
 **Last Updated:** 2026-03-17
-**Status:** Branch cut, cleanup, foundation, Phase 4 complete; Phase 5 GIMP docs preflight next
+**Status:** Branch cut, cleanup, foundation, Phase 4 complete; Phase 5 GIMP docs preflight active
 
 ## Phase 0: Demo Freeze And Branch Cut
 
@@ -235,7 +235,7 @@ The next official branch after Phase 4 closeout docs is:
 
 ## Phase 5: GIMP Self-Contained Provisioning
 
-**Status:** next
+**Status:** docs preflight active
 
 **Branches**
 
@@ -248,16 +248,33 @@ The next official branch after Phase 4 closeout docs is:
 
 **Scope**
 
-- vendor pinned upstream `gimp-mcp` source snapshot
+- vendor pinned upstream `maorcc/gimp-mcp` source snapshot
 - bundle GIMP plugin/server resources under unified app ownership
 - auto-provision GIMP plugin files into the user profile
 - auto-launch GIMP and bundled GIMP MCP runtime
 - keep unified provider transport on `127.0.0.1:10008`
 
+**Locked Phase 5 decisions**
+
+- authoritative GIMP runtime source is:
+  - upstream `maorcc/gimp-mcp` pinned to an exact commit/tag before implementation PR opens
+- unified bundled import target remains:
+  - `apps/codehelper/src-tauri/resources/gimp/`
+- setup remains app-level:
+  - one `Prepare` action only
+  - no GIMP-specific setup wizard or path-settings surface
+- `setup_prepare()` may provision/repair GIMP plugin/server assets, but it must not launch the interactive GIMP UI
+- mode-driven first-use may auto-launch GIMP and the bundled GIMP MCP runtime when required
+- existing Blender, LibreOffice, Code, and Calc behaviors must remain unchanged in this phase
+
 **Exit criteria**
 
 - GIMP mode works on a machine with GIMP installed but no plugin/server manually configured
 - no manual clone, environment variable, plugin copy, or terminal start step remains
+
+The next official branch after Phase 5 docs preflight merge is:
+
+- `codex/unified-self-contained-gimp`
 
 ## Phase 6: Release Packaging And Validation
 

--- a/docs/unified-assistant-self-contained-spec/MCP_INTEGRATION.md
+++ b/docs/unified-assistant-self-contained-spec/MCP_INTEGRATION.md
@@ -1,7 +1,7 @@
 # MCP And Provider Integration For The Self-Contained Line
 
 **Last Updated:** 2026-03-17
-**Status:** Integration ownership spec with Phase 2 setup foundation, Phase 3 LibreOffice runtime ownership landed, and Phase 4 Blender provisioning landed
+**Status:** Integration ownership spec with Phase 2 setup foundation, Phase 3 LibreOffice runtime ownership landed, Phase 4 Blender provisioning landed, and Phase 5 GIMP provisioning preflight locked
 
 ## 1. Scope
 
@@ -140,14 +140,17 @@ Transport/runtime rules:
 
 - unified provider keeps TCP MCP transport on `127.0.0.1:10008`
 - bundled GIMP MCP runtime is launched by the unified app
+- transport contract remains unchanged for Phase 5
 
 Ownership rules:
 
 - GIMP remains separately installed
+- authoritative upstream source is `maorcc/gimp-mcp` pinned to an exact commit/tag before import
 - plugin/server payload is bundled by the unified app
 - unified app provisions plugin files into the user GIMP profile
 - unified app launches GIMP when needed
 - unified app launches the bundled GIMP MCP server when needed
+- unified app should reuse an already-running GIMP session instead of force-restarting it
 
 ## 6. Setup API Expectations
 
@@ -211,8 +214,9 @@ Expected provisioners:
 - `BlenderAddonProvisioner`
 - `GimpPluginProvisioner`
 
-Phase 2 establishes the shared provisioning foundation. Phase 4 now ships the
-Blender addon provisioner path while keeping GIMP provisioning for Phase 5.
+Phase 2 establishes the shared provisioning foundation. Phase 4 ships the
+Blender addon provisioner path. Phase 5 is the next locked implementation slice
+for GIMP provisioning and runtime ownership.
 
 ## 8. Runtime Supervision Rules
 

--- a/docs/unified-assistant-self-contained-spec/PACKAGING.md
+++ b/docs/unified-assistant-self-contained-spec/PACKAGING.md
@@ -1,7 +1,7 @@
 # Packaging And Distribution For The Self-Contained Line
 
 **Last Updated:** 2026-03-17
-**Status:** Packaging target with Phase 2 foundation contract, Phase 3 LibreOffice bundled-Python ownership landed, and Phase 4 Blender addon delivery landed
+**Status:** Packaging target with Phase 2 foundation contract, Phase 3 LibreOffice bundled-Python ownership landed, Phase 4 Blender addon delivery landed, and Phase 5 GIMP packaging rules preflight locked
 
 ## 1. Packaging Direction
 
@@ -90,6 +90,23 @@ Phase 4 provisioning rule:
 - the app enables the addon through Blender CLI background execution
 - the setup panel may repair or provision the addon, but it must not launch the interactive Blender UI
 
+## 4.3 Phase 5 GIMP Plugin/Runtime Delivery
+
+Phase 5 preflight locks the GIMP delivery shape to:
+
+- source snapshot from:
+  - upstream `maorcc/gimp-mcp` pinned to an exact commit/tag before import
+- bundled unified resource target root:
+  - `apps/codehelper/src-tauri/resources/gimp/`
+- existing GIMP provider transport unchanged:
+  - `127.0.0.1:10008`
+
+Phase 5 provisioning rule:
+
+- setup and provider paths may provision/repair bundled GIMP plugin/server assets
+- setup and provider paths must not force-launch or restart an already-running GIMP session
+- setup panel remains repair-focused and must not launch interactive GIMP UI
+
 ## 4.1 Phase 3 Bundled Python Delivery
 
 Phase 3 locks the bundled Python delivery source for Writer and Slides to:
@@ -136,6 +153,12 @@ Phase 4 live state:
 - Blender interactive launch may happen on first Blender mode use
 - already running Blender sessions are not forcibly restarted
 - setup prepare may repair/provision the addon, but still must not launch interactive Blender UI
+
+Phase 5 next state:
+
+- GIMP plugin/server provisioning becomes live
+- GIMP mode may auto-launch GIMP and the bundled GIMP MCP runtime on first use when needed
+- setup prepare may repair/provision GIMP assets, but still must not launch interactive GIMP UI
 
 ## 6. Packaging Invariants
 

--- a/docs/unified-assistant-self-contained-spec/README.md
+++ b/docs/unified-assistant-self-contained-spec/README.md
@@ -4,7 +4,7 @@
 > and document map for the self-contained delivery line.
 
 **Last Updated:** 2026-03-17
-**Status:** Single-mainline self-contained workflow active; Phase 4 Blender provisioning complete; Phase 5 GIMP docs preflight next
+**Status:** Single-mainline self-contained workflow active; Phase 4 Blender provisioning complete; Phase 5 GIMP docs preflight active
 
 ## Project Summary
 
@@ -152,17 +152,19 @@ self-contained roadmap phases.
 | Shipping OS           | Windows only                                                           |
 | Python ownership      | Bundled app-private runtime                                            |
 | Blender integration   | Reuse existing repo addon source; provision automatically              |
-| GIMP integration      | Vendor pinned upstream `gimp-mcp` snapshot and provision automatically |
+| GIMP integration      | Vendor pinned upstream `maorcc/gimp-mcp` snapshot and provision automatically |
 | Provenance            | Mandatory before bundling imported third-party runtime assets          |
 
 ## Current Phase
 
 The current active docs-first phase is Phase 5 GIMP self-contained provisioning
-preflight:
+preflight (in progress):
 
 - keep the single-mainline workflow explicit on `dev/unified-assistant-self-contained`
-- lock `gimp-mcp` source pin and license/provenance notes before import
+- lock `maorcc/gimp-mcp` source pin and license/provenance notes before import
 - lock bundled GIMP plugin/server provisioning and launch ownership scope
+- keep GIMP transport anchored to `127.0.0.1:10008`
+- keep the setup surface app-level with one `Prepare` action and no mode-specific setup wizard
 - keep Blender, LibreOffice, Code, and Calc behavior unchanged in this docs preflight
 - keep Calc scaffold-only
 

--- a/docs/unified-assistant-self-contained-spec/RESOURCES.md
+++ b/docs/unified-assistant-self-contained-spec/RESOURCES.md
@@ -23,7 +23,7 @@ not changed since then.
 | --------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | Blender addon payload       | `apps/blender-assistant/blender_addon/blender_helper_http.py` and companion addon files          | This in-repo source is now repackaged under unified app resources for automatic Blender addon provisioning and repair.                      |
 | LibreOffice runtime scripts | `apps/codehelper/src-tauri/resources/libreoffice/mcp_server/`                                    | Writer and Slides already depend on these bundled scripts. The self-contained line uses them as the baseline for removing external Python. |
-| GIMP MCP/plugin runtime     | Pending pinned upstream `gimp-mcp` snapshot                                                      | The self-contained line needs a vendored, provenance-tracked import before GIMP can be provisioned and launched automatically.             |
+| GIMP MCP/plugin runtime     | Pending pinned upstream `maorcc/gimp-mcp` snapshot                                               | The self-contained line needs a vendored, provenance-tracked import before GIMP can be provisioned and launched automatically.             |
 | Bundled Python packaging    | `uv`, `uv tool`, `uv pip`, and packaged wheel/runtime inputs                                     | This is the planned app-private Python foundation for LibreOffice first, and likely for GIMP-side runtime ownership later.                 |
 | Bundled model packaging     | Engine model registry plus packaged resource layout under `apps/codehelper/src-tauri/resources/` | The self-contained finish line requires shipping a default model payload instead of expecting external model installation.                 |
 
@@ -53,6 +53,14 @@ Phase 4 closeout locks and lands the Blender addon snapshot source at:
 Phase 4 implementation repacks that snapshot into:
 
 - `apps/codehelper/src-tauri/resources/blender/addon/blender_helper_http.py`
+
+Phase 5 preflight locks the GIMP runtime source to:
+
+- upstream `maorcc/gimp-mcp` with an exact commit/tag pin required before import
+
+Phase 5 implementation will vendor that snapshot under:
+
+- `apps/codehelper/src-tauri/resources/gimp/`
 
 ---
 

--- a/docs/unified-assistant-self-contained-spec/SETUP_SPEC.md
+++ b/docs/unified-assistant-self-contained-spec/SETUP_SPEC.md
@@ -1,7 +1,7 @@
 # Setup Subsystem Spec
 
 **Last Updated:** 2026-03-17
-**Status:** Phase 2 foundation contract merged; Phase 3 consumes prepared bundled Python; Phase 4 Blender provisioning has landed without changing setup command names
+**Status:** Phase 2 foundation contract merged; Phase 3 consumes prepared bundled Python; Phase 4 Blender provisioning has landed; Phase 5 GIMP provisioning preflight is locked without changing setup command names
 
 ## 1. Purpose
 
@@ -45,6 +45,12 @@ Phase 4 closeout status:
 - setup now includes one additional status item for Blender addon readiness
 - `setup_prepare()` now provisions and enables the Blender addon through Blender CLI background execution
 - `setup_prepare()` still does not launch the interactive Blender UI
+
+Phase 5 locked next step:
+
+- setup gains app-level GIMP plugin/server provisioning and repair visibility
+- `setup_prepare()` may provision and repair bundled GIMP plugin/server assets
+- `setup_prepare()` still must not launch the interactive GIMP UI
 
 Phase 2 setup work does not include:
 
@@ -91,6 +97,12 @@ Phase 4 live extension:
 - it does so through Blender CLI background execution
 - it may update app-local provision markers under `setup/state/`
 - it still must not launch the interactive Blender UI
+
+Phase 5 locked extension:
+
+- `setup_prepare()` may provision and repair bundled GIMP plugin/server assets
+- it may update app-local provision markers under `setup/state/`
+- it still must not launch the interactive GIMP UI
 
 ## 4. Public DTOs
 

--- a/docs/unified-assistant-self-contained-spec/THIRD_PARTY_PROVENANCE.md
+++ b/docs/unified-assistant-self-contained-spec/THIRD_PARTY_PROVENANCE.md
@@ -1,7 +1,7 @@
 # Third-Party Provenance Tracker
 
 **Last Updated:** 2026-03-17
-**Status:** Required tracker with Phase 3 bundled-Python source contract locked for LibreOffice and Phase 4 Blender addon repackaged on the self-contained line
+**Status:** Required tracker with Phase 3 bundled-Python source contract locked for LibreOffice, Phase 4 Blender addon repackaged, and Phase 5 GIMP provenance preflight active
 
 ## Purpose
 
@@ -22,16 +22,16 @@ Required fields:
 
 | Component                                      | Current source                                                                                                  | Pin status     | License status                                                    | Import status                             | Notes                                                                                                                                                                        |
 | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | -------------- | ----------------------------------------------------------------- | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| GIMP MCP/plugin runtime                        | upstream `gimp-mcp` source snapshot                                                                             | pending        | pending                                                           | not yet imported into self-contained line | Required before Phase 5 implementation                                                                                                                                       |
+| GIMP MCP/plugin runtime                        | upstream `maorcc/gimp-mcp` source snapshot (exact commit/tag pin required before import)                       | preflight lock | pending                                                           | not yet imported into self-contained line | Phase 5 docs preflight requires a concrete pinned revision, license note, and file import map before the implementation PR can import payload files                        |
 | Blender addon payload                          | `apps/blender-assistant/blender_addon/blender_helper_http.py` (`bl_info.version = 7.0.0`)                       | pinned in-repo | same repo lineage; formal release packaging review still required | repackaged into unified resources         | Phase 4 copied the pinned snapshot into `apps/codehelper/src-tauri/resources/blender/addon/blender_helper_http.py`; setup/provider now provision and enable this payload automatically |
 | LibreOffice MCP runtime scripts                | imported from `origin/codex/libreoffice-port-track-a` @ `7acad1fa0eb31e32a5485069e85c021d14284455`              | pinned         | same repo lineage; formal release packaging review still required | already present in unified resources      | Imported from the same repository line; Phase 3 switches them onto bundled Python ownership                                                                                  |
 | Bundled Python runtime                         | official Windows x64 CPython embeddable distribution from `python.org`, staged into `resources/python/payload/` | source locked  | Python Software Foundation License                                | packaged-mode contract is live            | Phase 3 runtime code now consumes the prepared bundled runtime for Writer/Slides; exact staged CPython release still needs a manifest pin when payloads are populated        |
 | Bundled `uv` tooling/runtime support           | Astral `uv` Windows binary staged alongside the bundled Python payload                                          | source locked  | Apache-2.0 OR MIT                                                 | manifest/staging contract landed          | Used for packaged Python management and future offline wheel install/repair flows; exact staged binary release still needs a manifest pin when payloads are populated        |
 | Default bundled model `qwen3-4b-instruct-2507` | current engine-supported model artifact source                                                                  | pending        | pending                                                           | manifest/staging contract landed          | Phase 2 added manifests and staging hooks; exact packaged artifact validation is still required                                                                              |
 
-## Phase 2-4 Provenance Rule
+## Phase 2-5 Provenance Rule
 
-Phases 2 through 4 may add manifests, staging hooks, runtime ownership code, and
+Phases 2 through 5 may add manifests, staging hooks, runtime ownership code, and
 in-repo payload repackaging, but they should not silently treat those artifacts
 as fully cleared for release packaging. The tracker must stay honest about:
 


### PR DESCRIPTION
Stacked follow-up to the blender status docs PR.

- Contains only phase 5 gimp provisioning scope updates
- Rebased as a clean stacked commit chain