### PR TITLE
chore: fix all clippy warnings across workspace

### DIFF
--- a/apps/codehelper/src-tauri/src/modes/blender/prompts.rs
+++ b/apps/codehelper/src-tauri/src/modes/blender/prompts.rs
@@ -29,18 +29,17 @@ Your teaching style:
 - Use numbered steps for workflows.
 - Keep answers concrete and practical.
 
-{}
+{scene_summary}
 
 The documentation below contains Python references for grounding only. Translate concepts into Blender UI actions:
-{}
+{context_section}
 
 Answer the student's question in a friendly, educational manner with UI-based instructions.
 If they ask for scene status, start with a compact bullet summary of the live scene data before any teaching guidance.
 Default to a medium-length answer (roughly 4-8 actionable steps or 2-4 short paragraphs).
 If more detail would help, finish with a brief offer for a deeper breakdown instead of overlong output.
 
-Never provide Python code snippets, bpy commands, or scripts.",
-        scene_summary, context_section
+Never provide Python code snippets, bpy commands, or scripts."
     );
 
     let user_prompt = format!(

--- a/apps/codehelper/src-tauri/src/modes/blender/provider.rs
+++ b/apps/codehelper/src-tauri/src/modes/blender/provider.rs
@@ -336,7 +336,7 @@ impl BlenderProvider {
 
         let cached_blender_path = {
             let mut state = self.state.lock().await;
-            if let Err(_) = self.ensure_bridge_started(mode, &mut state).await {
+            if self.ensure_bridge_started(mode, &mut state).await.is_err() {
                 return Self::disconnected_state(mode, &state);
             }
             state.detected_blender_path.clone()

--- a/apps/codehelper/src-tauri/src/modes/gimp/provider.rs
+++ b/apps/codehelper/src-tauri/src/modes/gimp/provider.rs
@@ -23,7 +23,7 @@ use tokio::time::{sleep, Duration};
 const GIMP_CONNECTION_RETRY_ATTEMPTS: usize = 24;
 const GIMP_CONNECTION_RETRY_DELAY_MS: u64 = 250;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct RuntimeState {
     session: Option<McpSession>,
     runtime_child: Option<Child>,
@@ -31,19 +31,6 @@ struct RuntimeState {
     last_error: Option<String>,
     ever_connected: bool,
     detected_gimp_path: Option<PathBuf>,
-}
-
-impl Default for RuntimeState {
-    fn default() -> Self {
-        Self {
-            session: None,
-            runtime_child: None,
-            tools: Vec::new(),
-            last_error: None,
-            ever_connected: false,
-            detected_gimp_path: None,
-        }
-    }
 }
 
 impl Drop for RuntimeState {

--- a/apps/codehelper/src-tauri/src/modes/libreoffice/executor.rs
+++ b/apps/codehelper/src-tauri/src/modes/libreoffice/executor.rs
@@ -143,8 +143,7 @@ fn build_summary_messages(
         EngineChatMessage {
             role: "system".to_string(),
             content: format!(
-                "You are the unified LibreOffice {} assistant. A document tool has already run successfully. Summarize the result for the user in 2 or 3 short sentences. Plain text only. Do not suggest replaying the action. Do not mention undo.",
-                label
+                "You are the unified LibreOffice {label} assistant. A document tool has already run successfully. Summarize the result for the user in 2 or 3 short sentences. Plain text only. Do not suggest replaying the action. Do not mention undo."
             ),
         },
         EngineChatMessage {

--- a/apps/codehelper/src-tauri/src/modes/libreoffice/provider.rs
+++ b/apps/codehelper/src-tauri/src/modes/libreoffice/provider.rs
@@ -362,10 +362,7 @@ impl ToolProvider for LibreOfficeProvider {
             return Err(FOUNDATION_PROVIDER_EXECUTION_NOT_IMPLEMENTED.to_string());
         }
 
-        if !allowed_tool_names(mode)
-            .iter()
-            .any(|candidate| *candidate == name)
-        {
+        if !allowed_tool_names(mode).contains(&name) {
             let profile = Self::profile_for_mode(mode)?;
             return Err(format!(
                 "{name} is not available in {} mode.",

--- a/apps/codehelper/src-tauri/src/modes/libreoffice/response.rs
+++ b/apps/codehelper/src-tauri/src/modes/libreoffice/response.rs
@@ -82,7 +82,7 @@ pub fn build_local_fallback_summary(tool_result: &ToolExecutionResultDto) -> Str
             );
         }
 
-        return format!("Found {} document(s).", doc_count);
+        return format!("Found {doc_count} document(s).");
     }
 
     if text.len() <= 280 {

--- a/apps/codehelper/src-tauri/src/setup/gimp.rs
+++ b/apps/codehelper/src-tauri/src/setup/gimp.rs
@@ -390,11 +390,11 @@ fn resolve_gimp_plugin_target_dir(_gimp_path: &Path) -> Result<PathBuf, String> 
             .ok_or_else(|| {
                 "APPDATA is unavailable, so the GIMP profile root cannot be resolved.".to_string()
             })?;
-        return Ok(appdata
+        Ok(appdata
             .join("GIMP")
             .join("3.0")
             .join("plug-ins")
-            .join("gimp-mcp-plugin"));
+            .join("gimp-mcp-plugin"))
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/smolpc-mcp-client/src/mcp.rs
+++ b/crates/smolpc-mcp-client/src/mcp.rs
@@ -22,8 +22,8 @@ pub struct McpSession {
 
 #[derive(Debug)]
 enum SessionClient {
-    Tcp(TcpJsonRpcClient),
-    Stdio(StdioJsonRpcClient),
+    Tcp(Box<TcpJsonRpcClient>),
+    Stdio(Box<StdioJsonRpcClient>),
 }
 
 impl SessionClient {
@@ -66,7 +66,7 @@ impl McpSession {
         client_version: &str,
     ) -> Result<Self, McpClientError> {
         Self::initialize(
-            SessionClient::Tcp(TcpJsonRpcClient::connect(config).await?),
+            SessionClient::Tcp(Box::new(TcpJsonRpcClient::connect(config).await?)),
             client_name,
             client_version,
         )
@@ -79,7 +79,7 @@ impl McpSession {
         client_version: &str,
     ) -> Result<Self, McpClientError> {
         Self::initialize(
-            SessionClient::Stdio(StdioJsonRpcClient::connect(config).await?),
+            SessionClient::Stdio(Box::new(StdioJsonRpcClient::connect(config).await?)),
             client_name,
             client_version,
         )


### PR DESCRIPTION
## Summary

Fixes all 8 clippy warnings across the workspace. Zero warnings remaining.

| File | Fix |
|------|-----|
| `smolpc-mcp-client/mcp.rs` | Box large enum variants (`SessionClient::Tcp`, `::Stdio`) |
| `blender/prompts.rs` | Inline format args |
| `blender/provider.rs` | `is_err()` instead of `if let Err(_)` |
| `gimp/provider.rs` | Derive `Default` instead of manual impl |
| `libreoffice/executor.rs` | Inline format args |
| `libreoffice/provider.rs` | `contains()` instead of `iter().any()` |
| `libreoffice/response.rs` | Inline format args |
| `setup/gimp.rs` | Remove needless `return` |

Closes #128.

## Test plan
- [x] `cargo clippy --workspace` — zero warnings
- [x] `cargo check --workspace` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)