### PR TITLE
fix(setup): add dev fallback for app-local-data resolution

### DIFF
--- a/apps/codehelper/src-tauri/src/lib.rs
+++ b/apps/codehelper/src-tauri/src/lib.rs
@@ -25,7 +25,137 @@ use commands::setup::{setup_prepare, setup_status};
 use launcher::orchestrator::LauncherState;
 use modes::registry::ModeProviderRegistry;
 use setup::SetupState;
+use std::path::PathBuf;
 use tauri::Manager;
+
+const DIRS_LOCAL_DATA_SOURCE: &str = "dirs::data_local_dir()";
+const PLATFORM_ENV_LOCAL_DATA_SOURCE: &str = "platform env fallback";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AppLocalDataResolution {
+    Direct(PathBuf),
+    Fallback { path: PathBuf, source: &'static str },
+}
+
+fn build_managed_state(
+    resource_dir: Option<PathBuf>,
+    app_local_data_dir: Option<PathBuf>,
+) -> (SetupState, ModeProviderRegistry) {
+    (
+        SetupState::new(resource_dir.clone(), app_local_data_dir.clone()),
+        ModeProviderRegistry::new(resource_dir, app_local_data_dir),
+    )
+}
+
+fn select_app_local_data_resolution(
+    identifier: &str,
+    tauri_result: Result<PathBuf, String>,
+    is_debug: bool,
+    dirs_local_data_root: Option<PathBuf>,
+    last_resort_local_data_root: Option<PathBuf>,
+) -> Option<AppLocalDataResolution> {
+    match tauri_result {
+        Ok(path) => Some(AppLocalDataResolution::Direct(path)),
+        Err(_) if !is_debug => None,
+        Err(_) => dirs_local_data_root
+            .map(|base| AppLocalDataResolution::Fallback {
+                path: base.join(identifier),
+                source: DIRS_LOCAL_DATA_SOURCE,
+            })
+            .or_else(|| {
+                last_resort_local_data_root.map(|base| AppLocalDataResolution::Fallback {
+                    path: base.join(identifier),
+                    source: PLATFORM_ENV_LOCAL_DATA_SOURCE,
+                })
+            }),
+    }
+}
+
+fn ensure_fallback_app_local_data_dir(
+    path: PathBuf,
+    source: &str,
+    tauri_error: &str,
+) -> Option<PathBuf> {
+    match std::fs::create_dir_all(&path) {
+        Ok(()) => {
+            log::warn!(
+                "Using dev-mode app-local-data fallback at {} after Tauri resolution failed: {} (source: {})",
+                path.display(),
+                tauri_error,
+                source
+            );
+            Some(path)
+        }
+        Err(create_error) => {
+            log::warn!(
+                "Unable to create dev-mode app-local-data fallback at {} after Tauri resolution failed: {} (source: {}, create_dir_all error: {})",
+                path.display(),
+                tauri_error,
+                source,
+                create_error
+            );
+            None
+        }
+    }
+}
+
+#[cfg(windows)]
+fn debug_last_resort_local_data_root() -> Option<PathBuf> {
+    std::env::var_os("LOCALAPPDATA")
+        .or_else(|| std::env::var_os("APPDATA"))
+        .map(PathBuf::from)
+}
+
+#[cfg(target_os = "macos")]
+fn debug_last_resort_local_data_root() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .map(|home| home.join("Library").join("Application Support"))
+}
+
+#[cfg(all(not(windows), not(target_os = "macos")))]
+fn debug_last_resort_local_data_root() -> Option<PathBuf> {
+    std::env::var_os("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .map(PathBuf::from)
+                .map(|home| home.join(".local").join("share"))
+        })
+}
+
+fn resolve_app_local_data_dir<R: tauri::Runtime>(app: &tauri::App<R>) -> Option<PathBuf> {
+    let tauri_result = app.path().app_local_data_dir().map_err(|error| {
+        let message = error.to_string();
+        log::warn!("Unable to resolve Tauri app-local-data directory: {message}");
+        message
+    });
+    let tauri_error = tauri_result.as_ref().err().cloned();
+
+    match select_app_local_data_resolution(
+        &app.config().identifier,
+        tauri_result,
+        cfg!(debug_assertions),
+        dirs::data_local_dir(),
+        debug_last_resort_local_data_root(),
+    ) {
+        Some(AppLocalDataResolution::Direct(path)) => Some(path),
+        Some(AppLocalDataResolution::Fallback { path, source }) => {
+            let tauri_error = tauri_error
+                .unwrap_or_else(|| "unknown Tauri app-local-data resolution failure".to_string());
+            ensure_fallback_app_local_data_dir(path, source, &tauri_error)
+        }
+        None => {
+            if let Some(tauri_error) = tauri_error {
+                log::warn!(
+                    "Dev-mode app-local-data fallback is unavailable after Tauri resolution failed: {}",
+                    tauri_error
+                );
+            }
+            None
+        }
+    }
+}
 
 #[allow(clippy::missing_panics_doc)]
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -42,9 +172,18 @@ pub fn run() {
 
             log::info!("Hardware detection will occur on first request");
 
-            let resource_dir = app.path().resource_dir().ok();
-            let app_local_data_dir = app.path().app_local_data_dir().ok();
-            app.manage(SetupState::new(resource_dir, app_local_data_dir));
+            let resource_dir = match app.path().resource_dir() {
+                Ok(path) => Some(path),
+                Err(error) => {
+                    log::warn!("Unable to resolve Tauri resource directory: {error}");
+                    None
+                }
+            };
+            let app_local_data_dir = resolve_app_local_data_dir(app);
+            let (setup_state, mode_provider_registry) =
+                build_managed_state(resource_dir, app_local_data_dir);
+            app.manage(setup_state);
+            app.manage(mode_provider_registry);
 
             Ok(())
         })
@@ -52,7 +191,6 @@ pub fn run() {
         .manage(HardwareCache::default())
         .manage(InferenceState::default())
         .manage(LauncherState::default())
-        .manage(ModeProviderRegistry::default())
         .invoke_handler(tauri::generate_handler![
             read,
             write,
@@ -180,4 +318,121 @@ fn force_kill_engine() {
     }
 
     let _ = std::fs::remove_file(&pid_path);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_managed_state, ensure_fallback_app_local_data_dir, select_app_local_data_resolution,
+        AppLocalDataResolution, DIRS_LOCAL_DATA_SOURCE, PLATFORM_ENV_LOCAL_DATA_SOURCE,
+    };
+    use smolpc_assistant_types::AppMode;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    #[test]
+    fn app_local_data_resolution_prefers_tauri_path_when_available() {
+        let expected = PathBuf::from("/resolved/by/tauri");
+
+        let resolution = select_app_local_data_resolution(
+            "com.smolpc.codehelper",
+            Ok(expected.clone()),
+            true,
+            Some(PathBuf::from("/dirs/local/data")),
+            Some(PathBuf::from("/env/local/data")),
+        );
+
+        assert_eq!(resolution, Some(AppLocalDataResolution::Direct(expected)));
+    }
+
+    #[test]
+    fn app_local_data_resolution_uses_dirs_local_data_fallback_in_debug_mode() {
+        let resolution = select_app_local_data_resolution(
+            "com.smolpc.codehelper",
+            Err("tauri path unavailable".to_string()),
+            true,
+            Some(PathBuf::from("/dirs/local/data")),
+            Some(PathBuf::from("/env/local/data")),
+        );
+
+        assert_eq!(
+            resolution,
+            Some(AppLocalDataResolution::Fallback {
+                path: PathBuf::from("/dirs/local/data").join("com.smolpc.codehelper"),
+                source: DIRS_LOCAL_DATA_SOURCE,
+            })
+        );
+    }
+
+    #[test]
+    fn app_local_data_resolution_uses_last_resort_fallback_when_dirs_root_is_missing() {
+        let resolution = select_app_local_data_resolution(
+            "com.smolpc.codehelper",
+            Err("tauri path unavailable".to_string()),
+            true,
+            None,
+            Some(PathBuf::from("/env/local/data")),
+        );
+
+        assert_eq!(
+            resolution,
+            Some(AppLocalDataResolution::Fallback {
+                path: PathBuf::from("/env/local/data").join("com.smolpc.codehelper"),
+                source: PLATFORM_ENV_LOCAL_DATA_SOURCE,
+            })
+        );
+    }
+
+    #[test]
+    fn app_local_data_resolution_stays_unavailable_outside_debug_mode() {
+        let resolution = select_app_local_data_resolution(
+            "com.smolpc.codehelper",
+            Err("tauri path unavailable".to_string()),
+            false,
+            Some(PathBuf::from("/dirs/local/data")),
+            Some(PathBuf::from("/env/local/data")),
+        );
+
+        assert_eq!(resolution, None);
+    }
+
+    #[test]
+    fn ensure_fallback_app_local_data_dir_creates_directory_on_disk() {
+        let temp = TempDir::new().expect("temp dir");
+        let fallback_path = temp.path().join("com.smolpc.codehelper");
+
+        let resolved = ensure_fallback_app_local_data_dir(
+            fallback_path.clone(),
+            DIRS_LOCAL_DATA_SOURCE,
+            "tauri path unavailable",
+        )
+        .expect("fallback path");
+
+        assert_eq!(resolved, fallback_path);
+        assert!(resolved.is_dir());
+    }
+
+    #[tokio::test]
+    async fn build_managed_state_passes_app_local_data_dir_to_setup_and_providers() {
+        let resource_temp = TempDir::new().expect("resource temp");
+        let app_temp = TempDir::new().expect("app temp");
+        let (setup_state, registry) = build_managed_state(
+            Some(resource_temp.path().to_path_buf()),
+            Some(app_temp.path().to_path_buf()),
+        );
+
+        assert_eq!(setup_state.app_local_data_dir(), Some(app_temp.path()));
+
+        let provider_state = registry
+            .provider_for_mode(AppMode::Gimp)
+            .status(AppMode::Gimp)
+            .await
+            .expect("provider status");
+
+        assert_eq!(provider_state.state, "disconnected");
+        assert!(provider_state
+            .detail
+            .expect("provider detail")
+            .contains("GIMP is not installed or could not be detected yet"));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #154 by centralizing `app_local_data_dir` resolution at Tauri startup.

In dev mode, the app now:
1. tries `app.path().app_local_data_dir()`
2. falls back to `dirs::data_local_dir() + identifier`
3. falls back again to a debug-only platform-env local-data root if needed

The resolved path is created on disk when using a fallback, logged clearly, and then passed once into both:
- `SetupState::new(...)`
- `ModeProviderRegistry::new(...)`

This keeps the fix scoped to startup path resolution and avoids scattering fallback logic through setup/provisioning consumers.

## Why

Issue #154 reported that in `npm run tauri:dev`, setup could fail with:

`Tauri app-local-data directory is unavailable, so setup roots cannot be created`

That blocked:
- setup root creation
- bundled Python preparation
- GIMP/Blender setup state persistence
- provider-owned runtime state that depends on `app_local_data_dir`

## What Changed

- Added a centralized `resolve_app_local_data_dir(...)` helper in `apps/codehelper/src-tauri/src/lib.rs`
- Added a small helper so setup state and provider registry are built from the same resolved path
- Moved `ModeProviderRegistry` initialization into startup so it receives the same resolved app-local-data path as setup state
- Added tests covering:
  - direct Tauri success
  - debug fallback to `dirs::data_local_dir`
  - debug last-resort platform-env fallback
  - non-debug no-fallback behavior
  - fallback directory creation on disk
  - resolved path reaching both setup state and providers

## Validation

Manual validation in dev mode confirmed the issue symptom is gone:
- the setup panel no longer reports `Tauri app-local-data directory is unavailable, so setup roots cannot be created`
- `Engine runtime` now reports `ready`
- setup resolves through `%LOCALAPPDATA%\\com.smolpc.codehelper\\setup`
- `%LOCALAPPDATA%\\com.smolpc.codehelper\\setup` contains:
  - `logs`
  - `python`
  - `state`

This means the original `app_local_data_dir == None` failure chain is no longer the blocker.

## Notes About Remaining Errors

During manual validation, `Prepare` exposed a separate dev bundled-resource-root problem:

- `Bundled resource root is missing: ...\\target\\debug\\python`
- `Bundled resource root is missing: ...\\target\\debug\\models`

That is not part of #154. This PR only fixes app-local-data resolution. The new error appears to be a separate dev bundled-resource resolution/staging issue.

## Reviewer Test Steps

1. Run `npm run tauri:dev`
2. Open the Setup panel
3. Confirm this error is gone:
   - `Tauri app-local-data directory is unavailable, so setup roots cannot be created`
4. Confirm `Engine runtime` is no longer blocked by missing app-local-data
5. Click `Prepare`
6. Confirm the failure, if any, is now about real staged resources or host apps rather than missing app-local-data
7. Confirm `%LOCALAPPDATA%\\com.smolpc.codehelper\\setup` exists and contains:
   - `logs`
   - `python`
   - `state`

## Automation / Check Notes

On my original working tree:
- `npm run check` passed
- targeted tests for the new fallback logic passed
- manual dev validation confirmed the `#154` symptom is fixed

On a fresh branch from current `main`:
- `cargo check -p smolpc-code-helper --lib` passed
- `npm run check` could not be rerun there because workspace node modules were not installed in the fresh worktree
- `cargo test -p smolpc-code-helper` is currently blocked by unrelated existing test-build issues on current `main` in `modes/blender/bridge.rs` (`tower::util::ServiceExt` / `oneshot` test setup), so this PR does not attempt to fix those unrelated failures

## Scope

This PR does not touch:
- engine internals
- packaging / installer logic
- downstream setup call sites
- unrelated frontend work
