### PR TITLE
perf: defer WMI hardware detection from startup — ~10s faster

### DIFF
--- a/apps/codehelper/src/App.svelte
+++ b/apps/codehelper/src/App.svelte
@@ -613,7 +613,8 @@ Teaching rules:
 		initInference();
 		modeStore.initialize();
 		setupStore.initialize();
-		hardwareStore.getCached();
+		// Hardware detection deferred to HardwarePanel open — WMI takes ~10s
+		// and is purely cosmetic (engine does its own detection independently)
 		chatsStore.finalizeStaleStreamingMessages();
 		chatsStore.setMode(modeStore.activeMode);
 


### PR DESCRIPTION
## Summary

Remove WMI hardware detection from app startup. Single line change, ~10s faster startup.

### Root cause

`hardwareStore.getCached()` in `App.svelte` `onMount` triggers full WMI hardware detection (~10s). This runs simultaneously with the engine's own backend probe (also WMI-based), causing COM apartment contention that makes both take 9.5s+ each. Result: 30s+ startup on a machine with RTX 4050.

### Fix

Defer hardware detection to first `HardwarePanel` open. Hardware info is cosmetic — the engine does its own independent detection for backend selection.

### Impact

- Removes ~10s of WMI blocking from startup
- Eliminates COM contention with engine probe (may speed up engine probe too)
- Hardware panel still works — just loads on first open instead of eagerly

### Files

| File | Change |
|------|--------|
| `App.svelte` | -1 line (`hardwareStore.getCached()` removed from onMount) |

Addresses #164. Partially addresses #123 (WMI hang no longer affects startup).

## Test plan
- [ ] `npm run tauri:dev` — measure startup time (target: <15s vs 30s+ before)
- [ ] Loading screen shows faster progression
- [ ] Hardware panel still loads when opened manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)