### PR TITLE
fix(setup): stage bundled python payload for dev mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ dist-ssr
 !/apps/codehelper/src-tauri/libs/openvino/
 /apps/codehelper/src-tauri/libs/openvino/*
 !/apps/codehelper/src-tauri/libs/openvino/.gitkeep
+/apps/codehelper/src-tauri/resources/python/payload/
 /apps/codehelper/src-tauri/*.dll
 nul
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Shared model bootstrap:
 
 ```bash
 npm run runtime:setup:openvino
+npm run runtime:setup:python
 npm run model:setup:qwen25-instruct
 npm run model:setup:qwen3-4b
 ```

--- a/apps/codehelper/README.md
+++ b/apps/codehelper/README.md
@@ -10,6 +10,8 @@ CodeHelper frontend and Tauri app shell.
 
 ## Commands (from repo root)
 
+- `npm run runtime:setup:openvino`
+- `npm run runtime:setup:python`
 - `npm run tauri:dev`
 - `npm run tauri:dml`
 - `npm run check`

--- a/apps/codehelper/package.json
+++ b/apps/codehelper/package.json
@@ -19,6 +19,7 @@
 		"tauri:dev": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/run-tauri-dev.ps1",
 		"tauri:dml": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/run-tauri-dml.ps1",
 		"runtime:setup:openvino": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/setup-openvino-runtime.ps1",
+		"runtime:setup:python": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/setup-bundled-python-runtime.ps1",
 		"model:export:dml": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/export-dml-model.ps1",
 		"model:setup:qwen25-instruct": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/setup-qwen25-instruct-model.ps1",
 		"model:setup:qwen3-4b": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/setup-qwen3-4b-model.ps1",

--- a/apps/codehelper/scripts/setup-bundled-python-runtime.ps1
+++ b/apps/codehelper/scripts/setup-bundled-python-runtime.ps1
@@ -1,0 +1,215 @@
+param(
+    [string]$PayloadRoot = "",
+    [string]$PythonArchivePath = "",
+    [string]$UvArchivePath = "",
+    [string]$PythonArchiveUrl = "https://www.python.org/ftp/python/3.12.9/python-3.12.9-embed-amd64.zip",
+    [string]$PythonArchiveMd5 = "f34996cc1f44c98729ef6ce92d05e41c",
+    [string]$UvArchiveUrl = "https://releases.astral.sh/github/uv/releases/download/0.10.12/uv-x86_64-pc-windows-msvc.zip",
+    [string]$UvArchiveSha256 = "4c1d55501869b3330d4aabf45ad6024ce2367e0f3af83344395702d272c22e88"
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+if ([System.Environment]::OSVersion.Platform -ne [System.PlatformID]::Win32NT) {
+    throw "Bundled Python dev staging is currently supported only on Windows."
+}
+
+function Resolve-TargetPath {
+    param(
+        [string]$Path,
+        [string]$RepoRoot
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return Join-Path $RepoRoot "src-tauri\resources\python\payload"
+    }
+
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        return $Path
+    }
+
+    return Join-Path $RepoRoot $Path
+}
+
+function Resolve-ArchivePath {
+    param(
+        [string]$ArchivePath,
+        [string]$DownloadPath
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($ArchivePath)) {
+        if (-not (Test-Path $ArchivePath -PathType Leaf)) {
+            throw "Archive file not found: $ArchivePath"
+        }
+        return (Resolve-Path $ArchivePath).Path
+    }
+
+    return $DownloadPath
+}
+
+function Download-ArchiveIfNeeded {
+    param(
+        [string]$ArchivePath,
+        [string]$ArchiveUrl,
+        [string]$Label
+    )
+
+    if (Test-Path $ArchivePath -PathType Leaf) {
+        Write-Host "Using existing $Label archive: $ArchivePath"
+        return
+    }
+
+    Write-Host "Downloading $Label archive..."
+    Invoke-WebRequest -Uri $ArchiveUrl -OutFile $ArchivePath
+}
+
+function Assert-FileHash {
+    param(
+        [string]$Path,
+        [string]$Algorithm,
+        [string]$Expected,
+        [string]$Label
+    )
+
+    $actual = (Get-FileHash -Path $Path -Algorithm $Algorithm).Hash.ToLowerInvariant()
+    $expectedNormalized = $Expected.ToLowerInvariant()
+    if ($actual -ne $expectedNormalized) {
+        throw "$Label archive hash mismatch. Expected $expectedNormalized but got $actual."
+    }
+}
+
+function Resolve-ExtractedRoot {
+    param(
+        [string]$ExtractRoot,
+        [string]$Sentinel
+    )
+
+    $directSentinel = Join-Path $ExtractRoot $Sentinel
+    if (Test-Path $directSentinel -PathType Leaf) {
+        return $ExtractRoot
+    }
+
+    foreach ($candidate in Get-ChildItem -Path $ExtractRoot -Directory) {
+        $candidateSentinel = Join-Path $candidate.FullName $Sentinel
+        if (Test-Path $candidateSentinel -PathType Leaf) {
+            return $candidate.FullName
+        }
+    }
+
+    throw "Failed to locate extracted archive contents containing $Sentinel under $ExtractRoot"
+}
+
+function Copy-DirectoryContents {
+    param(
+        [string]$SourceRoot,
+        [string]$DestinationRoot
+    )
+
+    foreach ($entry in Get-ChildItem -LiteralPath $SourceRoot -Force) {
+        Copy-Item -LiteralPath $entry.FullName -Destination $DestinationRoot -Recurse -Force
+    }
+}
+
+function Copy-RequiredFile {
+    param(
+        [string]$Source,
+        [string]$Destination
+    )
+
+    if (-not (Test-Path $Source -PathType Leaf)) {
+        throw "Missing staged runtime file: $Source"
+    }
+
+    Copy-Item -LiteralPath $Source -Destination $Destination -Force
+}
+
+function Remove-TreeIfPresent {
+    param([string]$Path)
+
+    if (-not (Test-Path $Path)) {
+        return
+    }
+
+    Remove-Item -LiteralPath $Path -Recurse -Force
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$payloadRoot = Resolve-TargetPath -Path $PayloadRoot -RepoRoot $repoRoot
+$tempRoot = Join-Path $env:TEMP ("smolpc-python-runtime-" + [Guid]::NewGuid().ToString("N"))
+$pythonDownloadPath = Join-Path $tempRoot "python-embed.zip"
+$uvDownloadPath = Join-Path $tempRoot "uv.zip"
+$pythonExtractRoot = Join-Path $tempRoot "python-extract"
+$uvExtractRoot = Join-Path $tempRoot "uv-extract"
+$stagingPayloadRoot = Join-Path $tempRoot "payload"
+
+$pythonArchive = Resolve-ArchivePath -ArchivePath $PythonArchivePath -DownloadPath $pythonDownloadPath
+$uvArchive = Resolve-ArchivePath -ArchivePath $UvArchivePath -DownloadPath $uvDownloadPath
+
+$requiredPayloadFiles = @(
+    "python.exe",
+    "pythonw.exe",
+    "python312.dll",
+    "python312.zip",
+    "python312._pth",
+    "vcruntime140.dll",
+    "uv.exe",
+    "uvx.exe"
+)
+
+try {
+    New-Item -ItemType Directory -Force -Path $tempRoot, $pythonExtractRoot, $uvExtractRoot, $stagingPayloadRoot | Out-Null
+
+    Download-ArchiveIfNeeded -ArchivePath $pythonArchive -ArchiveUrl $PythonArchiveUrl -Label "CPython embeddable"
+    Download-ArchiveIfNeeded -ArchivePath $uvArchive -ArchiveUrl $UvArchiveUrl -Label "uv"
+
+    Assert-FileHash -Path $pythonArchive -Algorithm MD5 -Expected $PythonArchiveMd5 -Label "CPython embeddable"
+    Assert-FileHash -Path $uvArchive -Algorithm SHA256 -Expected $UvArchiveSha256 -Label "uv"
+
+    Write-Host "Extracting CPython embeddable runtime..."
+    Expand-Archive -LiteralPath $pythonArchive -DestinationPath $pythonExtractRoot -Force
+    $pythonRoot = Resolve-ExtractedRoot -ExtractRoot $pythonExtractRoot -Sentinel "python.exe"
+    Copy-DirectoryContents -SourceRoot $pythonRoot -DestinationRoot $stagingPayloadRoot
+
+    Write-Host "Extracting uv runtime..."
+    Expand-Archive -LiteralPath $uvArchive -DestinationPath $uvExtractRoot -Force
+    $uvRoot = Resolve-ExtractedRoot -ExtractRoot $uvExtractRoot -Sentinel "uv.exe"
+    foreach ($fileName in @("uv.exe", "uvx.exe")) {
+        $source = Join-Path $uvRoot $fileName
+        $destination = Join-Path $stagingPayloadRoot $fileName
+        Copy-RequiredFile -Source $source -Destination $destination
+    }
+
+    $missing = @(
+        foreach ($fileName in $requiredPayloadFiles) {
+            $candidate = Join-Path $stagingPayloadRoot $fileName
+            if (-not (Test-Path $candidate -PathType Leaf)) {
+                $fileName
+            }
+        }
+    )
+
+    if ($missing.Count -gt 0) {
+        throw "Bundled Python payload staging was incomplete. Missing: $($missing -join ', ')"
+    }
+
+    if (Test-Path $payloadRoot) {
+        Remove-TreeIfPresent -Path $payloadRoot
+    }
+    if (-not (Test-Path (Split-Path -Parent $payloadRoot))) {
+        New-Item -ItemType Directory -Force -Path (Split-Path -Parent $payloadRoot) | Out-Null
+    }
+    Move-Item -LiteralPath $stagingPayloadRoot -Destination $payloadRoot -Force
+
+    Write-Host ""
+    Write-Host "Bundled Python payload staged successfully."
+    Write-Host "Payload root: $payloadRoot"
+    Write-Host "Python archive: $PythonArchiveUrl"
+    Write-Host "uv archive: $UvArchiveUrl"
+    Write-Host "Files:"
+    foreach ($fileName in $requiredPayloadFiles) {
+        Write-Host "  - $fileName"
+    }
+} finally {
+    Remove-TreeIfPresent -Path $tempRoot
+}

--- a/apps/codehelper/src-tauri/resources/python/README.md
+++ b/apps/codehelper/src-tauri/resources/python/README.md
@@ -3,16 +3,25 @@
 This directory defines the packaged resource contract for the app-private
 Python runtime used by the self-contained line.
 
-Phase 3 locks the delivery source to:
+The dev and packaging contract is pinned to:
 
-- the official Windows x64 CPython embeddable distribution from `python.org`
-- a pinned `uv` Windows binary from Astral
-- provider-owned wheel/runtime inputs staged into `payload/`
+- the official Windows x64 CPython 3.12.9 embeddable distribution from `python.org`
+- the pinned `uv` 0.10.12 Windows binary from Astral
+- staged runtime files under `payload/`
 
-The final large runtime payload still stays out of git history. Packaging-stage
-scripts populate `payload/` at build time.
+The staged payload stays out of git history. Developers should populate it with:
 
-Expected future staged contents:
+```powershell
+npm run runtime:setup:python
+```
 
-- `payload/`
-- runtime wheels or environment inputs needed for bundled execution
+That command stages the pinned embeddable Python runtime plus `uv.exe` and
+`uvx.exe` into this directory so `Prepare` can copy the payload into app-local
+setup state during `npm run tauri:dev`.
+
+Expected staged contents:
+
+- `payload/python.exe`
+- `payload/uv.exe`
+- `payload/uvx.exe`
+- the rest of the embeddable CPython runtime files extracted alongside them

--- a/apps/codehelper/src-tauri/resources/python/manifest.json
+++ b/apps/codehelper/src-tauri/resources/python/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "phase3-bundled-python-placeholder",
-  "source": "python.org embeddable CPython + Astral uv staging contract",
-  "expectedPaths": ["README.md", "payload"],
-  "status": "placeholder"
+  "version": "phase5-bundled-python-cpython-3.12.9-uv-0.10.12",
+  "source": "python.org CPython 3.12.9 embeddable amd64 + Astral uv 0.10.12 staged by runtime:setup:python",
+  "expectedPaths": ["README.md", "payload/python.exe", "payload/uv.exe", "payload/uvx.exe"],
+  "status": "staging-required"
 }

--- a/apps/codehelper/src-tauri/src/setup/python.rs
+++ b/apps/codehelper/src-tauri/src/setup/python.rs
@@ -221,7 +221,59 @@ fn copy_path_recursively(source: &Path, target: &Path) -> Result<(), String> {
 mod tests {
     use super::{bundled_python_item, prepare_bundled_python, resolve_prepared_python_command};
     use smolpc_assistant_types::SetupItemStateDto;
+    use std::path::{Path, PathBuf};
     use tempfile::TempDir;
+
+    fn write_python_manifest(root: &Path, version: &str, expected_paths: &[&str], status: &str) {
+        let expected = expected_paths
+            .iter()
+            .map(|path| format!(r#""{}""#, path))
+            .collect::<Vec<_>>()
+            .join(", ");
+        std::fs::write(
+            root.join("manifest.json"),
+            format!(
+                r#"{{
+              "version": "{version}",
+              "source": "tests",
+              "expectedPaths": [{expected}],
+              "status": "{status}"
+            }}"#
+            ),
+        )
+        .expect("manifest");
+    }
+
+    fn write_file(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent dirs");
+        }
+        std::fs::write(path, contents).expect("write file");
+    }
+
+    fn staged_payload_python_path(root: &Path) -> PathBuf {
+        root.join("payload").join("python.exe")
+    }
+
+    fn staged_payload_uv_path(root: &Path) -> PathBuf {
+        root.join("payload").join("uv.exe")
+    }
+
+    fn staged_payload_uvx_path(root: &Path) -> PathBuf {
+        root.join("payload").join("uvx.exe")
+    }
+
+    fn prepared_python_candidate_path(root: &Path) -> PathBuf {
+        #[cfg(windows)]
+        {
+            root.join("payload").join("python.exe")
+        }
+
+        #[cfg(not(windows))]
+        {
+            root.join("payload").join("bin").join("python3")
+        }
+    }
 
     #[test]
     fn bundled_python_item_reports_not_prepared_when_payload_missing() {
@@ -229,19 +281,52 @@ mod tests {
         let root = temp.path().join("python");
         std::fs::create_dir_all(&root).expect("python root");
         std::fs::write(root.join("README.md"), "placeholder").expect("readme");
-        std::fs::write(
-            root.join("manifest.json"),
-            r#"{
-              "version": "phase2",
-              "source": "tests",
-              "expectedPaths": ["README.md", "payload"],
-              "status": "placeholder"
-            }"#,
-        )
-        .expect("manifest");
+        write_python_manifest(
+            &root,
+            "phase2",
+            &[
+                "README.md",
+                "payload/python.exe",
+                "payload/uv.exe",
+                "payload/uvx.exe",
+            ],
+            "placeholder",
+        );
 
         let item = bundled_python_item(Some(temp.path()), Some(temp.path()));
         assert_eq!(item.state, SetupItemStateDto::NotPrepared);
+        assert!(!item.can_prepare);
+        assert!(item
+            .detail
+            .expect("detail")
+            .contains("payload/python.exe, payload/uv.exe, payload/uvx.exe"));
+    }
+
+    #[test]
+    fn bundled_python_item_reports_staged_payload_can_prepare() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = temp.path().join("python");
+        std::fs::create_dir_all(root.join("payload")).expect("payload root");
+        std::fs::write(root.join("README.md"), "placeholder").expect("readme");
+        write_file(&staged_payload_python_path(&root), "python");
+        write_file(&staged_payload_uv_path(&root), "uv");
+        write_file(&staged_payload_uvx_path(&root), "uvx");
+        write_python_manifest(
+            &root,
+            "phase2",
+            &[
+                "README.md",
+                "payload/python.exe",
+                "payload/uv.exe",
+                "payload/uvx.exe",
+            ],
+            "staged",
+        );
+
+        let item = bundled_python_item(Some(temp.path()), Some(temp.path()));
+        assert_eq!(item.state, SetupItemStateDto::NotPrepared);
+        assert!(item.can_prepare);
+        assert!(item.detail.expect("detail").contains("payload is staged"));
     }
 
     #[test]
@@ -249,27 +334,33 @@ mod tests {
         let resource_temp = TempDir::new().expect("resource temp");
         let app_temp = TempDir::new().expect("app temp");
         let root = resource_temp.path().join("python");
-        std::fs::create_dir_all(root.join("payload").join("bin")).expect("payload");
+        std::fs::create_dir_all(root.join("payload")).expect("payload");
         std::fs::write(root.join("README.md"), "placeholder").expect("readme");
-        std::fs::write(root.join("payload").join("bin").join("python"), "python").expect("binary");
-        std::fs::write(
-            root.join("manifest.json"),
-            r#"{
-              "version": "phase2",
-              "source": "tests",
-              "expectedPaths": ["README.md", "payload"],
-              "status": "staged"
-            }"#,
-        )
-        .expect("manifest");
+        write_file(&staged_payload_python_path(&root), "python");
+        write_file(&staged_payload_uv_path(&root), "uv");
+        write_file(&staged_payload_uvx_path(&root), "uvx");
+        write_file(&root.join("payload").join("runtime-marker.txt"), "payload");
+        write_python_manifest(
+            &root,
+            "phase2",
+            &[
+                "README.md",
+                "payload/python.exe",
+                "payload/uv.exe",
+                "payload/uvx.exe",
+            ],
+            "staged",
+        );
 
         prepare_bundled_python(Some(resource_temp.path()), Some(app_temp.path())).expect("prepare");
 
         let prepared_root = app_temp.path().join("setup").join("python");
+        assert!(prepared_root.join("payload").join("python.exe").exists());
+        assert!(prepared_root.join("payload").join("uv.exe").exists());
+        assert!(prepared_root.join("payload").join("uvx.exe").exists());
         assert!(prepared_root
             .join("payload")
-            .join("bin")
-            .join("python")
+            .join("runtime-marker.txt")
             .exists());
         assert!(prepared_root.join(".prepared-version").exists());
     }
@@ -277,13 +368,13 @@ mod tests {
     #[test]
     fn resolve_prepared_python_command_detects_prepared_runtime() {
         let app_temp = TempDir::new().expect("app temp");
-        let prepared_root = app_temp.path().join("setup").join("python").join("payload");
-        std::fs::create_dir_all(prepared_root.join("bin")).expect("python payload");
-        std::fs::write(prepared_root.join("bin").join("python3"), "python").expect("runtime");
+        let prepared_root = app_temp.path().join("setup").join("python");
+        let prepared_python = prepared_python_candidate_path(&prepared_root);
+        write_file(&prepared_python, "python");
 
         let command =
             resolve_prepared_python_command(Some(app_temp.path())).expect("prepared python");
 
-        assert!(command.ends_with("python3"));
+        assert_eq!(command, prepared_python.to_string_lossy().to_string());
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,24 +1,25 @@
 {
-  "name": "smolpc-platform-migration",
-  "private": true,
-  "version": "1.0.0",
-  "workspaces": [
-    "apps/codehelper"
-  ],
-  "scripts": {
-    "dev": "npm run dev --workspace apps/codehelper",
-    "build": "npm run build --workspace apps/codehelper",
-    "preview": "npm run preview --workspace apps/codehelper",
-    "check": "npm run check --workspace apps/codehelper",
-    "format": "npm run format --workspace apps/codehelper",
-    "lint": "npm run lint --workspace apps/codehelper",
-    "tauri": "npm run tauri --workspace apps/codehelper",
-    "tauri:dev": "npm run tauri:dev --workspace apps/codehelper",
-    "tauri:dml": "npm run tauri:dml --workspace apps/codehelper",
-    "runtime:setup:openvino": "npm run runtime:setup:openvino --workspace apps/codehelper",
-    "model:export:dml": "npm run model:export:dml --workspace apps/codehelper",
-    "model:setup:qwen25-instruct": "npm run model:setup:qwen25-instruct --workspace apps/codehelper",
-    "model:setup:qwen3-4b": "npm run model:setup:qwen3-4b --workspace apps/codehelper",
-    "boundary:check": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/check-boundaries.ps1"
-  }
+	"name": "smolpc-platform-migration",
+	"private": true,
+	"version": "1.0.0",
+	"workspaces": [
+		"apps/codehelper"
+	],
+	"scripts": {
+		"dev": "npm run dev --workspace apps/codehelper",
+		"build": "npm run build --workspace apps/codehelper",
+		"preview": "npm run preview --workspace apps/codehelper",
+		"check": "npm run check --workspace apps/codehelper",
+		"format": "npm run format --workspace apps/codehelper",
+		"lint": "npm run lint --workspace apps/codehelper",
+		"tauri": "npm run tauri --workspace apps/codehelper",
+		"tauri:dev": "npm run tauri:dev --workspace apps/codehelper",
+		"tauri:dml": "npm run tauri:dml --workspace apps/codehelper",
+		"runtime:setup:openvino": "npm run runtime:setup:openvino --workspace apps/codehelper",
+		"runtime:setup:python": "npm run runtime:setup:python --workspace apps/codehelper",
+		"model:export:dml": "npm run model:export:dml --workspace apps/codehelper",
+		"model:setup:qwen25-instruct": "npm run model:setup:qwen25-instruct --workspace apps/codehelper",
+		"model:setup:qwen3-4b": "npm run model:setup:qwen3-4b --workspace apps/codehelper",
+		"boundary:check": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/check-boundaries.ps1"
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #179 by adding a real dev workflow for staging the bundled Python payload used by setup/provisioning.

This PR adds a new command:

- `npm run runtime:setup:python`

That command stages a pinned Windows embeddable CPython runtime plus pinned `uv` binaries into:

- `apps/codehelper/src-tauri/resources/python/payload`

This keeps the packaged setup contract unchanged while making source-based dev mode realistically provisionable.

## Why

After #171 fixed bundled resource-root resolution in dev mode, setup could find the Python resource contract correctly but still failed with:

- `Bundled Python payload is not staged yet. Missing payload`

That blocked:

- `Prepare` in the setup panel
- app-local bundled Python preparation
- realistic source-based setup/provision testing
- self-contained GIMP / LibreOffice flows that depend on prepared bundled Python
- end-to-end setup reaching `ready` in dev mode

## What Changed

### New dev staging command

Added:

- `apps/codehelper/scripts/setup-bundled-python-runtime.ps1`

Exposed as:

- root `package.json`: `runtime:setup:python`
- `apps/codehelper/package.json`: `runtime:setup:python`

The script:

- stages into `apps/codehelper/src-tauri/resources/python/payload`
- downloads the pinned Windows x64 embeddable CPython archive
- downloads the pinned `uv` Windows archive
- verifies the archives before staging
- extracts/copies the runtime into `payload/`
- ensures `python.exe`, `uv.exe`, and `uvx.exe` are present
- replaces the staged payload idempotently on rerun

### Python resource contract updates

Updated:

- `apps/codehelper/src-tauri/resources/python/manifest.json`
- `apps/codehelper/src-tauri/resources/python/README.md`

The contract now checks for real staged files instead of only a placeholder `payload/` directory, and the docs explicitly tell devs to run:

- `npm run runtime:setup:python`

### Setup Python test coverage

Updated targeted tests in:

- `apps/codehelper/src-tauri/src/setup/python.rs`

Coverage now includes:

- missing staged files reports `NotPrepared`
- staged payload becomes prepare-enabled
- `prepare_bundled_python()` copies staged payload entries and writes `.prepared-version`
- `resolve_prepared_python_command()` detects the prepared runtime using the supported layout

This also fixes the previously brittle prepared-runtime test layout on Windows.

### Repo hygiene

Added ignore coverage so locally staged payloads do not dirty the repo:

- `.gitignore` now ignores `apps/codehelper/src-tauri/resources/python/payload/`

## Manual Validation

Validated in dev mode with:

1. `npm run runtime:setup:openvino`
2. `npm run runtime:setup:python`
3. `npm run tauri:dev`

Observed before clicking `Prepare`:

- `Bundled Python` changed from missing-payload failure to:
  - `not prepared`
  - `Bundled Python payload is staged and can be prepared into app-local setup state`
- `Bundled Python` became `Prepare-enabled`

Observed after clicking `Prepare`:

- overall setup state became `ready`
- `Bundled Python` became `ready`
- GIMP plugin/runtime became `ready`
- Blender addon became `ready`

This confirms the original #179 blocker is gone.

## Notes

There is one minor setup UX quirk observed during manual validation:

- before the successful `Prepare`, the top-level setup banner still showed an older cached error message
- after the successful `Prepare`, that stale banner disappeared and setup became `ready`

That appears to be a cached `last_error` display detail rather than a remaining functional failure, so this PR does not widen scope to change setup-panel error lifecycle behavior.

## Reviewer Test Steps

1. Run:
   - `npm ci`
   - `npm run runtime:setup:openvino`
   - `npm run runtime:setup:python`
   - `npm run tauri:dev`
2. Open the Setup panel
3. Confirm `Bundled Python` no longer says `Missing payload`
4. Confirm `Bundled Python` says the payload is staged and can be prepared
5. Click `Prepare`
6. Confirm setup reaches `ready`
7. Confirm these exist:
   - `%LOCALAPPDATA%\com.smolpc.codehelper\setup\python`
   - `%LOCALAPPDATA%\com.smolpc.codehelper\setup\python\.prepared-version`
   - `%LOCALAPPDATA%\com.smolpc.codehelper\setup\python\payload\python.exe`
   - `%LOCALAPPDATA%\com.smolpc.codehelper\setup\python\payload\uv.exe`

## Scope

This PR does not touch:

- engine internals
- packaging / installer logic
- downstream GIMP / Blender / LibreOffice setup call sites
- unrelated frontend work
