### PR TITLE
feat(ux): add mode-aware help drawer

### DIFF
--- a/apps/codehelper/src/App.svelte
+++ b/apps/codehelper/src/App.svelte
@@ -7,6 +7,7 @@
 	import HardwarePanel from '$lib/components/HardwarePanel.svelte';
 	import ModelInfoPanel from '$lib/components/ModelInfoPanel.svelte';
 	import KeyboardShortcutsOverlay from '$lib/components/KeyboardShortcutsOverlay.svelte';
+	import ModeHelpDrawer from '$lib/components/ModeHelpDrawer.svelte';
 	import WorkspaceHeader from '$lib/components/layout/WorkspaceHeader.svelte';
 	import WorkspaceControls from '$lib/components/layout/WorkspaceControls.svelte';
 	import AppModeDropdown from '$lib/components/layout/AppModeDropdown.svelte';
@@ -39,6 +40,7 @@
 	let currentStreamingMessageId = $state<string | null>(null);
 	let bottomOffset = $state(0);
 	let showShortcutsOverlay = $state(false);
+	let showHelpDrawer = $state(false);
 	let showSetupPanel = $state(false);
 	let startupComplete = $state(false);
 	let isSwitchingMode = $state(false);
@@ -52,6 +54,7 @@
 	const activeMode = $derived(modeStore.activeMode);
 	const activeModeConfigs = $derived(modeStore.modeConfigs);
 	const activeModeConfig = $derived(modeStore.activeConfig);
+	const activeModeLabel = $derived(activeModeConfig?.label ?? 'Mode');
 	const modeSuggestions = $derived(activeModeConfig?.suggestions ?? []);
 	const setupNeedsAttention = $derived(setupStore.initialized && setupStore.needsAttention);
 	const setupStatus = $derived(setupStore.status);
@@ -596,6 +599,55 @@ Teaching rules:
 		});
 	}
 
+	function closeHelpDrawer() {
+		showHelpDrawer = false;
+	}
+
+	function closeCompetingOverlaysForHelp() {
+		showShortcutsOverlay = false;
+		showSetupPanel = false;
+		if (uiStore.activeOverlay !== 'none') {
+			uiStore.closeOverlay();
+		}
+	}
+
+	function handleToggleHelpDrawer() {
+		if (showHelpDrawer) {
+			closeHelpDrawer();
+			return;
+		}
+		closeCompetingOverlaysForHelp();
+		showHelpDrawer = true;
+	}
+
+	function handleToggleShortcutsOverlay() {
+		if (!showShortcutsOverlay && showHelpDrawer) {
+			closeHelpDrawer();
+		}
+		showShortcutsOverlay = !showShortcutsOverlay;
+	}
+
+	function handleOpenShortcutsOverlay() {
+		if (showHelpDrawer) {
+			closeHelpDrawer();
+		}
+		showShortcutsOverlay = true;
+	}
+
+	function handleToggleHeaderOverlay(overlay: 'benchmark' | 'hardware' | 'modelInfo') {
+		if (showHelpDrawer) {
+			closeHelpDrawer();
+		}
+		uiStore.toggleOverlay(overlay);
+	}
+
+	function openSetupPanel() {
+		if (showHelpDrawer) {
+			closeHelpDrawer();
+		}
+		showSetupPanel = true;
+	}
+
 	function handleKeyDown(event: KeyboardEvent) {
 		const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
 		const modifierKey = isMac ? event.metaKey : event.ctrlKey;
@@ -603,7 +655,7 @@ Teaching rules:
 
 		if (modifierKey && event.shiftKey && event.key.toLowerCase() === 'b') {
 			event.preventDefault();
-			uiStore.toggleOverlay('benchmark');
+			handleToggleHeaderOverlay('benchmark');
 			return;
 		}
 
@@ -615,17 +667,23 @@ Teaching rules:
 
 		if (modifierKey && event.key === '/') {
 			event.preventDefault();
-			showShortcutsOverlay = !showShortcutsOverlay;
+			handleToggleShortcutsOverlay();
 			return;
 		}
 
 		if (!typingInInput && event.key === '?') {
 			event.preventDefault();
-			showShortcutsOverlay = true;
+			handleOpenShortcutsOverlay();
 			return;
 		}
 
 		if (event.key === 'Escape') {
+			if (showHelpDrawer) {
+				closeHelpDrawer();
+				event.preventDefault();
+				return;
+			}
+
 			if (showShortcutsOverlay) {
 				showShortcutsOverlay = false;
 				event.preventDefault();
@@ -799,9 +857,9 @@ Teaching rules:
 			shortcutsOpen={showShortcutsOverlay}
 			canExport={messages.length > 0}
 			onOpenSidebar={() => uiStore.setSidebarOpen(true)}
-			onToggleModelInfo={() => uiStore.toggleOverlay('modelInfo')}
-			onToggleHardware={() => uiStore.toggleOverlay('hardware')}
-			onToggleShortcuts={() => (showShortcutsOverlay = !showShortcutsOverlay)}
+			onToggleModelInfo={() => handleToggleHeaderOverlay('modelInfo')}
+			onToggleHardware={() => handleToggleHeaderOverlay('hardware')}
+			onToggleShortcuts={handleToggleShortcutsOverlay}
 			onExportChat={handleExportChat}
 		>
 			{#snippet modeSwitcher()}
@@ -816,7 +874,7 @@ Teaching rules:
 			{/snippet}
 		</WorkspaceHeader>
 
-		<WorkspaceControls>
+		<WorkspaceControls helpOpen={showHelpDrawer} onToggleHelp={handleToggleHelpDrawer}>
 			{#snippet leadingContent()}
 				{#if activeHostLaunchLabel}
 					<button
@@ -873,7 +931,7 @@ Teaching rules:
 		{/if}
 
 		{#if setupNeedsAttention}
-			<SetupBanner status={setupStatus} error={setupError} onOpen={() => (showSetupPanel = true)} />
+			<SetupBanner status={setupStatus} error={setupError} onOpen={openSetupPanel} />
 		{/if}
 
 		<ConversationView
@@ -916,6 +974,12 @@ Teaching rules:
 	<KeyboardShortcutsOverlay
 		open={showShortcutsOverlay}
 		onClose={() => (showShortcutsOverlay = false)}
+	/>
+	<ModeHelpDrawer
+		open={showHelpDrawer}
+		mode={activeMode}
+		modeLabel={activeModeLabel}
+		onClose={closeHelpDrawer}
 	/>
 	<SetupPanel
 		visible={showSetupPanel}

--- a/apps/codehelper/src/lib/components/ModeHelpDrawer.svelte
+++ b/apps/codehelper/src/lib/components/ModeHelpDrawer.svelte
@@ -1,0 +1,282 @@
+<script lang="ts">
+	import { X } from '@lucide/svelte';
+	import { Button } from '$lib/components/ui/button';
+	import type { AppMode } from '$lib/types/mode';
+
+	type ModeHelpContent = {
+		summary: string;
+		controls: string[];
+		troubleshooting: string[];
+	};
+
+	interface Props {
+		open: boolean;
+		mode: AppMode;
+		modeLabel: string;
+		onClose: () => void;
+	}
+
+	let { open, mode, modeLabel, onClose }: Props = $props();
+
+	const HELP_CONTENT: Record<AppMode, ModeHelpContent> = {
+		code: {
+			summary: 'Use Code mode when you want help understanding, fixing, or writing code.',
+			controls: [
+				'Mode changes which assistant toolchain you are using.',
+				'Setup checks what the app needs to work and shows what needs attention.',
+				'Model shows which AI model and runtime are currently active.',
+				'Context decides whether recent chat history is included in answers.',
+				'Prompt starters are quick ideas you can run or adapt.'
+			],
+			troubleshooting: [
+				'If responses feel slow, ask a shorter question first.',
+				'If generation stops, wait a moment and retry once.',
+				'If startup or model info shows a problem, open Setup and review what needs attention.'
+			]
+		},
+		gimp: {
+			summary: 'Use GIMP mode when you want the assistant to help edit the image in GIMP.',
+			controls: [
+				'Mode keeps you in the GIMP workflow while still using the same chat shell.',
+				'Open GIMP launches the host app when this mode is ready.',
+				'Setup shows whether GIMP integration prerequisites are ready.',
+				'Model and status controls still show system/runtime health.'
+			],
+			troubleshooting: [
+				'Open GIMP first, then try your request again.',
+				'If the mode shows unavailable, open Setup and fix the item marked for GIMP.',
+				'If a request fails, retry with a simpler edit instruction (one change at a time).'
+			]
+		},
+		blender: {
+			summary: 'Use Blender mode when you want help with a live Blender scene.',
+			controls: [
+				'Mode switches the assistant to Blender-aware guidance.',
+				'Open Blender launches the host app for scene-connected workflows.',
+				'Setup shows whether Blender integration is ready.',
+				'Model and status controls are still available for runtime checks.'
+			],
+			troubleshooting: [
+				'Open Blender first so scene context is available.',
+				'If Blender mode is unavailable, open Setup and resolve the Blender requirement.',
+				'If answers seem off-topic, ask about one object or step at a time.'
+			]
+		},
+		writer: {
+			summary: 'Use Writer mode when you want help creating or editing a document.',
+			controls: [
+				'Mode routes the assistant to the Writer workflow.',
+				'Open LibreOffice launches the host app for document actions.',
+				'Setup shows whether LibreOffice integration is ready.',
+				'Status controls still help diagnose model/runtime health.'
+			],
+			troubleshooting: [
+				'Open LibreOffice Writer first, then retry.',
+				'If Writer mode is unavailable, open Setup and check the LibreOffice requirement.',
+				'If a request fails, use shorter instructions and mention the exact document change.'
+			]
+		},
+		calc: {
+			summary:
+				'Calc is visible so you can see the future workflow, but this mode is not fully live yet.',
+			controls: [
+				'Mode lets you preview where Calc fits in the unified app.',
+				'Open LibreOffice can still launch the host app.',
+				'Setup shows whether LibreOffice prerequisites are present.',
+				'Model and status controls remain available for system checks.'
+			],
+			troubleshooting: [
+				'If Calc does not behave like a live assistant mode yet, that is expected right now.',
+				'Use Code, Writer, or Slides for currently live workflows.',
+				'Keep Setup healthy so Calc can be enabled smoothly when support lands.'
+			]
+		},
+		impress: {
+			summary: 'Use Slides mode when you want help creating or editing a presentation.',
+			controls: [
+				'Mode switches the assistant to the Slides workflow (Impress backend).',
+				'Open LibreOffice launches the host app for presentation tasks.',
+				'Setup shows whether LibreOffice integration is ready.',
+				'Model and status controls remain available for runtime visibility.'
+			],
+			troubleshooting: [
+				'Open LibreOffice Impress first, then retry your request.',
+				'If Slides mode is unavailable, open Setup and resolve LibreOffice prerequisites.',
+				'If a request fails, ask for one slide action at a time.'
+			]
+		}
+	};
+
+	const content = $derived(HELP_CONTENT[mode]);
+	const heading = $derived(`What can I do in ${modeLabel}?`);
+</script>
+
+{#if open}
+	<div class="mode-help-drawer">
+		<div class="mode-help-drawer__backdrop" onclick={onClose} aria-hidden="true"></div>
+		<div
+			class="mode-help-drawer__panel"
+			role="dialog"
+			aria-modal="true"
+			aria-label="Mode help panel"
+		>
+			<header class="mode-help-drawer__header">
+				<div class="mode-help-drawer__header-copy">
+					<span class="mode-help-drawer__eyebrow">Help</span>
+					<h2>{heading}</h2>
+				</div>
+				<Button variant="ghost" class="mode-help-drawer__close" onclick={onClose}>
+					<X class="h-4 w-4" />
+					<span>Close</span>
+				</Button>
+			</header>
+
+			<div class="mode-help-drawer__content">
+				<section class="mode-help-drawer__section">
+					<h3>What this mode is for</h3>
+					<p>{content.summary}</p>
+				</section>
+
+				<section class="mode-help-drawer__section">
+					<h3>What the controls mean</h3>
+					<ul>
+						{#each content.controls as item (item)}
+							<li>{item}</li>
+						{/each}
+					</ul>
+				</section>
+
+				<section class="mode-help-drawer__section">
+					<h3>If something is not working</h3>
+					<ul>
+						{#each content.troubleshooting as item (item)}
+							<li>{item}</li>
+						{/each}
+					</ul>
+				</section>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.mode-help-drawer {
+		position: fixed;
+		inset: 0;
+		z-index: 82;
+	}
+
+	.mode-help-drawer__backdrop {
+		position: absolute;
+		inset: 0;
+		background: rgb(3 7 16 / 56%);
+		backdrop-filter: blur(3px);
+	}
+
+	.mode-help-drawer__panel {
+		position: absolute;
+		top: 0;
+		right: 0;
+		height: 100%;
+		width: min(28rem, calc(100vw - 1rem));
+		display: flex;
+		flex-direction: column;
+		border-left: 1px solid var(--outline-soft);
+		background:
+			linear-gradient(
+				180deg,
+				color-mix(in srgb, var(--surface-floating) 98%, black),
+				color-mix(in srgb, var(--surface-subtle) 96%, black)
+			),
+			var(--surface-floating);
+		box-shadow: var(--shadow-strong);
+		backdrop-filter: blur(12px);
+	}
+
+	.mode-help-drawer__header {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 0.75rem;
+		padding: 1rem 1rem 0.85rem;
+		border-bottom: 1px solid var(--outline-soft);
+	}
+
+	.mode-help-drawer__header-copy {
+		display: grid;
+		gap: 0.35rem;
+	}
+
+	.mode-help-drawer__eyebrow {
+		font-size: 0.68rem;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: color-mix(in srgb, var(--color-primary) 70%, var(--color-foreground));
+	}
+
+	.mode-help-drawer__header-copy h2 {
+		font-size: 1rem;
+		font-weight: 700;
+		line-height: 1.3;
+		color: var(--color-foreground);
+	}
+
+	:global(.mode-help-drawer__close) {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		border: 1px solid var(--outline-soft);
+		background: color-mix(in srgb, var(--surface-widget) 95%, black);
+	}
+
+	.mode-help-drawer__content {
+		flex: 1;
+		overflow-y: auto;
+		padding: 0.95rem 1rem 1.15rem;
+		display: grid;
+		align-content: start;
+		gap: 0.75rem;
+	}
+
+	.mode-help-drawer__section {
+		display: grid;
+		gap: 0.5rem;
+		padding: 0.8rem;
+		border-radius: var(--radius-lg);
+		border: 1px solid var(--outline-soft);
+		background: color-mix(in srgb, var(--surface-widget) 96%, black);
+	}
+
+	.mode-help-drawer__section h3 {
+		font-size: 0.84rem;
+		font-weight: 700;
+		color: var(--color-foreground);
+	}
+
+	.mode-help-drawer__section p,
+	.mode-help-drawer__section li {
+		font-size: 0.79rem;
+		line-height: 1.45;
+		color: var(--color-muted-foreground);
+	}
+
+	.mode-help-drawer__section ul {
+		margin: 0;
+		padding-left: 1rem;
+		display: grid;
+		gap: 0.35rem;
+	}
+
+	@media (max-width: 520px) {
+		.mode-help-drawer__panel {
+			width: calc(100vw - 0.5rem);
+		}
+
+		.mode-help-drawer__header,
+		.mode-help-drawer__content {
+			padding-left: 0.8rem;
+			padding-right: 0.8rem;
+		}
+	}
+</style>

--- a/apps/codehelper/src/lib/components/layout/WorkspaceControls.svelte
+++ b/apps/codehelper/src/lib/components/layout/WorkspaceControls.svelte
@@ -1,13 +1,17 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import { CircleHelp } from '@lucide/svelte';
+	import { Button } from '$lib/components/ui/button';
 	import ContextToggle from '$lib/components/ContextToggle.svelte';
 	import ThemeSelector from '$lib/components/ThemeSelector.svelte';
 
 	interface Props {
 		leadingContent?: Snippet;
+		helpOpen?: boolean;
+		onToggleHelp?: () => void;
 	}
 
-	let { leadingContent }: Props = $props();
+	let { leadingContent, helpOpen = false, onToggleHelp }: Props = $props();
 </script>
 
 <section class="workspace-controls" aria-label="Session controls">
@@ -19,6 +23,17 @@
 	</div>
 	<div class="workspace-controls__row workspace-controls__row--compact">
 		<ThemeSelector />
+		<Button
+			variant="ghost"
+			size="sm"
+			onclick={() => onToggleHelp?.()}
+			class={`workspace-controls__help ${helpOpen ? 'workspace-controls__help--active' : ''}`}
+			aria-label="Open mode help"
+			title="Open mode help"
+		>
+			<CircleHelp class="h-4 w-4" />
+			<span>Help</span>
+		</Button>
 	</div>
 </section>
 
@@ -53,6 +68,20 @@
 
 	.workspace-controls__row--compact {
 		margin-left: auto;
+	}
+
+	:global(.workspace-controls__help) {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.38rem;
+		border: 1px solid var(--outline-soft);
+		background: color-mix(in srgb, var(--surface-widget) 95%, black);
+		box-shadow: var(--glow-subtle);
+	}
+
+	:global(.workspace-controls__help--active) {
+		border-color: var(--outline-strong);
+		background: var(--surface-active);
 	}
 
 	@media (max-width: 768px) {


### PR DESCRIPTION
Closes #178

## Summary

- add a compact, mode-aware `Help` drawer to the unified app
- add a visible `Help` entry point in the workspace controls
- show mode-specific guidance for:
  - what the current mode is for
  - what the current controls mean
  - what to try if something is not working
- keep the drawer lightweight, on-demand, and consistent with the existing app UI

## Why

The unified app now has a more visible mode switcher and cleaner empty-state copy, but it still benefits from a simple orientation layer. This PR adds a lightweight help surface that explains each mode in plain language without turning the workspace into a docs-heavy experience.

## Scope

- frontend-only UI work
- no backend contract changes
- no engine/setup/provider behavior changes
- no changes to welcome-state or prompt-starter behavior from #177
- no changes to mode-switching behavior from #176

## Implementation Notes

- Help opens as a right-side drawer with backdrop and standard overlay interactions
- the drawer can be closed by:
  - clicking the close button
  - clicking the backdrop
  - pressing `Escape`
- help content is driven by a simple frontend mode-aware content map
- the Help trigger was placed in the controls row near the theme toggle to keep the top header compact

## Validation

- `npm run check`
- manual desktop UI verification in the local app:
  - Help button is visible but not intrusive
  - drawer opens/closes cleanly
  - title and content update with the active mode
  - `Calc` uses explicit placeholder wording
  - no regression to the visible mode switcher or compact welcome state behavior

## Follow-Up Ideas

A likely follow-up is adding lightweight live status context to the Help drawer by reusing existing setup/provider state already available in the app, such as:
- current mode readiness
- setup needs-attention state
- provider/tool availability hints

That would stay additive and frontend-scoped, but is intentionally not included in this PR.
