### PR TITLE
fix(engine): flip model path priority — bundled before shared local

### DIFF
--- a/apps/codehelper/src-tauri/src/engine/supervisor.rs
+++ b/apps/codehelper/src-tauri/src/engine/supervisor.rs
@@ -598,15 +598,17 @@ fn resolve_models_dir(resource_dir: Option<&std::path::Path>) -> Option<PathBuf>
     let override_dir = std::env::var("SMOLPC_MODELS_DIR").ok().map(PathBuf::from);
     let shared_dir = dirs::data_local_dir()
         .map(|base| base.join(SHARED_MODELS_VENDOR_DIR).join(SHARED_MODELS_DIR));
+    let bundled_dir = resource_dir
+        .map(|res_dir| res_dir.join("models"))
+        .filter(|path| path.exists());
 
+    // Priority: env override → bundled (fresh from installer) → shared local.
+    // Bundled before shared prevents a stale prior install from shadowing
+    // fresh models shipped with the current version.
     override_dir
         .filter(|path| path.exists())
+        .or(bundled_dir)
         .or_else(|| shared_dir.filter(|path| path.exists()))
-        .or_else(|| {
-            resource_dir
-                .map(|res_dir| res_dir.join("models"))
-                .filter(|path| path.exists())
-        })
 }
 
 fn resolve_host_binary_path() -> Option<PathBuf> {


### PR DESCRIPTION
## Summary

Swaps the model directory resolution priority so bundled models (from the installer) take precedence over shared local models (from a prior install).

**Before:** env override → shared local (`%LOCALAPPDATA%/SmolPC/models`) → bundled (`resource_dir/models`)
**After:** env override → bundled → shared local

This prevents a stale prior install with old or corrupt models from shadowing the fresh models shipped with the current version.

## Change

One function in `supervisor.rs` — `resolve_models_dir()`. Swapped the `.or_else` chain order.

## Context

The resolved path is passed to the engine host via `SMOLPC_MODELS_DIR` env var at spawn time. The engine host uses whatever path it receives. So this single change controls the priority for the entire system.

Closes #202.