### PR TITLE
docs(self-contained): close out functional test handoff

### DIFF
--- a/docs/unified-assistant-self-contained-spec/CURRENT_STATE.md
+++ b/docs/unified-assistant-self-contained-spec/CURRENT_STATE.md
@@ -1,7 +1,7 @@
 # Current State
 
 **Last Updated:** 2026-03-21
-**Status:** Demo line frozen; Phase 5 GIMP self-contained provisioning is complete on the single self-contained mainline; Windows source-based functional validation is the active gate before engine reconciliation or broader Phase 6 packaging work
+**Status:** Demo line frozen; Phase 5 GIMP self-contained provisioning is complete on the single self-contained mainline; Windows source-testing handoff is merged and broader Windows source testing is the active gate before engine reconciliation or broader Phase 6 packaging work
 
 ## 1. Branch State
 
@@ -236,7 +236,7 @@ Phase 4 intentionally did not land:
 - GIMP host-app launch orchestration
 - Calc activation
 
-## 10. Phase 5 Closeout And Current Validation Gate
+## 10. Phase 5 Closeout And Functional Test Handoff
 
 Phase 5 is now merged into `dev/unified-assistant-self-contained`.
 
@@ -250,20 +250,29 @@ Phase 5 landed:
 - existing Blender, LibreOffice, Code, and Calc behavior remained unchanged
 
 Before engine/platform reconciliation or packaging work, the current mainline
-needs a clean source-based Windows functional validation pass.
+needed a clean source-based Windows functional validation pass.
 
-Active validation branches:
+That repo-side handoff work is now merged on the mainline:
 
-- docs: `codex/unified-self-contained-functional-test-docs`
-- implementation: `codex/unified-self-contained-functional-test-prep`
-- closeout docs: `codex/unified-self-contained-functional-test-status-docs`
+- the Windows testing guide is merged
+- the repeated-results template is merged
+- the narrow prep fixes are merged:
+  - GIMP source mode now prefers prepared bundled Python, then repo `.venv`,
+    then PATH Python in debug/source mode
+  - Windows host detection now accepts `gimp-3.exe` during system lookup
+- `dev/unified-assistant-self-contained` is now ready for broader
+  source-based Windows testing from clean developer clones
 
 Tester handoff docs for this gate:
 
 - [WINDOWS_SOURCE_TESTING.md](WINDOWS_SOURCE_TESTING.md)
 - [WINDOWS_SOURCE_TEST_RESULTS_TEMPLATE.md](WINDOWS_SOURCE_TEST_RESULTS_TEMPLATE.md)
 
-After this validation gate closes out, the next official docs branch returns to:
+This closeout makes the branch ready for testing; it does not claim that the
+real Windows test matrix has already been executed.
+
+After initial Windows testing and any narrow tester-found follow-ups, the next
+official docs branch returns to:
 
 - `codex/unified-self-contained-release-docs`
 
@@ -279,9 +288,9 @@ After this validation gate closes out, the next official docs branch returns to:
 
 Current validation note:
 
-- before broader Windows testing, source-based tester handoff still needs to
-  prove that another developer can follow the runbook on
-  `dev/unified-assistant-self-contained` without relying on tribal knowledge
+- the repo-side tester handoff is now merged
+- the next required input is actual Windows tester results recorded with the
+  shared runbook and results template
 
 Tracking note for the GPL-3.0 release gate:
 

--- a/docs/unified-assistant-self-contained-spec/GIT_WORKFLOW.md
+++ b/docs/unified-assistant-self-contained-spec/GIT_WORKFLOW.md
@@ -1,7 +1,7 @@
 # Git Workflow For The Self-Contained Unified Assistant Line
 
 **Last Updated:** 2026-03-21
-**Status:** Required workflow on the single self-contained mainline; Phase 5 is complete and the immediate post-Phase-5 branch stack is the Windows source-testing validation gate before broader Phase 6 release work
+**Status:** Required workflow on the single self-contained mainline; Phase 5 is complete, the Windows source-testing handoff stack is merged, and broader Windows source testing is the active gate before broader Phase 6 release work
 
 ## 1. Branch Roles
 
@@ -72,7 +72,7 @@ No future self-contained PR should target
 Phase 5 is now complete on the mainline.
 
 Before engine upgrades, packaging work, or broader Phase 6 release changes, the
-immediate branch stack is:
+post-Phase-5 validation stack is:
 
 - docs:
   - `codex/unified-self-contained-functional-test-docs`
@@ -81,10 +81,14 @@ immediate branch stack is:
 - closeout docs:
   - `codex/unified-self-contained-functional-test-status-docs`
 
-That stack is a narrow functional validation gate on
-`dev/unified-assistant-self-contained`, not a phase renumbering.
+That stack is now merged on `dev/unified-assistant-self-contained`. It is a
+narrow functional validation gate, not a phase renumbering.
 
-After it closes out, the branch queue returns to:
+The next work is broader Windows source testing from clean developer clones
+using the merged runbook and results template.
+
+After those test results and any narrow follow-up fixes, the branch queue
+returns to:
 
 - `codex/unified-self-contained-release-docs`
 
@@ -224,9 +228,10 @@ As of 2026-03-21:
   `dev/unified-assistant-self-contained`
 - Phase 5 closeout docs are merged on
   `dev/unified-assistant-self-contained`
-- the active validation gate branches are:
+- the merged validation gate branches are:
   - `codex/unified-self-contained-functional-test-docs`
   - `codex/unified-self-contained-functional-test-prep`
   - `codex/unified-self-contained-functional-test-status-docs`
-- after that gate closes out, the queue returns to:
+- broader Windows source testing is now the active manual work on the mainline
+- after those test results and any narrow follow-up fixes, the queue returns to:
   - `codex/unified-self-contained-release-docs`

--- a/docs/unified-assistant-self-contained-spec/IMPLEMENTATION_PHASES.md
+++ b/docs/unified-assistant-self-contained-spec/IMPLEMENTATION_PHASES.md
@@ -283,7 +283,21 @@ Complete on the self-contained implementation line:
 - GIMP mode works on a machine with GIMP installed but no plugin/server manually configured
 - no manual clone, environment variable, plugin copy, or terminal start step remains
 
-The next official branch after Phase 5 closeout docs is:
+Immediately after Phase 5 closeout, the unified mainline runs a narrow Windows
+source-testing gate:
+
+- docs:
+  - `codex/unified-self-contained-functional-test-docs`
+- implementation:
+  - `codex/unified-self-contained-functional-test-prep`
+- closeout docs:
+  - `codex/unified-self-contained-functional-test-status-docs`
+
+That gate is now merged and leaves the branch ready for broader Windows
+source-based testing without renumbering phases.
+
+After initial Windows testing results and any narrow follow-up fixes, the next
+official Phase 6 docs branch is:
 
 - `codex/unified-self-contained-release-docs`
 

--- a/docs/unified-assistant-self-contained-spec/README.md
+++ b/docs/unified-assistant-self-contained-spec/README.md
@@ -4,7 +4,7 @@
 > and document map for the self-contained delivery line.
 
 **Last Updated:** 2026-03-21
-**Status:** Single-mainline self-contained workflow active; Phase 5 GIMP self-contained provisioning complete; source-based Windows functional validation is the active gate before broader Phase 6 packaging work
+**Status:** Single-mainline self-contained workflow active; Phase 5 GIMP self-contained provisioning complete; Windows source-testing handoff is merged and broader Windows source testing is the active gate before broader Phase 6 packaging work
 
 ## Project Summary
 
@@ -52,11 +52,17 @@ As of 2026-03-21:
 - `docs/unified-assistant-self-contained-spec` remains a frozen archive at
   `06d32a5219b69d8182079843c79661aca98ad220` and is not kept in sync
 - Phase 4 Blender closeout docs are merged on the self-contained mainline
-- Phase 5 GIMP preflight docs, implementation, and closeout docs are merged on the self-contained mainline
-- the active post-Phase-5 validation pass is:
-  - docs: `codex/unified-self-contained-functional-test-docs`
-  - implementation: `codex/unified-self-contained-functional-test-prep`
-  - closeout docs: `codex/unified-self-contained-functional-test-status-docs`
+- Phase 5 GIMP preflight docs, implementation, and closeout docs are merged on
+  the self-contained mainline
+- the Windows source-testing guide and results template are merged on the
+  self-contained mainline
+- the narrow Windows source-testing prep changes are merged on the
+  self-contained mainline
+- `dev/unified-assistant-self-contained` is now handoff-ready for broader
+  source-based Windows functional testing from clean developer clones
+- after initial Windows test results and any narrow follow-up fixes, the next
+  new docs-first branch returns to:
+  - `codex/unified-self-contained-release-docs`
 
 ## Freeze Tags
 
@@ -187,18 +193,24 @@ Phase 5 is now complete on `dev/unified-assistant-self-contained`:
 - GIMP mode now validates the detected host version, provisions missing assets on demand, launches GIMP only when needed, and supervises the bundled bridge on `127.0.0.1:10008`
 - Blender, LibreOffice, Code, and Calc behavior remained unchanged during Phase 5
 
-Current validation branches:
+The source-testing handoff is now merged on the mainline:
 
-- docs: `codex/unified-self-contained-functional-test-docs`
-- implementation: `codex/unified-self-contained-functional-test-prep`
-- closeout docs: `codex/unified-self-contained-functional-test-status-docs`
+- the Windows testing runbook and results template are merged
+- the narrow prep fixes are merged:
+  - GIMP source mode now prefers prepared bundled Python, then repo `.venv`,
+    then PATH Python in debug/source mode
+  - Windows host detection now accepts `gimp-3.exe` during system lookup
 
-Use these alongside:
+Use these to start broader Windows testing:
 
 - [WINDOWS_SOURCE_TESTING.md](WINDOWS_SOURCE_TESTING.md)
 - [WINDOWS_SOURCE_TEST_RESULTS_TEMPLATE.md](WINDOWS_SOURCE_TEST_RESULTS_TEMPLATE.md)
 
-After this validation gate is closed out, the branch queue returns to:
+This pass makes the branch ready for broader Windows testing; it does not
+replace the actual tester results from separate Windows laptops.
+
+After initial Windows testing and any narrow follow-up fixes, the branch queue
+returns to:
 
 - `codex/unified-self-contained-release-docs`
 

--- a/docs/unified-assistant-self-contained-spec/SETUP_SPEC.md
+++ b/docs/unified-assistant-self-contained-spec/SETUP_SPEC.md
@@ -233,6 +233,11 @@ The single-mainline workflow adopted after Phase 2 does not change the
 `setup_status` or `setup_prepare` wire contract. It only changes where the
 future docs PRs land.
 
-The next official branch after Phase 5 closeout is:
+After Phase 5 closeout, the mainline runs a narrow Windows source-testing gate
+before broader Phase 6 release work. That gate is now merged, and the next step
+is to run the shared Windows source-testing guide on real developer laptops and
+record results.
+
+The next official new Phase 6 docs branch after that testing remains:
 
 - `codex/unified-self-contained-release-docs`

--- a/docs/unified-assistant-self-contained-spec/WINDOWS_SOURCE_TESTING.md
+++ b/docs/unified-assistant-self-contained-spec/WINDOWS_SOURCE_TESTING.md
@@ -1,11 +1,16 @@
 # Windows Source Testing Guide
 
 **Last Updated:** 2026-03-21
-**Status:** Pre-upgrade functional validation gate for `dev/unified-assistant-self-contained` before engine reconciliation, packaging, or installer work
+**Status:** Canonical handoff guide for broader Windows source-based functional testing on `dev/unified-assistant-self-contained` before engine reconciliation, packaging, or installer work
 
 ## 1. Purpose
 
 Use this guide to test the actual unified app behavior on Windows from source.
+
+The runbook and narrow source-testing prep fixes are already merged on
+`dev/unified-assistant-self-contained`. Use this guide to collect the first real
+multi-developer Windows results; do not treat the existence of this guide as
+proof that those results already exist.
 
 This is intentionally narrower than Phase 6 packaging work:
 
@@ -22,7 +27,7 @@ This is intentionally narrower than Phase 6 packaging work:
 ## 2. Branch And Clone Rules
 
 - branch to test:
-  - `origin/dev/unified-assistant-self-contained`
+  - latest `origin/dev/unified-assistant-self-contained`
 - use a separate clean clone for this work
 - do not test from a stale local `main` checkout
 - do not mix this testing pass with engine/platform reconciliation branches


### PR DESCRIPTION
## Summary
- close out the post-Phase-5 functional test handoff on the unified mainline
- update the source-of-truth docs to say the runbook and narrow prep fixes are merged
- make it explicit that broader Windows source testing is the active manual work before engine/platform reconciliation or Phase 6 packaging

## Testing
- npm run check
- npx prettier --check docs/unified-assistant-self-contained-spec/README.md docs/unified-assistant-self-contained-spec/CURRENT_STATE.md docs/unified-assistant-self-contained-spec/GIT_WORKFLOW.md docs/unified-assistant-self-contained-spec/IMPLEMENTATION_PHASES.md docs/unified-assistant-self-contained-spec/SETUP_SPEC.md docs/unified-assistant-self-contained-spec/WINDOWS_SOURCE_TESTING.md