### PR TITLE
fix(setup): normalize bundled resource roots in dev mode

### DIFF
--- a/apps/codehelper/src-tauri/src/app_paths.rs
+++ b/apps/codehelper/src-tauri/src/app_paths.rs
@@ -1,0 +1,184 @@
+use std::path::{Path, PathBuf};
+
+const KNOWN_BUNDLED_RESOURCE_ROOTS: [&str; 5] =
+    ["python", "models", "gimp", "blender", "libreoffice"];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum BundledResourceDirResolution {
+    Direct(PathBuf),
+    NestedResources(PathBuf),
+    DevFallback(PathBuf),
+}
+
+pub(crate) fn default_dev_bundled_resource_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resources")
+}
+
+pub(crate) fn bundled_resource_dir_path(resolution: &BundledResourceDirResolution) -> &Path {
+    match resolution {
+        BundledResourceDirResolution::Direct(path)
+        | BundledResourceDirResolution::NestedResources(path)
+        | BundledResourceDirResolution::DevFallback(path) => path,
+    }
+}
+
+pub(crate) fn bundled_resource_dir_source(
+    resolution: &BundledResourceDirResolution,
+) -> &'static str {
+    match resolution {
+        BundledResourceDirResolution::Direct(_) => "Tauri resource directory",
+        BundledResourceDirResolution::NestedResources(_) => "Tauri resource directory/resources",
+        BundledResourceDirResolution::DevFallback(_) => "debug manifest-dir resources fallback",
+    }
+}
+
+pub(crate) fn select_bundled_resource_dir_resolution(
+    tauri_result: Result<PathBuf, String>,
+    is_debug: bool,
+    dev_fallback_root: Option<PathBuf>,
+) -> Option<BundledResourceDirResolution> {
+    match tauri_result {
+        Ok(path) => normalize_tauri_resource_dir(path).or_else(|| {
+            if !is_debug {
+                None
+            } else {
+                dev_fallback_root
+                    .filter(|path| contains_known_resource_root(path))
+                    .map(BundledResourceDirResolution::DevFallback)
+            }
+        }),
+        Err(_) if !is_debug => None,
+        Err(_) => dev_fallback_root
+            .filter(|path| contains_known_resource_root(path))
+            .map(BundledResourceDirResolution::DevFallback),
+    }
+}
+
+fn normalize_tauri_resource_dir(path: PathBuf) -> Option<BundledResourceDirResolution> {
+    if contains_known_resource_root(&path) {
+        return Some(BundledResourceDirResolution::Direct(path));
+    }
+
+    let nested = path.join("resources");
+    if contains_known_resource_root(&nested) {
+        Some(BundledResourceDirResolution::NestedResources(nested))
+    } else {
+        None
+    }
+}
+
+fn contains_known_resource_root(path: &Path) -> bool {
+    KNOWN_BUNDLED_RESOURCE_ROOTS
+        .iter()
+        .any(|resource| path.join(resource).exists())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        bundled_resource_dir_path, bundled_resource_dir_source, default_dev_bundled_resource_dir,
+        select_bundled_resource_dir_resolution, BundledResourceDirResolution,
+    };
+    use tempfile::TempDir;
+
+    fn write_resource_root(base: &std::path::Path, name: &str) {
+        std::fs::create_dir_all(base.join(name)).expect("resource root");
+    }
+
+    #[test]
+    fn bundled_resource_dir_resolution_preserves_direct_tauri_root() {
+        let temp = TempDir::new().expect("temp dir");
+        write_resource_root(temp.path(), "python");
+
+        let resolution = select_bundled_resource_dir_resolution(
+            Ok(temp.path().to_path_buf()),
+            true,
+            Some(default_dev_bundled_resource_dir()),
+        )
+        .expect("resolution");
+
+        assert_eq!(
+            resolution,
+            BundledResourceDirResolution::Direct(temp.path().to_path_buf())
+        );
+        assert_eq!(bundled_resource_dir_path(&resolution), temp.path());
+        assert_eq!(
+            bundled_resource_dir_source(&resolution),
+            "Tauri resource directory"
+        );
+    }
+
+    #[test]
+    fn bundled_resource_dir_resolution_normalizes_nested_resources_root() {
+        let temp = TempDir::new().expect("temp dir");
+        let nested = temp.path().join("resources");
+        write_resource_root(&nested, "models");
+
+        let resolution = select_bundled_resource_dir_resolution(
+            Ok(temp.path().to_path_buf()),
+            true,
+            Some(default_dev_bundled_resource_dir()),
+        )
+        .expect("resolution");
+
+        assert_eq!(
+            resolution,
+            BundledResourceDirResolution::NestedResources(nested.clone())
+        );
+        assert_eq!(bundled_resource_dir_path(&resolution), nested);
+        assert_eq!(
+            bundled_resource_dir_source(&resolution),
+            "Tauri resource directory/resources"
+        );
+    }
+
+    #[test]
+    fn bundled_resource_dir_resolution_uses_debug_fallback_when_tauri_is_unusable() {
+        let dev = TempDir::new().expect("dev dir");
+        write_resource_root(dev.path(), "gimp");
+
+        let resolution = select_bundled_resource_dir_resolution(
+            Err("resource dir unavailable".to_string()),
+            true,
+            Some(dev.path().to_path_buf()),
+        )
+        .expect("resolution");
+
+        assert_eq!(
+            resolution,
+            BundledResourceDirResolution::DevFallback(dev.path().to_path_buf())
+        );
+        assert_eq!(
+            bundled_resource_dir_source(&resolution),
+            "debug manifest-dir resources fallback"
+        );
+    }
+
+    #[test]
+    fn bundled_resource_dir_resolution_skips_debug_fallback_outside_debug_builds() {
+        let dev = TempDir::new().expect("dev dir");
+        write_resource_root(dev.path(), "blender");
+
+        let resolution = select_bundled_resource_dir_resolution(
+            Err("resource dir unavailable".to_string()),
+            false,
+            Some(dev.path().to_path_buf()),
+        );
+
+        assert_eq!(resolution, None);
+    }
+
+    #[test]
+    fn bundled_resource_dir_resolution_returns_none_for_unusable_candidates() {
+        let temp = TempDir::new().expect("temp dir");
+        let dev = TempDir::new().expect("dev dir");
+
+        let resolution = select_bundled_resource_dir_resolution(
+            Ok(temp.path().to_path_buf()),
+            true,
+            Some(dev.path().to_path_buf()),
+        );
+
+        assert_eq!(resolution, None);
+    }
+}

--- a/apps/codehelper/src-tauri/src/commands/inference.rs
+++ b/apps/codehelper/src-tauri/src/commands/inference.rs
@@ -1,3 +1,7 @@
+use crate::app_paths::{
+    bundled_resource_dir_path, default_dev_bundled_resource_dir,
+    select_bundled_resource_dir_resolution,
+};
 use smolpc_engine_client::{
     connect_or_spawn, read_runtime_env_overrides, EngineChatMessage, EngineClient,
     EngineConnectOptions, RuntimeModePreference,
@@ -5,6 +9,7 @@ use smolpc_engine_client::{
 use smolpc_engine_core::inference::backend::{BackendStatus, CheckModelResponse};
 use smolpc_engine_core::models::registry::{ModelDefinition, ModelRegistry};
 use smolpc_engine_core::{GenerationConfig, GenerationMetrics};
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::UNIX_EPOCH;
@@ -372,7 +377,16 @@ pub(super) async fn resolve_client(
         .resource_dir()
         .ok()
         .or_else(|| Some(PathBuf::from(env!("CARGO_MANIFEST_DIR"))));
-    let models_dir = resolve_models_dir(resource_dir.as_ref());
+    let bundled_resource_dir = select_bundled_resource_dir_resolution(
+        app_handle
+            .path()
+            .resource_dir()
+            .map_err(|error| error.to_string()),
+        cfg!(debug_assertions),
+        Some(default_dev_bundled_resource_dir()),
+    )
+    .map(|resolution| bundled_resource_dir_path(&resolution).to_path_buf());
+    let models_dir = resolve_models_dir(bundled_resource_dir.as_deref());
     let host_binary = resolve_host_binary_path();
     log_host_binary_resolution(host_binary.as_ref());
 
@@ -410,34 +424,27 @@ pub(super) async fn resolve_client(
     Ok(client)
 }
 
-fn resolve_models_dir(resource_dir: Option<&PathBuf>) -> Option<PathBuf> {
-    if let Ok(override_dir) = std::env::var("SMOLPC_MODELS_DIR") {
-        let path = PathBuf::from(override_dir);
-        if path.exists() {
-            return Some(path);
-        }
-    }
+fn resolve_models_dir(resource_dir: Option<&Path>) -> Option<PathBuf> {
+    let override_dir = std::env::var("SMOLPC_MODELS_DIR").ok().map(PathBuf::from);
+    let shared_dir = dirs::data_local_dir()
+        .map(|base| base.join(SHARED_MODELS_VENDOR_DIR).join(SHARED_MODELS_DIR));
 
-    if let Some(base) = dirs::data_local_dir() {
-        let shared = base.join(SHARED_MODELS_VENDOR_DIR).join(SHARED_MODELS_DIR);
-        if shared.exists() {
-            return Some(shared);
-        }
-    }
+    select_models_dir(override_dir, shared_dir, resource_dir)
+}
 
-    let dev_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("models");
-    if dev_path.exists() {
-        return Some(dev_path);
-    }
-
-    if let Some(res_dir) = resource_dir {
-        let bundled = res_dir.join("models");
-        if bundled.exists() {
-            return Some(bundled);
-        }
-    }
-
-    None
+fn select_models_dir(
+    override_dir: Option<PathBuf>,
+    shared_dir: Option<PathBuf>,
+    resource_dir: Option<&Path>,
+) -> Option<PathBuf> {
+    override_dir
+        .filter(|path| path.exists())
+        .or_else(|| shared_dir.filter(|path| path.exists()))
+        .or_else(|| {
+            resource_dir
+                .map(|res_dir| res_dir.join("models"))
+                .filter(|path| path.exists())
+        })
 }
 
 fn resolve_host_binary_path() -> Option<PathBuf> {
@@ -880,6 +887,7 @@ pub(crate) async fn cached_generation_client(state: &InferenceState) -> Option<E
 mod tests {
     use super::*;
     use smolpc_engine_client::test_utils::with_runtime_env;
+    use tempfile::TempDir;
 
     #[test]
     fn apply_runtime_mode_rollback_restores_previous_config_and_clears_client() {
@@ -1039,5 +1047,36 @@ mod tests {
         .expect("auto-unload message");
         assert!(message.contains("was minimized"));
         assert!(message.contains("qwen2.5-1.5b-instruct"));
+    }
+
+    #[test]
+    fn select_models_dir_prefers_override_over_shared_and_bundled() {
+        let override_temp = TempDir::new().expect("override temp");
+        let shared_temp = TempDir::new().expect("shared temp");
+        let resource_temp = TempDir::new().expect("resource temp");
+        std::fs::create_dir_all(override_temp.path()).expect("override dir");
+        std::fs::create_dir_all(shared_temp.path()).expect("shared dir");
+        std::fs::create_dir_all(resource_temp.path().join("models")).expect("bundled models");
+
+        let selected = select_models_dir(
+            Some(override_temp.path().to_path_buf()),
+            Some(shared_temp.path().to_path_buf()),
+            Some(resource_temp.path()),
+        )
+        .expect("selected models dir");
+
+        assert_eq!(selected, override_temp.path());
+    }
+
+    #[test]
+    fn select_models_dir_uses_bundled_models_from_normalized_resource_root() {
+        let resource_temp = TempDir::new().expect("resource temp");
+        let bundled_models = resource_temp.path().join("models");
+        std::fs::create_dir_all(&bundled_models).expect("bundled models");
+
+        let selected = select_models_dir(None, None, Some(resource_temp.path()))
+            .expect("selected bundled models");
+
+        assert_eq!(selected, bundled_models);
     }
 }

--- a/apps/codehelper/src-tauri/src/lib.rs
+++ b/apps/codehelper/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod app_paths;
 mod assistant;
 mod benchmark;
 mod commands;
@@ -7,6 +8,10 @@ mod modes;
 mod security;
 mod setup;
 
+use app_paths::{
+    bundled_resource_dir_path, bundled_resource_dir_source, default_dev_bundled_resource_dir,
+    select_bundled_resource_dir_resolution, BundledResourceDirResolution,
+};
 use assistant::state::AssistantState;
 use commands::assistant::{assistant_cancel, assistant_send, mode_undo};
 use commands::benchmark::{get_benchmarks_directory, open_benchmarks_folder, run_benchmark};
@@ -157,6 +162,66 @@ fn resolve_app_local_data_dir<R: tauri::Runtime>(app: &tauri::App<R>) -> Option<
     }
 }
 
+fn resolve_bundled_resource_dir<R: tauri::Runtime>(app: &tauri::App<R>) -> Option<PathBuf> {
+    let tauri_result = app.path().resource_dir().map_err(|error| {
+        let message = error.to_string();
+        log::warn!("Unable to resolve Tauri resource directory: {message}");
+        message
+    });
+    let tauri_error = tauri_result.as_ref().err().cloned();
+    let tauri_path = tauri_result.as_ref().ok().cloned();
+
+    match select_bundled_resource_dir_resolution(
+        tauri_result,
+        cfg!(debug_assertions),
+        Some(default_dev_bundled_resource_dir()),
+    ) {
+        Some(
+            resolution @ (BundledResourceDirResolution::Direct(_)
+            | BundledResourceDirResolution::NestedResources(_)),
+        ) => {
+            let path = bundled_resource_dir_path(&resolution).to_path_buf();
+            let source = bundled_resource_dir_source(&resolution);
+            log::info!(
+                "Resolved bundled resource base at {} (source: {})",
+                path.display(),
+                source
+            );
+            Some(path)
+        }
+        Some(BundledResourceDirResolution::DevFallback(path)) => {
+            if let Some(tauri_path) = tauri_path {
+                log::warn!(
+                    "Using dev bundled-resource fallback at {} because Tauri resource directory {} did not contain bundled resources directly or under /resources",
+                    path.display(),
+                    tauri_path.display()
+                );
+            } else if let Some(tauri_error) = tauri_error {
+                log::warn!(
+                    "Using dev bundled-resource fallback at {} after Tauri resource directory resolution failed: {}",
+                    path.display(),
+                    tauri_error
+                );
+            }
+            Some(path)
+        }
+        None => {
+            if let Some(tauri_path) = tauri_path {
+                log::warn!(
+                    "Bundled resource base is unavailable because Tauri resource directory {} did not contain bundled resources directly or under /resources, and no dev fallback was usable",
+                    tauri_path.display()
+                );
+            } else if let Some(tauri_error) = tauri_error {
+                log::warn!(
+                    "Bundled resource base is unavailable after Tauri resource directory resolution failed: {}",
+                    tauri_error
+                );
+            }
+            None
+        }
+    }
+}
+
 #[allow(clippy::missing_panics_doc)]
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -172,13 +237,7 @@ pub fn run() {
 
             log::info!("Hardware detection will occur on first request");
 
-            let resource_dir = match app.path().resource_dir() {
-                Ok(path) => Some(path),
-                Err(error) => {
-                    log::warn!("Unable to resolve Tauri resource directory: {error}");
-                    None
-                }
-            };
+            let resource_dir = resolve_bundled_resource_dir(app);
             let app_local_data_dir = resolve_app_local_data_dir(app);
             let (setup_state, mode_provider_registry) =
                 build_managed_state(resource_dir, app_local_data_dir);
@@ -421,6 +480,7 @@ mod tests {
             Some(app_temp.path().to_path_buf()),
         );
 
+        assert_eq!(setup_state.resource_dir(), Some(resource_temp.path()));
         assert_eq!(setup_state.app_local_data_dir(), Some(app_temp.path()));
 
         let provider_state = registry


### PR DESCRIPTION
## Summary

Fixes #171 by centralizing bundled resource-root resolution for dev mode.

In dev builds, the app now resolves bundled resources from one normalized base:
1. use `app.path().resource_dir()` directly if it already contains bundled roots
2. otherwise normalize to `resource_dir()/resources`
3. otherwise fall back in debug builds to `src-tauri/resources`

That resolved bundled resource base is now reused by:
- startup-managed setup state / mode providers
- inference bundled model lookup

## Why

Issue #171 reported that in `npm run tauri:dev`, setup could fail with errors like:

- `Bundled resource root is missing: ...\target\debug\python`
- `Bundled resource root is missing: ...\target\debug\models`

The real problem was that dev builds could have bundled resources under `target\debug\resources`, while some code paths assumed `target\debug` itself was the bundled resource root.

## What Changed

- Added a shared internal bundled-resource resolver in `apps/codehelper/src-tauri/src/app_paths.rs`
- Updated `apps/codehelper/src-tauri/src/lib.rs` to resolve and log one bundled resource base at startup before constructing:
  - `SetupState`
  - `ModeProviderRegistry`
- Updated `apps/codehelper/src-tauri/src/commands/inference.rs` so bundled model lookup uses the same normalized bundled resource base
- Removed the incorrect inference fallback that assumed `env!("CARGO_MANIFEST_DIR").join("models")`

## Validation

Automated:
- `npm run check` ✅
- `cargo check -p smolpc-code-helper --lib` ✅

Manual:
- setup no longer reports:
  - `Bundled resource root is missing: ...\target\debug\python`
  - `Bundled resource root is missing: ...\target\debug\models`
- setup now reports real staged/not-staged resource states:
  - bundled model resolves correctly
  - bundled Python resolves correctly
  - GIMP bundled resources resolve correctly
  - Blender bundled resources resolve correctly

## Notes

During manual validation, `Prepare` still stops on:

- `Bundled Python payload is not staged yet. Missing payload`

That is not part of #171. This PR fixes bundled resource-root resolution only. The Python payload issue is a separate follow-up about dev/runtime asset staging.

## Reviewer Test Steps

1. Run:
   - `npm run runtime:setup:openvino`
   - `npm run tauri:dev`
2. Open the Setup panel
3. Confirm these old errors are gone:
   - `Bundled resource root is missing: ...\target\debug\python`
   - `Bundled resource root is missing: ...\target\debug\models`
4. Confirm setup now shows real staged-resource states instead of bad-root `missing`
5. Optionally click `Prepare`
6. Confirm that any remaining blocker is now about real staged assets (for example the bundled Python payload), not a broken bundled resource root

## Scope

This PR does not touch:
- engine internals
- packaging / installer logic
- downstream setup consumer logic
- unrelated frontend work
