### PR TITLE
feat(engine): increase NPU context window from 1024 to 2048 tokens

### DIFF
--- a/engine/crates/smolpc-engine-host/src/openvino.rs
+++ b/engine/crates/smolpc-engine-host/src/openvino.rs
@@ -11,10 +11,11 @@ use std::path::{Component, Path, PathBuf};
 const OPENVINO_NPU_DRIVER_RECOMMENDED_FLOOR: &str = "32.0.100.3104";
 const OPENVINO_NPU_MAX_PROMPT_LEN_ENV: &str = "SMOLPC_OPENVINO_NPU_MAX_PROMPT_LEN";
 const OPENVINO_NPU_MIN_RESPONSE_LEN_ENV: &str = "SMOLPC_OPENVINO_NPU_MIN_RESPONSE_LEN";
-/// NPU StaticLLMPipeline prompt budget. Intel's default is 1024. Increasing
-/// this allows longer multi-turn conversations but invalidates the cached
-/// compiled blob (CACHE_DIR), triggering a one-time recompilation (~2-3 min).
-const DEFAULT_OPENVINO_NPU_MAX_PROMPT_LEN: usize = 1024;
+/// NPU StaticLLMPipeline prompt budget. Must be a multiple of the NPU prefill
+/// chunk size (default 1024). Increasing this allows longer multi-turn
+/// conversations but invalidates the cached compiled blob (CACHE_DIR),
+/// triggering a one-time recompilation (~3-5 min for 2048).
+const DEFAULT_OPENVINO_NPU_MAX_PROMPT_LEN: usize = 2048;
 const DEFAULT_OPENVINO_NPU_MIN_RESPONSE_LEN: usize = 1024;
 const DEFAULT_QWEN_EOS_TOKEN_ID: i64 = 151645;
 const DEFAULT_QWEN_STOP_TOKEN_IDS: [i64; 2] = [151643, 151645];


### PR DESCRIPTION
## Summary

Doubles the NPU StaticLLMPipeline MAX_PROMPT_LEN from 1024 to 2048 tokens, allowing longer multi-turn conversations before hitting the fixed context limit.

**Before:** ~5-7 turn conversations crash with "unknown exception" on NPU.
**After:** ~10-15 turns before reaching the limit.

## Tradeoffs

- First run triggers NPU blob recompilation (~3-5 min, cached after via CACHE_DIR)
- KV cache memory increases ~200-400MB (total ~5.0-5.5GB with Qwen2.5-1.5B on 8GB — fits)
- 2048 = 2x1024 chunk size, satisfying the NPU prefill multiple constraint

## Override

SMOLPC_OPENVINO_NPU_MAX_PROMPT_LEN=1024 reverts to old default for testing.

## Next steps

Phase 2 (separate PR): host-side history truncation with tokenizers crate for conversations exceeding 2048.