### PR TITLE
docs(self-contained): add windows source testing guide

### DIFF
--- a/apps/codehelper/README.md
+++ b/apps/codehelper/README.md
@@ -1,6 +1,17 @@
 # CodeHelper App
 
-CodeHelper frontend and Tauri app shell.
+CodeHelper is the current frontend and Tauri shell for the unified app on
+`dev/unified-assistant-self-contained`.
+
+## Start Here
+
+For the current Windows source-based functional validation pass, use:
+
+- `docs/unified-assistant-self-contained-spec/WINDOWS_SOURCE_TESTING.md`
+- `docs/unified-assistant-self-contained-spec/WINDOWS_SOURCE_TEST_RESULTS_TEMPLATE.md`
+
+Those docs are the source of truth for testing the unified app before any
+engine reconciliation, packaging, or installer work.
 
 ## Structure
 
@@ -10,12 +21,37 @@ CodeHelper frontend and Tauri app shell.
 
 ## Commands (from repo root)
 
+- `npm run check`
 - `npm run tauri:dev`
 - `npm run tauri:dml`
-- `npm run check`
+- `npm run model:setup:qwen3`
+- `node apps/codehelper/scripts/self-contained/validate-resource-manifests.mjs`
+
+## Windows Source-Test Quickstart
+
+1. Use a separate clean clone on `origin/dev/unified-assistant-self-contained`.
+2. Run `npm ci`.
+3. Run `npm run check`.
+4. If you want Code mode to execute prompts, either:
+   - make sure `SMOLPC_MODELS_DIR` already points at a working shared model
+     root, or
+   - run `npm run model:setup:qwen3`.
+5. Launch the app with `npm run tauri:dev`.
+
+## Current Source-Test Expectations
+
+- This branch is being tested for source-based functionality, not packaged
+  self-contained delivery yet.
+- `bundled_model` and `bundled_python` can still show `not_prepared` in the
+  setup panel during source-mode testing if packaged payloads have not been
+  staged.
+- That does not automatically mean the branch is broken for this test pass.
+- Setup detail text and per-mode status are the source of truth for whether a
+  mode is usable on the tester's machine.
 
 ## Engine Integration
 
 - Startup/readiness flow is engine-driven (`ensure_started` + readiness status).
-- Inference generation/cancel/list/load calls route through `smolpc-engine-client`.
+- Inference generation/cancel/list/load calls route through
+  `smolpc-engine-client`.
 - App-local inference engine modules are removed.

--- a/docs/unified-assistant-self-contained-spec/CURRENT_STATE.md
+++ b/docs/unified-assistant-self-contained-spec/CURRENT_STATE.md
@@ -1,7 +1,7 @@
 # Current State
 
 **Last Updated:** 2026-03-21
-**Status:** Demo line frozen; Phase 5 GIMP self-contained provisioning is complete on the single self-contained mainline; Phase 6 release packaging and validation is next
+**Status:** Demo line frozen; Phase 5 GIMP self-contained provisioning is complete on the single self-contained mainline; Windows source-based functional validation is the active gate before engine reconciliation or broader Phase 6 packaging work
 
 ## 1. Branch State
 
@@ -236,7 +236,7 @@ Phase 4 intentionally did not land:
 - GIMP host-app launch orchestration
 - Calc activation
 
-## 10. Phase 5 Closeout And Next Official Branches
+## 10. Phase 5 Closeout And Current Validation Gate
 
 Phase 5 is now merged into `dev/unified-assistant-self-contained`.
 
@@ -249,7 +249,21 @@ Phase 5 landed:
 - GIMP mode now validates GIMP 3.x installs, provisions assets on demand, launches GIMP only when needed, and supervises the bundled loopback bridge on `127.0.0.1:10008`
 - existing Blender, LibreOffice, Code, and Calc behavior remained unchanged
 
-The next official docs branch is:
+Before engine/platform reconciliation or packaging work, the current mainline
+needs a clean source-based Windows functional validation pass.
+
+Active validation branches:
+
+- docs: `codex/unified-self-contained-functional-test-docs`
+- implementation: `codex/unified-self-contained-functional-test-prep`
+- closeout docs: `codex/unified-self-contained-functional-test-status-docs`
+
+Tester handoff docs for this gate:
+
+- [WINDOWS_SOURCE_TESTING.md](WINDOWS_SOURCE_TESTING.md)
+- [WINDOWS_SOURCE_TEST_RESULTS_TEMPLATE.md](WINDOWS_SOURCE_TEST_RESULTS_TEMPLATE.md)
+
+After this validation gate closes out, the next official docs branch returns to:
 
 - `codex/unified-self-contained-release-docs`
 
@@ -262,6 +276,12 @@ The next official docs branch is:
 | Host-app variance         | GIMP, Blender, and LibreOffice install/profile paths still vary across user machines and clean-machine validation is next           |
 | Calc expectation drift    | Users may assume all LibreOffice modes are live; docs and UI must keep Calc explicitly deferred                                     |
 | Phase 6 packaging surface | The installer, first-run repair flow, and upgrade path remain the largest remaining finish-line risk                                |
+
+Current validation note:
+
+- before broader Windows testing, source-based tester handoff still needs to
+  prove that another developer can follow the runbook on
+  `dev/unified-assistant-self-contained` without relying on tribal knowledge
 
 Tracking note for the GPL-3.0 release gate:
 

--- a/docs/unified-assistant-self-contained-spec/GIT_WORKFLOW.md
+++ b/docs/unified-assistant-self-contained-spec/GIT_WORKFLOW.md
@@ -1,7 +1,7 @@
 # Git Workflow For The Self-Contained Unified Assistant Line
 
 **Last Updated:** 2026-03-21
-**Status:** Required workflow on the single self-contained mainline; Phase 5 is complete and Phase 6 release docs are next
+**Status:** Required workflow on the single self-contained mainline; Phase 5 is complete and the immediate post-Phase-5 branch stack is the Windows source-testing validation gate before broader Phase 6 release work
 
 ## 1. Branch Roles
 
@@ -69,13 +69,24 @@ The standard self-contained phase flow now follows this exact sequence:
 No future self-contained PR should target
 `docs/unified-assistant-self-contained-spec`.
 
-Phase 5 is now complete on the mainline:
+Phase 5 is now complete on the mainline.
 
-- Phase 5 docs preflight is merged on the mainline
-- Phase 5 implementation is merged on the mainline
-- Phase 5 closeout docs are merged on the mainline
-- the next official docs branch should be:
-  - `codex/unified-self-contained-release-docs`
+Before engine upgrades, packaging work, or broader Phase 6 release changes, the
+immediate branch stack is:
+
+- docs:
+  - `codex/unified-self-contained-functional-test-docs`
+- implementation:
+  - `codex/unified-self-contained-functional-test-prep`
+- closeout docs:
+  - `codex/unified-self-contained-functional-test-status-docs`
+
+That stack is a narrow functional validation gate on
+`dev/unified-assistant-self-contained`, not a phase renumbering.
+
+After it closes out, the branch queue returns to:
+
+- `codex/unified-self-contained-release-docs`
 
 ## 6. Clone Rule
 
@@ -128,6 +139,7 @@ Allowed:
 - packaging and provenance documentation
 - API contract documentation
 - workflow migration or phase-closeout docs that belong on the active mainline
+- tester runbooks and repeatable validation templates
 
 Avoid:
 
@@ -210,5 +222,11 @@ As of 2026-03-21:
   `dev/unified-assistant-self-contained`
 - Phase 5 GIMP implementation is merged on
   `dev/unified-assistant-self-contained`
-- the next official docs branch is:
+- Phase 5 closeout docs are merged on
+  `dev/unified-assistant-self-contained`
+- the active validation gate branches are:
+  - `codex/unified-self-contained-functional-test-docs`
+  - `codex/unified-self-contained-functional-test-prep`
+  - `codex/unified-self-contained-functional-test-status-docs`
+- after that gate closes out, the queue returns to:
   - `codex/unified-self-contained-release-docs`

--- a/docs/unified-assistant-self-contained-spec/README.md
+++ b/docs/unified-assistant-self-contained-spec/README.md
@@ -4,7 +4,7 @@
 > and document map for the self-contained delivery line.
 
 **Last Updated:** 2026-03-21
-**Status:** Single-mainline self-contained workflow active; Phase 5 GIMP self-contained provisioning complete; Phase 6 release packaging and validation is next
+**Status:** Single-mainline self-contained workflow active; Phase 5 GIMP self-contained provisioning complete; source-based Windows functional validation is the active gate before broader Phase 6 packaging work
 
 ## Project Summary
 
@@ -53,8 +53,10 @@ As of 2026-03-21:
   `06d32a5219b69d8182079843c79661aca98ad220` and is not kept in sync
 - Phase 4 Blender closeout docs are merged on the self-contained mainline
 - Phase 5 GIMP preflight docs, implementation, and closeout docs are merged on the self-contained mainline
-- the next official docs branch is:
-  - `codex/unified-self-contained-release-docs`
+- the active post-Phase-5 validation pass is:
+  - docs: `codex/unified-self-contained-functional-test-docs`
+  - implementation: `codex/unified-self-contained-functional-test-prep`
+  - closeout docs: `codex/unified-self-contained-functional-test-status-docs`
 
 ## Freeze Tags
 
@@ -113,9 +115,10 @@ Never branch new self-contained work from the frozen demo branches.
 
 1. [CURRENT_STATE.md](CURRENT_STATE.md)
 2. [GIT_WORKFLOW.md](GIT_WORKFLOW.md)
-3. [IMPLEMENTATION_PHASES.md](IMPLEMENTATION_PHASES.md)
-4. [SETUP_SPEC.md](SETUP_SPEC.md)
-5. [SELF_CONTAINED_PLAN.md](SELF_CONTAINED_PLAN.md)
+3. [WINDOWS_SOURCE_TESTING.md](WINDOWS_SOURCE_TESTING.md)
+4. [IMPLEMENTATION_PHASES.md](IMPLEMENTATION_PHASES.md)
+5. [SETUP_SPEC.md](SETUP_SPEC.md)
+6. [SELF_CONTAINED_PLAN.md](SELF_CONTAINED_PLAN.md)
 
 `SETUP_SPEC.md` is intentionally cross-listed in both architecture and workflow
 reading orders because it defines both the technical setup contract and the
@@ -134,24 +137,26 @@ self-contained roadmap phases.
 
 ## Document Index
 
-| Document                                               | Purpose                                                                           |
-| ------------------------------------------------------ | --------------------------------------------------------------------------------- |
-| [CURRENT_STATE.md](CURRENT_STATE.md)                   | Frozen demo baseline, new mainlines, current gap to self-contained shipping       |
-| [IMPLEMENTATION_PHASES.md](IMPLEMENTATION_PHASES.md)   | Ordered self-contained delivery phases after the branch cut                       |
-| [ARCHITECTURE.md](ARCHITECTURE.md)                     | Target architecture for owned runtimes, provisioning, and host-app orchestration  |
-| [MCP_INTEGRATION.md](MCP_INTEGRATION.md)               | Mode-by-mode integration ownership, transports, and runtime supervision rules     |
-| [PACKAGING.md](PACKAGING.md)                           | Packaged layout, bundled runtime rules, and Windows validation checklist          |
-| [MODEL_STRATEGY.md](MODEL_STRATEGY.md)                 | Bundled default model decision and future model packaging policy                  |
-| [SETUP_SPEC.md](SETUP_SPEC.md)                         | App-level setup subsystem, public setup DTOs, setup commands, and Phase 2 limits  |
-| [SELF_CONTAINED_PLAN.md](SELF_CONTAINED_PLAN.md)       | Master roadmap from demo baseline to externally usable self-contained app         |
-| [THIRD_PARTY_PROVENANCE.md](THIRD_PARTY_PROVENANCE.md) | Pinned source, license, and modification tracking for imported third-party assets |
-| [GIT_WORKFLOW.md](GIT_WORKFLOW.md)                     | Required branch policy for the self-contained line                                |
-| [LEARNINGS.md](LEARNINGS.md)                           | Cross-phase corrections and non-obvious productization gotchas                    |
-| [RESOURCES.md](RESOURCES.md)                           | External repos, packaging tools, and upstream integration references              |
-| [CODE_CONVENTIONS.md](CODE_CONVENTIONS.md)             | Shared coding standards carried forward from the demo line                        |
-| [FRONTEND_SPEC.md](FRONTEND_SPEC.md)                   | Shared shell/UI reference carried forward from the demo line                      |
-| [CODE_MODE_SPEC.md](CODE_MODE_SPEC.md)                 | Historical Code-mode reference from the demo line; not a self-contained driver    |
-| [VSCODE_EXTENSION_SPEC.md](VSCODE_EXTENSION_SPEC.md)   | Historical extension research reference from the demo line                        |
+| Document                                                                           | Purpose                                                                           |
+| ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| [CURRENT_STATE.md](CURRENT_STATE.md)                                               | Frozen demo baseline, new mainlines, current gap to self-contained shipping       |
+| [IMPLEMENTATION_PHASES.md](IMPLEMENTATION_PHASES.md)                               | Ordered self-contained delivery phases after the branch cut                       |
+| [ARCHITECTURE.md](ARCHITECTURE.md)                                                 | Target architecture for owned runtimes, provisioning, and host-app orchestration  |
+| [MCP_INTEGRATION.md](MCP_INTEGRATION.md)                                           | Mode-by-mode integration ownership, transports, and runtime supervision rules     |
+| [PACKAGING.md](PACKAGING.md)                                                       | Packaged layout, bundled runtime rules, and Windows validation checklist          |
+| [MODEL_STRATEGY.md](MODEL_STRATEGY.md)                                             | Bundled default model decision and future model packaging policy                  |
+| [SETUP_SPEC.md](SETUP_SPEC.md)                                                     | App-level setup subsystem, public setup DTOs, setup commands, and Phase 2 limits  |
+| [SELF_CONTAINED_PLAN.md](SELF_CONTAINED_PLAN.md)                                   | Master roadmap from demo baseline to externally usable self-contained app         |
+| [THIRD_PARTY_PROVENANCE.md](THIRD_PARTY_PROVENANCE.md)                             | Pinned source, license, and modification tracking for imported third-party assets |
+| [GIT_WORKFLOW.md](GIT_WORKFLOW.md)                                                 | Required branch policy for the self-contained line                                |
+| [WINDOWS_SOURCE_TESTING.md](WINDOWS_SOURCE_TESTING.md)                             | Decision-complete Windows source-testing guide for the current functional gate    |
+| [WINDOWS_SOURCE_TEST_RESULTS_TEMPLATE.md](WINDOWS_SOURCE_TEST_RESULTS_TEMPLATE.md) | Short reporting template for repeated Windows source-test runs                    |
+| [LEARNINGS.md](LEARNINGS.md)                                                       | Cross-phase corrections and non-obvious productization gotchas                    |
+| [RESOURCES.md](RESOURCES.md)                                                       | External repos, packaging tools, and upstream integration references              |
+| [CODE_CONVENTIONS.md](CODE_CONVENTIONS.md)                                         | Shared coding standards carried forward from the demo line                        |
+| [FRONTEND_SPEC.md](FRONTEND_SPEC.md)                                               | Shared shell/UI reference carried forward from the demo line                      |
+| [CODE_MODE_SPEC.md](CODE_MODE_SPEC.md)                                             | Historical Code-mode reference from the demo line; not a self-contained driver    |
+| [VSCODE_EXTENSION_SPEC.md](VSCODE_EXTENSION_SPEC.md)                               | Historical extension research reference from the demo line                        |
 
 ## Locked Decisions
 
@@ -170,7 +175,10 @@ self-contained roadmap phases.
 
 ## Current Phase
 
-The current mainline-ready phase is Phase 6 Release Packaging And Validation.
+The current mainline-ready phase is still Phase 6 Release Packaging And
+Validation, but the immediate gate before broader Phase 6 work is a dedicated
+Windows source-based functional validation pass on the unified mainline.
+
 Phase 5 is now complete on `dev/unified-assistant-self-contained`:
 
 - the vendored `maorcc/gimp-mcp` snapshot is bundled under `apps/codehelper/src-tauri/resources/gimp/`
@@ -179,7 +187,18 @@ Phase 5 is now complete on `dev/unified-assistant-self-contained`:
 - GIMP mode now validates the detected host version, provisions missing assets on demand, launches GIMP only when needed, and supervises the bundled bridge on `127.0.0.1:10008`
 - Blender, LibreOffice, Code, and Calc behavior remained unchanged during Phase 5
 
-The next official docs branch is:
+Current validation branches:
+
+- docs: `codex/unified-self-contained-functional-test-docs`
+- implementation: `codex/unified-self-contained-functional-test-prep`
+- closeout docs: `codex/unified-self-contained-functional-test-status-docs`
+
+Use these alongside:
+
+- [WINDOWS_SOURCE_TESTING.md](WINDOWS_SOURCE_TESTING.md)
+- [WINDOWS_SOURCE_TEST_RESULTS_TEMPLATE.md](WINDOWS_SOURCE_TEST_RESULTS_TEMPLATE.md)
+
+After this validation gate is closed out, the branch queue returns to:
 
 - `codex/unified-self-contained-release-docs`
 

--- a/docs/unified-assistant-self-contained-spec/WINDOWS_SOURCE_TESTING.md
+++ b/docs/unified-assistant-self-contained-spec/WINDOWS_SOURCE_TESTING.md
@@ -1,0 +1,225 @@
+# Windows Source Testing Guide
+
+**Last Updated:** 2026-03-21
+**Status:** Pre-upgrade functional validation gate for `dev/unified-assistant-self-contained` before engine reconciliation, packaging, or installer work
+
+## 1. Purpose
+
+Use this guide to test the actual unified app behavior on Windows from source.
+
+This is intentionally narrower than Phase 6 packaging work:
+
+- in scope:
+  - source-based functional testing on Windows
+  - verifying the unified shell, setup panel, and live modes work as expected
+  - collecting repeatable tester results before any platform upgrades
+- out of scope:
+  - installer testing
+  - clean-machine packaged validation
+  - engine upgrade work from `main`
+  - packaging or installer changes
+
+## 2. Branch And Clone Rules
+
+- branch to test:
+  - `origin/dev/unified-assistant-self-contained`
+- use a separate clean clone for this work
+- do not test from a stale local `main` checkout
+- do not mix this testing pass with engine/platform reconciliation branches
+
+Recommended clone command:
+
+```bash
+git clone --branch dev/unified-assistant-self-contained --single-branch https://github.com/SmolPC-2-0/smolpc-codehelper.git
+cd smolpc-codehelper
+```
+
+Record the exact tested commit in your results.
+
+## 3. Windows Prerequisites
+
+### Required developer tooling
+
+- Node.js 18+
+- Rust toolchain through `rustup`
+- Windows Tauri prerequisites for a normal Rust/Tauri dev build
+  - MSVC C++ build tools
+  - WebView2 runtime
+
+### Required host apps
+
+- GIMP 3.x
+- Blender
+- LibreOffice or Collabora
+
+Phase 5 only supports GIMP 3.x. If the machine only has GIMP 2.x, treat that as
+an expected unsupported-host result, not as a mysterious regression.
+
+### Optional but often needed for local source testing
+
+- Python on PATH, or a repo-local `.venv`, for source-mode GIMP and
+  Writer/Slides fallback behavior
+- a working shared model root for Code mode
+
+Code mode is functional only when the engine can resolve a model. The simplest
+paths are:
+
+- an existing `SMOLPC_MODELS_DIR`
+- or `npm run model:setup:qwen3`
+
+## 4. Bootstrap The Clone
+
+From the repo root:
+
+```bash
+npm ci
+npm run check
+cargo test -p smolpc-code-helper
+node apps/codehelper/scripts/self-contained/validate-resource-manifests.mjs
+```
+
+If you plan to test Code mode and do not already have a shared model root:
+
+```powershell
+npm run model:setup:qwen3
+```
+
+This functional test gate is not trying to prove packaged payload staging yet.
+It is only trying to prove that the current unified app behavior works from
+source on real Windows laptops.
+
+## 5. Launch The Unified App
+
+Start from the repo root:
+
+```powershell
+npm run tauri:dev
+```
+
+This wrapper:
+
+- builds `smolpc-engine-host`
+- shuts down stale local engine-host processes first
+- starts the unified app in Tauri dev mode
+
+Use the setup panel and per-mode status surfaces as the source of truth during
+testing.
+
+## 6. Expected Source-Mode Behavior
+
+These behaviors are expected in the current validation pass:
+
+- `bundled_model` may still show `not_prepared` if the packaged model payload
+  has not been staged into `apps/codehelper/src-tauri/resources/models/`
+- `bundled_python` may still show `not_prepared` if the packaged Python payload
+  has not been staged into `apps/codehelper/src-tauri/resources/python/payload/`
+- that alone does not mean the branch is broken for source-based functional
+  testing
+- GIMP source mode can use:
+  - prepared bundled Python if present
+  - repo `.venv` Python if present
+  - PATH Python as a last resort in debug/source mode
+- Writer and Slides source mode can use:
+  - prepared bundled Python if present
+  - repo `.venv` Python if present
+  - PATH Python as a last resort in debug/source mode
+- Code mode still requires a real model to be discoverable by the shared engine
+
+Treat source-mode usability and honest status/error reporting as the goal here.
+Do not treat missing packaged payloads as a release regression during this pass.
+
+## 7. Functional Test Matrix
+
+### Setup And Shell
+
+Verify:
+
+- the app launches from source
+- the setup banner and setup panel render
+- setup item states are readable and believable
+- setup details distinguish missing host apps from not-prepared app-owned assets
+
+### Code Mode
+
+With a model configured:
+
+- engine starts automatically
+- one simple prompt completes successfully
+
+Without a model configured:
+
+- the app reports the failure honestly
+- the result is logged in the tester report as an expected environment gap, not
+  an unexplained regression
+
+### GIMP Mode
+
+Verify:
+
+- GIMP 3.x is detected
+- `setup_prepare()` can provision or repair the bundled plugin/runtime without
+  launching the interactive GIMP UI
+- first GIMP use provisions when needed
+- first GIMP use launches GIMP only when no suitable process is already running
+- already-running GIMP is reused
+- GIMP tools connect successfully through the bundled bridge on `127.0.0.1:10008`
+- missing GIMP or GIMP 2.x surfaces honest detail
+
+### Blender Mode
+
+Verify:
+
+- Blender is detected
+- `setup_prepare()` provisions the addon without launching Blender UI
+- first Blender use launches Blender only when needed
+- already-running Blender is reused
+- Blender tools connect successfully
+
+### Writer And Slides
+
+Verify:
+
+- LibreOffice or Collabora is detected
+- first Writer use launches the runtime plus the host app when needed
+- first Slides use launches the runtime plus the host app when needed
+- missing LibreOffice surfaces honest detail
+
+### Calc
+
+Verify:
+
+- Calc remains visible
+- Calc remains intentionally disabled
+
+## 8. What To Capture
+
+Use the results template in:
+
+- `docs/unified-assistant-self-contained-spec/WINDOWS_SOURCE_TEST_RESULTS_TEMPLATE.md`
+
+At minimum, record:
+
+- tested commit
+- Windows version
+- host app versions
+- whether Code mode had a configured model
+- whether PATH Python or a repo `.venv` was used
+- exact failing step, if any
+- exact setup or mode detail text shown by the app
+- terminal output from `npm run tauri:dev` when something fails
+
+## 9. Escalation Rules
+
+- If a step only fails because the tester skipped a documented prerequisite,
+  fix the environment and continue.
+- If a step fails even though the documented prerequisites are satisfied, treat
+  it as a branch-local functional issue on
+  `dev/unified-assistant-self-contained`.
+- Do not pull in engine-upgrade or packaging work just to explain a current
+  unified-app failure during this pass.
+
+## 10. Exit Condition For This Gate
+
+This gate is successful when another developer can follow this guide from a
+fresh Windows clone and complete the functional matrix without relying on
+unstated tribal knowledge.

--- a/docs/unified-assistant-self-contained-spec/WINDOWS_SOURCE_TEST_RESULTS_TEMPLATE.md
+++ b/docs/unified-assistant-self-contained-spec/WINDOWS_SOURCE_TEST_RESULTS_TEMPLATE.md
@@ -1,0 +1,72 @@
+# Windows Source Test Results Template
+
+Copy this into the issue, PR comment, or shared testing log for the current
+`dev/unified-assistant-self-contained` functional validation pass.
+
+```md
+# Windows Source Test Report
+
+- Tester:
+- Date:
+- Commit:
+- Windows version:
+- Clone path:
+
+## Environment
+
+- Node version:
+- Rust version:
+- PATH Python available:
+- Repo `.venv` available:
+- `SMOLPC_MODELS_DIR` configured:
+
+## Host Apps
+
+- GIMP version:
+- Blender version:
+- LibreOffice or Collabora version:
+
+## Preflight
+
+- `npm ci`:
+- `npm run check`:
+- `cargo test -p smolpc-code-helper`:
+- `node apps/codehelper/scripts/self-contained/validate-resource-manifests.mjs`:
+- `npm run model:setup:qwen3`:
+
+## Launch
+
+- `npm run tauri:dev`:
+- Setup banner loaded:
+- Setup panel loaded:
+
+## Functional Results
+
+- Code mode:
+- GIMP mode:
+- Blender mode:
+- Writer mode:
+- Slides mode:
+- Calc remains disabled:
+
+## Setup Notes
+
+- `bundled_model` state:
+- `bundled_python` state:
+- `host_gimp` state:
+- `gimp_plugin_runtime` state:
+- `host_blender` state:
+- `blender_addon` state:
+- `host_libreoffice` state:
+
+## Failures
+
+- Exact failing step:
+- Exact app detail text:
+- Relevant terminal output:
+
+## Overall Read
+
+- Ready for broader Windows source testing:
+- Blockers to fix before broader testing:
+```


### PR DESCRIPTION
## Summary\n- add a decision-complete Windows source-testing runbook for the unified app mainline\n- add a reusable Windows source-test results template\n- update the self-contained status/workflow docs and CodeHelper README to treat this as the active pre-upgrade functional validation gate\n\n## Validation\n- npx prettier --check apps/codehelper/README.md docs/unified-assistant-self-contained-spec/README.md docs/unified-assistant-self-contained-spec/CURRENT_STATE.md docs/unified-assistant-self-contained-spec/GIT_WORKFLOW.md docs/unified-assistant-self-contained-spec/WINDOWS_SOURCE_TESTING.md docs/unified-assistant-self-contained-spec/WINDOWS_SOURCE_TEST_RESULTS_TEMPLATE.md