### PR TITLE
fix(libreoffice): planner path hallucination + default to local Docum…

### DIFF
--- a/apps/codehelper/src-tauri/resources/libreoffice/mcp_server/mcp_server.py
+++ b/apps/codehelper/src-tauri/resources/libreoffice/mcp_server/mcp_server.py
@@ -136,44 +136,18 @@ def resolve_document_path(file_path: str) -> str:
 
 
 def get_default_document_path(filename: str) -> str:
+    # Use USERPROFILE on Windows to get the LOCAL Documents folder.
+    # SHGetKnownFolderPath with FOLDERID_Documents resolves to OneDrive
+    # when cloud sync is active, which breaks path expectations for users
+    # who store documents locally.
     if sys.platform == "win32":
-        try:
-            import ctypes
-            from ctypes import wintypes
-            from uuid import UUID
-
-            class GUID(ctypes.Structure):
-                _fields_ = [
-                    ("Data1", ctypes.c_ulong),
-                    ("Data2", ctypes.c_ushort),
-                    ("Data3", ctypes.c_ushort),
-                    ("Data4", ctypes.c_ubyte * 8),
-                ]
-
-                def __init__(self, uuidstr):
-                    uuid = UUID(uuidstr)
-                    ctypes.Structure.__init__(self)
-                    self.Data1 = uuid.time_low
-                    self.Data2 = uuid.time_mid
-                    self.Data3 = uuid.time_hi_version
-                    self.Data4[:] = uuid.bytes[8:]
-
-            SHGetKnownFolderPath = ctypes.windll.shell32.SHGetKnownFolderPath
-            SHGetKnownFolderPath.argtypes = [
-                ctypes.POINTER(GUID), wintypes.DWORD, wintypes.HANDLE,
-                ctypes.POINTER(ctypes.c_wchar_p),
-            ]
-            SHGetKnownFolderPath.restype = ctypes.HRESULT
-            path_ptr = ctypes.c_wchar_p()
-            guid = GUID("FDD39AD0-238F-46AF-ADB4-6C85480369C7")
-            result = SHGetKnownFolderPath(ctypes.byref(guid), 0, 0, ctypes.byref(path_ptr))
-            if result == 0 and path_ptr.value:
-                docs_path = path_ptr.value
-                ctypes.windll.ole32.CoTaskMemFree(path_ptr)
-                return os.path.join(docs_path, filename)
-        except Exception:
-            pass
+        user_profile = os.environ.get("USERPROFILE", "")
+        if user_profile:
+            docs_path = os.path.join(user_profile, "Documents")
+            os.makedirs(docs_path, exist_ok=True)
+            return os.path.join(docs_path, filename)
     docs_path = os.path.join(os.path.expanduser("~"), "Documents")
+    os.makedirs(docs_path, exist_ok=True)
     return os.path.join(docs_path, filename)
 
 

--- a/apps/codehelper/src-tauri/src/modes/libreoffice/executor.rs
+++ b/apps/codehelper/src-tauri/src/modes/libreoffice/executor.rs
@@ -250,9 +250,13 @@ fn build_planner_messages(
     let system_prompt = format!(
         "You are the LibreOffice {} assistant.\n\
 Reply with a JSON tool call. Use this shape:\n\
-{{\"tool_call\":{{\"name\":\"<tool_name>\",\"arguments\":{{...}}}}}}\n\
+{{\"tool_call\":{{\"name\":\"TOOL_NAME\",\"arguments\":{{...}}}}}}\n\
 No markdown. No natural language. JSON only.\n\
-If the user refers to a file from earlier in the conversation, use that file path.\n\
+IMPORTANT: The tool name MUST be exactly one of the tool names listed below. \
+Never use a filename, document title, or any other string as the tool name.\n\
+For file_path arguments: pass the filename exactly as the user wrote it. \
+Do NOT construct absolute paths yourself. \
+If the user message ends with a (Context: ...) note, copy that path verbatim.\n\
 Available tools:\n{}",
         label, tool_catalog
     );
@@ -297,8 +301,21 @@ fn enrich_user_text_with_file_context(
         .filter(|m| m.role == "assistant")
         .find_map(|m| extract_file_path_from_text(&m.content));
 
+    // Also check user messages — the path may have been mentioned by the user
+    // (e.g., "Create a document called X.docx") and echoed back in the
+    // assistant reply with the full resolved path.
+    let path = path.or_else(|| {
+        history
+            .iter()
+            .rev()
+            .filter(|m| m.role == "user")
+            .find_map(|m| extract_file_path_from_text(&m.content))
+    });
+
     match path {
-        Some(p) => format!("{user_text}\n(Context: the most recent file is {p})"),
+        Some(p) => format!("{user_text}\n(Context: the current file is {p})"),
+        // No context path found — return user text unchanged.
+        // The MCP server handles bare filenames by resolving them to Documents.
         None => user_text.to_string(),
     }
 }
@@ -727,12 +744,39 @@ where
         )
     })?;
     let allowlist = allowed_tool_names(mode);
-    if !allowlist.iter().any(|name| *name == tool_call.name) {
-        return Err(format!(
-            "{} is not an allowed {} tool in Phase 6B.",
-            tool_call.name, profile.label
-        ));
-    }
+    // If the extracted tool name isn't in the allowlist, try to recover:
+    // the small LLM sometimes emits a mangled filename instead of a tool name.
+    // Attempt a case-insensitive prefix/substring match against allowed tools.
+    let tool_call = if allowlist.iter().any(|name| *name == tool_call.name) {
+        tool_call
+    } else {
+        let lower_name = tool_call.name.to_ascii_lowercase();
+        let fuzzy_match = allowlist.iter().find(|allowed| {
+            let lower_allowed = allowed.to_ascii_lowercase();
+            lower_allowed.starts_with(&lower_name) || lower_name.starts_with(&lower_allowed)
+        });
+        match fuzzy_match {
+            Some(matched) => {
+                log::warn!(
+                    "Planner emitted '{}' which is not a valid tool; \
+                     fuzzy-matched to '{}'",
+                    tool_call.name,
+                    matched
+                );
+                ToolCall {
+                    name: matched.to_string(),
+                    arguments: tool_call.arguments,
+                }
+            }
+            None => {
+                return Err(format!(
+                    "I couldn't choose a safe {} action for that request. \
+                     Try rephrasing as a single supported step.",
+                    profile.label
+                ));
+            }
+        }
+    };
 
     ensure_not_cancelled(state)?;
     emit(AssistantStreamEventDto::ToolCall {


### PR DESCRIPTION
…ents

- Improve planner system prompt: tool name must be from listed tools, pass filenames as-is instead of constructing absolute paths
- Add tool name fuzzy-match: recover when LLM emits a mangled filename instead of a tool name (e.g. "StressTest" from "stress-test.docx")
- Strengthen file context enrichment: also scan user messages for paths
- Default to local Documents folder (USERPROFILE) instead of SHGetKnownFolderPath which resolves to OneDrive on synced machines

Writer stress test pass rate: 67% -> 96%

## Summary

- What changed:
- Why:

## Zone Impact

- [ ] `engine/`
- [ ] `launcher/`
- [ ] `apps/`
- [ ] `docs/`

## Boundary Compliance

- [ ] No app-owned inference implementation added.
- [ ] No direct dependency on engine host internals from apps/launcher.
- [ ] `npm run boundary:check` passes locally.

## Validation

- [ ] `npm run check`
- [ ] `cargo test -p smolpc-engine-core -p smolpc-engine-client -p smolpc-engine-host`
- [ ] `cargo check -p smolpc-code-helper`

## Documentation

- [ ] Updated relevant zone README(s).
- [ ] Updated contract docs (`docs/ENGINE_API.md`) if interface changed.
- [ ] Updated onboarding docs if integration flow changed.
