### PR TITLE
feat(frontend): wire mode routing in handleSendMessage

### DIFF
--- a/apps/codehelper/src/App.svelte
+++ b/apps/codehelper/src/App.svelte
@@ -166,8 +166,9 @@ Teaching rules:
 		if (activeMode === 'code' && (!inferenceStore.isLoaded || isInferenceBusy)) return;
 		if (activeMode !== 'code' && isInferenceBusy) return;
 
-		const activeChat =
-			currentChat ?? chatsStore.createChat(inferenceStore.currentModel ?? 'onnx-model');
+		const chatLabel =
+			activeMode === 'code' ? (inferenceStore.currentModel ?? 'onnx-model') : activeMode;
+		const activeChat = currentChat ?? chatsStore.createChat(chatLabel);
 		if (!activeChat) return;
 		const historyBeforeMessage = [...activeChat.messages];
 
@@ -201,7 +202,9 @@ Teaching rules:
 		const chatId = activeChat.id;
 		const messageId = assistantMessage.id;
 
-			try {
+		let handledByEventStream = false;
+
+		try {
 			if (activeMode === 'code') {
 				const messagesPayload = buildStructuredMessages(content, historyBeforeMessage);
 				const isOpenVinoNpu = inferenceStore.status.activeBackend === 'openvino_npu';
@@ -234,19 +237,25 @@ Teaching rules:
 							appendToken(chatId, messageId, streamSessionId, event.token);
 							break;
 						case 'error':
+							handledByEventStream = true;
 							chatsStore.updateMessage(chatId, messageId, {
 								content: `Error: ${event.message}`
 							});
+							break;
+						case 'complete':
+							// TODO: wire up event.response.undoable for undo support (#132)
 							break;
 					}
 				});
 			}
 		} catch (error) {
-			console.error('Generation error:', error);
-			chatsStore.updateMessage(chatId, messageId, {
-				content: `Error: ${error}`,
-				isStreaming: false
-			});
+			if (!handledByEventStream) {
+				console.error('Generation error:', error);
+				chatsStore.updateMessage(chatId, messageId, {
+					content: `Error: ${error}`,
+					isStreaming: false
+				});
+			}
 		} finally {
 			chatsStore.updateMessage(chatId, messageId, {
 				isStreaming: false


### PR DESCRIPTION
## Summary

Routes non-Code modes through the unified assistant backend. Single file change — all backend infrastructure already existed.

### What changed

- **Code mode**: unchanged — `inferenceStore.generateStreamMessages` path preserved exactly
- **GIMP/Blender/Writer/Impress modes**: now call `assistantSend()` from `unified.ts`, which invokes the `assistant_send` Tauri command → Rust-side mode routing to GIMP/Blender/LibreOffice executors
- **Cancel**: mode-aware — Code uses `inferenceStore.cancel()`, others use `assistantCancel()`
- **Send guard**: relaxed for non-Code modes (don't require engine model loaded)
- **Token streaming**: shared `appendToken` helper extracted from inline callback

### What this unlocks

- Selecting GIMP mode → sending a message → routes to GIMP MCP executor
- If host app isn't running: error displayed in chat (e.g., "Connection to GIMP failed")
- Availability gating (greying out uninstalled apps) is #132, not this PR

### Files

| File | Lines changed |
|------|--------------|
| `apps/codehelper/src/App.svelte` | +57 / -35 |

No Rust changes. No new files. No store changes.

Closes #124.

## Test plan
- [x] `svelte-check` — 0 errors, 0 warnings
- [x] `eslint` — clean
- [ ] Code mode: send message → tokens stream (no regression)
- [ ] Non-Code mode: switch to GIMP → send → error in chat (GIMP not installed)
- [ ] Cancel: works for both Code and non-Code modes
- [ ] Mode switch during generation: auto-cancels (from PR #149)

🤖 Generated with [Claude Code](https://claude.com/claude-code)