### PR TITLE
fix(ux): remove dead Calc mode from unified shell

### DIFF
--- a/apps/codehelper/src-tauri/resources/libreoffice/mcp_server/README.md
+++ b/apps/codehelper/src-tauri/resources/libreoffice/mcp_server/README.md
@@ -23,6 +23,6 @@ Runtime contract:
 Notes:
 
 1. `libre.py` currently exposes 27 active MCP tools upstream.
-2. Unified Phase 6B activates Writer and Slides only; Calc remains scaffold-only.
+2. Unified Phase 6B activates Writer and Slides in the unified shell.
 3. Keep this integration engine-only in this repo; do not add Ollama runtime
    dependencies while porting.

--- a/apps/codehelper/src-tauri/src/commands/modes.rs
+++ b/apps/codehelper/src-tauri/src/commands/modes.rs
@@ -7,7 +7,6 @@ use crate::setup::launch::{
 };
 use smolpc_assistant_types::{AppMode, ModeConfigDto, ModeStatusDto, ProviderStateDto};
 
-
 fn build_mode_status_dto(
     mode: AppMode,
     engine_ready: bool,
@@ -61,15 +60,6 @@ fn open_host_app_for_mode(mode: AppMode) -> Result<(), String> {
                 .clone()
                 .ok_or_else(|| detection_error_detail(&detection))?;
             launch_libreoffice_mode(&path, "--writer")?;
-            Ok(())
-        }
-        AppMode::Calc => {
-            let detection = detect_libreoffice(None);
-            let path = detection
-                .path
-                .clone()
-                .ok_or_else(|| detection_error_detail(&detection))?;
-            launch_libreoffice_mode(&path, "--calc")?;
             Ok(())
         }
         AppMode::Impress => {
@@ -167,10 +157,10 @@ mod tests {
     #[test]
     fn mode_status_dto_uses_camel_case_keys() {
         let dto = build_mode_status_dto(
-            AppMode::Calc,
+            AppMode::Writer,
             false,
             ProviderStateDto {
-                mode: AppMode::Calc,
+                mode: AppMode::Writer,
                 state: "disconnected".to_string(),
                 detail: Some("Provider not integrated yet".to_string()),
                 supports_tools: true,
@@ -181,7 +171,7 @@ mod tests {
         );
 
         let value = serde_json::to_value(dto).expect("serialize mode status");
-        assert_eq!(value["providerState"]["mode"], "calc");
+        assert_eq!(value["providerState"]["mode"], "writer");
         assert_eq!(value["engineReady"], false);
         assert_eq!(value["lastError"], "engine offline");
     }

--- a/apps/codehelper/src-tauri/src/modes/config.rs
+++ b/apps/codehelper/src-tauri/src/modes/config.rs
@@ -7,7 +7,6 @@ pub fn list_mode_configs() -> Vec<ModeConfigDto> {
         AppMode::Gimp,
         AppMode::Blender,
         AppMode::Writer,
-        AppMode::Calc,
         AppMode::Impress,
     ]
     .into_iter()
@@ -85,23 +84,6 @@ pub fn mode_config(mode: AppMode) -> ModeConfigDto {
                 capabilities: shared_tool_mode_capabilities(false),
             }
         }
-        AppMode::Calc => {
-            let profile = libreoffice_profile(AppMode::Calc).expect("calc profile");
-            ModeConfigDto {
-                id: AppMode::Calc,
-                label: profile.label.to_string(),
-                subtitle: profile.subtitle.to_string(),
-                icon: "table".to_string(),
-                provider_kind: ProviderKind::Mcp,
-                system_prompt_key: "mode.calc.default".to_string(),
-                suggestions: profile
-                    .suggestions
-                    .iter()
-                    .map(|value| (*value).to_string())
-                    .collect(),
-                capabilities: shared_tool_mode_capabilities(false),
-            }
-        }
         AppMode::Impress => {
             let profile = libreoffice_profile(AppMode::Impress).expect("impress profile");
             ModeConfigDto {
@@ -150,7 +132,6 @@ mod tests {
                 AppMode::Gimp,
                 AppMode::Blender,
                 AppMode::Writer,
-                AppMode::Calc,
                 AppMode::Impress,
             ]
         );

--- a/apps/codehelper/src-tauri/src/modes/libreoffice/executor.rs
+++ b/apps/codehelper/src-tauri/src/modes/libreoffice/executor.rs
@@ -149,34 +149,27 @@ fn filter_tools_by_intent<'a>(
             &["properties", "info", "metadata", "word count", "stats"],
             &["get_document_properties"],
         ),
-        (
-            &["copy", "duplicate"],
-            &["copy_document"],
-        ),
+        (&["copy", "duplicate"], &["copy_document"]),
         (
             &["create", "new", "blank", "make"],
             &["create_blank_document", "create_blank_presentation"],
         ),
-        (
-            &["heading"],
-            &["add_heading"],
-        ),
-        (
-            &["table"],
-            &["add_table", "format_table"],
-        ),
+        (&["heading"], &["add_heading"]),
+        (&["table"], &["add_table", "format_table"]),
         (
             &["slide"],
-            &["add_slide", "edit_slide_content", "edit_slide_title", "delete_slide"],
+            &[
+                "add_slide",
+                "edit_slide_content",
+                "edit_slide_title",
+                "delete_slide",
+            ],
         ),
         (
             &["image", "picture", "photo"],
             &["insert_image", "insert_slide_image"],
         ),
-        (
-            &["page break"],
-            &["insert_page_break"],
-        ),
+        (&["page break"], &["insert_page_break"]),
         (
             &["format", "bold", "italic", "font", "style", "color"],
             &[
@@ -189,21 +182,29 @@ fn filter_tools_by_intent<'a>(
             ],
         ),
         (
-            &["add text", "add the text", "add paragraph", "add a paragraph", "append text"],
+            &[
+                "add text",
+                "add the text",
+                "add paragraph",
+                "add a paragraph",
+                "append text",
+            ],
             &["add_text", "add_paragraph"],
         ),
         (
-            &["search and replace", "find and replace", "replace all", "search for"],
+            &[
+                "search and replace",
+                "find and replace",
+                "replace all",
+                "search for",
+            ],
             &["search_replace_text"],
         ),
         (
             &["delete", "remove"],
             &["delete_text", "delete_paragraph", "delete_slide"],
         ),
-        (
-            &["paragraph", "text"],
-            &["add_paragraph", "add_text"],
-        ),
+        (&["paragraph", "text"], &["add_paragraph", "add_text"]),
     ];
 
     for (keywords, tool_names) in routing {
@@ -266,10 +267,7 @@ Available tools:\n{}",
     // contains natural-language summaries that prime the small model to respond
     // in natural language instead of JSON.  File references like "that document"
     // are handled by scanning the history for the most recent file path.
-    let user_content = enrich_user_text_with_file_context(
-        &request.user_text,
-        &request.messages,
-    );
+    let user_content = enrich_user_text_with_file_context(&request.user_text, &request.messages);
     messages.push(EngineChatMessage {
         role: "user".to_string(),
         content: user_content,
@@ -306,8 +304,8 @@ fn enrich_user_text_with_file_context(
 fn extract_file_path_from_text(text: &str) -> Option<String> {
     // Document extensions we recognise (lowercase, with dot).
     const EXTENSIONS: &[&str] = &[
-        ".odt", ".docx", ".doc", ".rtf", ".odp", ".pptx", ".ppt", ".ods",
-        ".xlsx", ".xls", ".pdf", ".txt", ".csv",
+        ".odt", ".docx", ".doc", ".rtf", ".odp", ".pptx", ".ppt", ".ods", ".xlsx", ".xls", ".pdf",
+        ".txt", ".csv",
     ];
 
     // Scan for Windows absolute paths like `C:\...\file.ext`.  Paths may
@@ -319,10 +317,7 @@ fn extract_file_path_from_text(text: &str) -> Option<String> {
     let mut i = 0;
     while i + 2 < len {
         // Look for a drive letter followed by `:\`
-        if chars[i].is_ascii_alphabetic()
-            && chars[i + 1] == ':'
-            && chars[i + 2] == '\\'
-        {
+        if chars[i].is_ascii_alphabetic() && chars[i + 1] == ':' && chars[i + 2] == '\\' {
             // Find the end: scan forward for a known extension.
             let start = i;
             let rest = &text[start..];
@@ -670,9 +665,6 @@ where
     let mode = request.mode;
     let profile = libreoffice_profile(mode)
         .ok_or_else(|| format!("LibreOffice provider does not handle mode {mode:?}"))?;
-    if !profile.live_in_phase_6b {
-        return Err("UNIFIED_ASSISTANT_NOT_IMPLEMENTED".to_string());
-    }
 
     emit(AssistantStreamEventDto::Status {
         phase: "starting_libreoffice_request".to_string(),
@@ -1029,29 +1021,6 @@ I hope this helps!"#;
         let tool_call = extract_tool_call(raw).expect("should repair comma-for-colon");
         assert_eq!(tool_call.name, "create_blank_presentation");
         assert_eq!(tool_call.arguments["filename"], json!("test.odp"));
-    }
-
-    #[tokio::test]
-    async fn calc_mode_remains_unimplemented() {
-        let provider = Arc::new(MockProvider::default());
-        let planner = MockPlanner {
-            reply: "no-op".to_string(),
-        };
-        let streamer = MockStreamer;
-        let state = AssistantState::default();
-
-        let error = execute_libreoffice_request(
-            provider,
-            &planner,
-            &streamer,
-            &request(AppMode::Calc, "Open a sheet"),
-            &state,
-            |_| {},
-        )
-        .await
-        .expect_err("calc should remain scaffold-only");
-
-        assert_eq!(error, "UNIFIED_ASSISTANT_NOT_IMPLEMENTED");
     }
 
     #[tokio::test]

--- a/apps/codehelper/src-tauri/src/modes/libreoffice/profiles.rs
+++ b/apps/codehelper/src-tauri/src/modes/libreoffice/profiles.rs
@@ -1,14 +1,5 @@
 use smolpc_assistant_types::AppMode;
 
-pub const LIBREOFFICE_DISABLED_REASON: &str =
-    "LibreOffice integration is scaffolded in the unified app, but live document actions are not wired yet.";
-pub const WRITER_COMPOSER_PLACEHOLDER: &str =
-    "Ask LibreOffice Writer to create or edit a document (Shift+Enter for new line)...";
-pub const CALC_COMPOSER_PLACEHOLDER: &str =
-    "LibreOffice Calc is scaffolded here, but live spreadsheet chat is not active yet.";
-pub const SLIDES_COMPOSER_PLACEHOLDER: &str =
-    "Ask LibreOffice Slides to create or edit a presentation (Shift+Enter for new line)...";
-
 pub const WRITER_ALLOWED_TOOLS: &[&str] = &[
     "create_blank_document",
     "read_text_document",
@@ -47,17 +38,12 @@ pub const IMPRESS_ALLOWED_TOOLS: &[&str] = &[
     "open_in_libreoffice",
 ];
 
-pub const CALC_ALLOWED_TOOLS: &[&str] = &[];
+const NO_ALLOWED_TOOLS: &[&str] = &[];
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct LibreOfficeModeProfile {
     pub label: &'static str,
     pub subtitle: &'static str,
-    pub disabled_reason: &'static str,
-    pub composer_placeholder: &'static str,
-    pub source_coverage: &'static str,
-    pub future_runtime_family: &'static str,
-    pub live_in_phase_6b: bool,
     pub suggestions: &'static [&'static str],
     pub allowed_tools: &'static [&'static str],
 }
@@ -68,12 +54,6 @@ pub fn libreoffice_profile(mode: AppMode) -> Option<LibreOfficeModeProfile> {
             label: "Writer",
             subtitle:
                 "Live LibreOffice Writer help for creating and editing documents through the unified assistant shell",
-            disabled_reason: "",
-            composer_placeholder: WRITER_COMPOSER_PLACEHOLDER,
-            source_coverage:
-                "Writer already has meaningful source coverage on codex/libreoffice-port-track-a.",
-            future_runtime_family: "Document MCP server over stdio (python-docx/python-pptx/odfdo)",
-            live_in_phase_6b: true,
             suggestions: &[
                 "Create a blank document called lesson-plan.odt",
                 "Add a level 1 heading called Local AI in Schools",
@@ -81,33 +61,10 @@ pub fn libreoffice_profile(mode: AppMode) -> Option<LibreOfficeModeProfile> {
             ],
             allowed_tools: WRITER_ALLOWED_TOOLS,
         }),
-        AppMode::Calc => Some(LibreOfficeModeProfile {
-            label: "Calc",
-            subtitle:
-                "LibreOffice Calc scaffold in the unified shell; spreadsheet actions remain deferred for now",
-            disabled_reason: LIBREOFFICE_DISABLED_REASON,
-            composer_placeholder: CALC_COMPOSER_PLACEHOLDER,
-            source_coverage:
-                "Calc is not yet at parity on codex/libreoffice-port-track-a and remains scaffold-target only.",
-            future_runtime_family: "Document MCP server over stdio (python-docx/python-pptx/odfdo)",
-            live_in_phase_6b: false,
-            suggestions: &[
-                "LibreOffice Calc activation is planned next",
-                "Spreadsheet tools are not wired yet",
-                "Check back after the activation follow-up",
-            ],
-            allowed_tools: CALC_ALLOWED_TOOLS,
-        }),
         AppMode::Impress => Some(LibreOfficeModeProfile {
             label: "Slides",
             subtitle:
                 "Live LibreOffice Slides help for creating and editing presentations through the unified assistant shell",
-            disabled_reason: "",
-            composer_placeholder: SLIDES_COMPOSER_PLACEHOLDER,
-            source_coverage:
-                "Slides already has meaningful source coverage on codex/libreoffice-port-track-a.",
-            future_runtime_family: "Document MCP server over stdio (python-docx/python-pptx/odfdo)",
-            live_in_phase_6b: true,
             suggestions: &[
                 "Create a blank presentation called demo-pitch.odp",
                 "Add a title slide for Local AI in Classrooms",
@@ -119,14 +76,8 @@ pub fn libreoffice_profile(mode: AppMode) -> Option<LibreOfficeModeProfile> {
     }
 }
 
-pub fn is_live_libreoffice_mode(mode: AppMode) -> bool {
-    libreoffice_profile(mode)
-        .map(|profile| profile.live_in_phase_6b)
-        .unwrap_or(false)
-}
-
 pub fn allowed_tool_names(mode: AppMode) -> &'static [&'static str] {
     libreoffice_profile(mode)
         .map(|profile| profile.allowed_tools)
-        .unwrap_or(CALC_ALLOWED_TOOLS)
+        .unwrap_or(NO_ALLOWED_TOOLS)
 }

--- a/apps/codehelper/src-tauri/src/modes/libreoffice/provider.rs
+++ b/apps/codehelper/src-tauri/src/modes/libreoffice/provider.rs
@@ -1,12 +1,10 @@
-use super::profiles::{allowed_tool_names, is_live_libreoffice_mode, libreoffice_profile};
+use super::profiles::{allowed_tool_names, libreoffice_profile};
 use super::resources::{resolve_mcp_server_layout, ResourceResolutionOptions};
 use super::response::build_tool_execution_result;
 use super::runtime::LibreOfficeRuntimeConfig;
 use super::state::LibreOfficeProviderState;
 use crate::assistant::MODE_UNDO_NOT_SUPPORTED_IN_FOUNDATION;
-use crate::modes::provider::{
-    provider_state, ToolProvider, FOUNDATION_PROVIDER_EXECUTION_NOT_IMPLEMENTED,
-};
+use crate::modes::provider::{provider_state, ToolProvider};
 use async_trait::async_trait;
 use smolpc_assistant_types::{
     AppMode, ProviderStateDto, ToolDefinitionDto, ToolExecutionResultDto,
@@ -118,9 +116,7 @@ impl LibreOfficeProvider {
             );
         }
 
-        format!(
-            "Document runtime failed. Make sure bundled Python is prepared. {error}"
-        )
+        format!("Document runtime failed. Make sure bundled Python is prepared. {error}")
     }
 
     fn is_retryable_runtime_failure(message: &str) -> bool {
@@ -142,10 +138,9 @@ impl LibreOfficeProvider {
 
         self.connect_live(mode).await?;
         let state = self.state.lock().await;
-        state
-            .session
-            .clone()
-            .ok_or_else(|| "LibreOffice provider retry reconnect did not produce a session".to_string())
+        state.session.clone().ok_or_else(|| {
+            "LibreOffice provider retry reconnect did not produce a session".to_string()
+        })
     }
 
     async fn retry_tool_after_runtime_reconnect(
@@ -200,28 +195,6 @@ impl LibreOfficeProvider {
             "{} connected, but the runtime did not expose any {} allowlisted tools.",
             profile.label, profile.label
         )
-    }
-
-    fn calc_scaffold_state(
-        mode: AppMode,
-        state: &mut LibreOfficeProviderState,
-    ) -> Result<ProviderStateDto, String> {
-        let profile = Self::profile_for_mode(mode)?;
-        let detail = format!(
-            "{} scaffold is present in the unified app, but live spreadsheet actions remain deferred in Phase 6B. {} Future runtime: {}.",
-            profile.label,
-            profile.source_coverage,
-            profile.future_runtime_family
-        );
-        state.tools.clear();
-        state.last_error = None;
-        Ok(provider_state(
-            mode,
-            "disconnected",
-            Some(detail.as_str()),
-            true,
-            false,
-        ))
     }
 
     fn validate_runtime_prerequisites(
@@ -310,10 +283,7 @@ impl LibreOfficeProvider {
     }
 
     async fn refresh_live_state(&self, mode: AppMode) -> ProviderStateDto {
-        let profile = match Self::profile_for_mode(mode) {
-            Ok(profile) => profile,
-            Err(error) => return provider_state(mode, "error", Some(error.as_str()), true, false),
-        };
+        let profile = Self::profile_for_mode(mode).expect("validated libreoffice mode");
         let (layout, runtime) = match self.validate_runtime_prerequisites() {
             Ok(value) => value,
             Err(error) => {
@@ -377,10 +347,8 @@ impl LibreOfficeProvider {
 #[async_trait]
 impl ToolProvider for LibreOfficeProvider {
     async fn connect_if_needed(&self, mode: AppMode) -> Result<ProviderStateDto, String> {
-        let mut state = self.state.lock().await;
-        if !is_live_libreoffice_mode(mode) {
-            return Self::calc_scaffold_state(mode, &mut state);
-        }
+        Self::profile_for_mode(mode)?;
+        let state = self.state.lock().await;
 
         if state.session.is_some() && !state.tools.is_empty() {
             return Ok(Self::connected_state(mode, state.last_error.clone()));
@@ -391,6 +359,7 @@ impl ToolProvider for LibreOfficeProvider {
     }
 
     async fn status(&self, mode: AppMode) -> Result<ProviderStateDto, String> {
+        Self::profile_for_mode(mode)?;
         let mut state = self.state.lock().await;
 
         match self.validate_runtime_prerequisites() {
@@ -409,19 +378,13 @@ impl ToolProvider for LibreOfficeProvider {
                 ));
             }
         }
-
-        if !is_live_libreoffice_mode(mode) {
-            return Self::calc_scaffold_state(mode, &mut state);
-        }
         drop(state);
 
         Ok(self.refresh_live_state(mode).await)
     }
 
     async fn list_tools(&self, mode: AppMode) -> Result<Vec<ToolDefinitionDto>, String> {
-        if !is_live_libreoffice_mode(mode) {
-            return Ok(Vec::new());
-        }
+        Self::profile_for_mode(mode)?;
 
         let state = self.state.lock().await;
         Ok(state.tools.clone())
@@ -433,12 +396,9 @@ impl ToolProvider for LibreOfficeProvider {
         name: &str,
         arguments: serde_json::Value,
     ) -> Result<ToolExecutionResultDto, String> {
-        if !is_live_libreoffice_mode(mode) {
-            return Err(FOUNDATION_PROVIDER_EXECUTION_NOT_IMPLEMENTED.to_string());
-        }
+        let profile = Self::profile_for_mode(mode)?;
 
         if !allowed_tool_names(mode).contains(&name) {
-            let profile = Self::profile_for_mode(mode)?;
             return Err(format!(
                 "{name} is not available in {} mode.",
                 profile.label
@@ -465,9 +425,7 @@ impl ToolProvider for LibreOfficeProvider {
         match session.call_tool(name, arguments).await {
             Ok(payload) => {
                 let mut tool_result = build_tool_execution_result(name, payload);
-                if !tool_result.ok
-                    && Self::is_retryable_runtime_failure(&tool_result.summary)
-                {
+                if !tool_result.ok && Self::is_retryable_runtime_failure(&tool_result.summary) {
                     log::warn!(
                         "Retrying LibreOffice tool {} in mode {:?} after transient runtime failure: {}",
                         name,
@@ -527,9 +485,7 @@ impl ToolProvider for LibreOfficeProvider {
     }
 
     async fn disconnect_if_needed(&self, mode: AppMode) -> Result<(), String> {
-        if !is_live_libreoffice_mode(mode) {
-            return Ok(());
-        }
+        Self::profile_for_mode(mode)?;
 
         let mut state = self.state.lock().await;
         state.session = None;
@@ -633,7 +589,7 @@ for line in sys.stdin:
     }
 
     #[tokio::test]
-    async fn calc_mode_reports_scaffold_detail_without_starting_runtime() {
+    async fn unsupported_mode_returns_error_without_starting_runtime() {
         let tempdir = staged_runtime_root(
             "from pathlib import Path\nPath('runtime-started.txt').write_text('started')\n",
         );
@@ -645,16 +601,15 @@ for line in sys.stdin:
             },
         );
 
-        let state = provider.status(AppMode::Calc).await.expect("status");
+        let error = provider
+            .status(AppMode::Code)
+            .await
+            .expect_err("unsupported mode");
 
-        assert_eq!(state.state, "disconnected");
-        assert!(state
-            .detail
-            .expect("detail")
-            .contains("spreadsheet actions remain deferred"));
+        assert!(error.contains("does not handle mode"));
         assert!(
             !tempdir.path().join("runtime-started.txt").exists(),
-            "Calc status should not start the runtime"
+            "Unsupported mode status should not start the runtime"
         );
     }
 

--- a/apps/codehelper/src-tauri/src/modes/libreoffice/response.rs
+++ b/apps/codehelper/src-tauri/src/modes/libreoffice/response.rs
@@ -102,7 +102,6 @@ pub fn build_libreoffice_response(
     let mode_name = match mode {
         AppMode::Writer => "writer",
         AppMode::Impress => "impress",
-        AppMode::Calc => "calc",
         _ => "unknown",
     };
 

--- a/apps/codehelper/src-tauri/src/modes/registry.rs
+++ b/apps/codehelper/src-tauri/src/modes/registry.rs
@@ -49,7 +49,7 @@ impl ModeProviderRegistry {
             AppMode::Code => ProviderFamily::Code,
             AppMode::Gimp => ProviderFamily::Gimp,
             AppMode::Blender => ProviderFamily::Blender,
-            AppMode::Writer | AppMode::Calc | AppMode::Impress => ProviderFamily::LibreOffice,
+            AppMode::Writer | AppMode::Impress => ProviderFamily::LibreOffice,
         }
     }
 
@@ -72,10 +72,6 @@ mod tests {
     fn libreoffice_modes_share_one_provider_family() {
         assert_eq!(
             ModeProviderRegistry::provider_family(AppMode::Writer),
-            ProviderFamily::LibreOffice
-        );
-        assert_eq!(
-            ModeProviderRegistry::provider_family(AppMode::Calc),
             ProviderFamily::LibreOffice
         );
         assert_eq!(

--- a/apps/codehelper/src/App.svelte
+++ b/apps/codehelper/src/App.svelte
@@ -65,13 +65,12 @@
 	const SETUP_ID_TO_MODES: Readonly<Record<string, string[]>> = {
 		host_gimp: ['gimp'],
 		host_blender: ['blender'],
-		host_libreoffice: ['writer', 'calc', 'impress']
+		host_libreoffice: ['writer', 'impress']
 	};
 	const HOST_LAUNCH_LABELS: Partial<Record<AppMode, string>> = {
 		gimp: 'Open GIMP',
 		blender: 'Open Blender',
 		writer: 'Open LibreOffice',
-		calc: 'Open LibreOffice',
 		impress: 'Open LibreOffice'
 	};
 

--- a/apps/codehelper/src/lib/components/ModeHelpDrawer.svelte
+++ b/apps/codehelper/src/lib/components/ModeHelpDrawer.svelte
@@ -76,21 +76,6 @@
 				'If a request fails, use shorter instructions and mention the exact document change.'
 			]
 		},
-		calc: {
-			summary:
-				'Calc is visible so you can see the future workflow, but this mode is not fully live yet.',
-			controls: [
-				'Mode lets you preview where Calc fits in the unified app.',
-				'Open LibreOffice can still launch the host app.',
-				'Setup shows whether LibreOffice prerequisites are present.',
-				'Model and status controls remain available for system checks.'
-			],
-			troubleshooting: [
-				'If Calc does not behave like a live assistant mode yet, that is expected right now.',
-				'Use Code, Writer, or Slides for currently live workflows.',
-				'Keep Setup healthy so Calc can be enabled smoothly when support lands.'
-			]
-		},
 		impress: {
 			summary: 'Use Slides mode when you want help creating or editing a presentation.',
 			controls: [

--- a/apps/codehelper/src/lib/components/chat/WelcomeState.svelte
+++ b/apps/codehelper/src/lib/components/chat/WelcomeState.svelte
@@ -38,12 +38,6 @@
 			description:
 				'This mode helps with writing, headings, tables, and document structure inside LibreOffice Writer.'
 		},
-		calc: {
-			chip: 'Calc Preview',
-			headline: 'Spreadsheet help is still being wired up.',
-			description:
-				'Calc is visible so users can see it is part of the unified product, but it should clearly look like a future mode for now.'
-		},
 		impress: {
 			chip: 'Slides Mode',
 			headline: 'Build or edit a presentation slide by slide.',

--- a/apps/codehelper/src/lib/components/layout/AppModeDropdown.svelte
+++ b/apps/codehelper/src/lib/components/layout/AppModeDropdown.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ChevronDown, Code, Image, Box, FileText, Table, Presentation } from '@lucide/svelte';
+	import { ChevronDown, Code, Image, Box, FileText, Presentation } from '@lucide/svelte';
 	import type { AppMode, ModeConfigDto } from '$lib/types/mode';
 	import type { Component } from 'svelte';
 
@@ -31,7 +31,6 @@
 		image: Image,
 		box: Box,
 		'file-text': FileText,
-		table: Table,
 		presentation: Presentation
 	};
 

--- a/apps/codehelper/src/lib/stores/chats.svelte.ts
+++ b/apps/codehelper/src/lib/stores/chats.svelte.ts
@@ -6,16 +6,32 @@ import { saveToStorage, loadFromStorage } from '$lib/utils/storage';
 const STORAGE_KEY = 'smolpc_chats';
 const CURRENT_CHAT_KEY = 'smolpc_current_chat'; // legacy single key — kept for migration
 const MODE_CHAT_KEY = 'smolpc_mode_chats';
+const REMOVED_CALC_MODE = 'calc';
+type StoredMode = AppMode | typeof REMOVED_CALC_MODE;
+
+type StoredChat = Omit<Chat, 'mode'> & { mode?: StoredMode };
+type StoredModeChats = Partial<Record<StoredMode, string | null>>;
 
 // Load initial state from localStorage
-const initialChats = loadFromStorage<Chat[]>(STORAGE_KEY, []);
+const storedChats = loadFromStorage<StoredChat[]>(STORAGE_KEY, []);
+const initialChats = storedChats.filter((chat): chat is Chat => chat.mode !== REMOVED_CALC_MODE);
+
+if (initialChats.length !== storedChats.length) {
+	saveToStorage(STORAGE_KEY, initialChats);
+}
 
 // Migrate: if legacy single currentChatId exists, seed it as the 'code' mode chat
 const legacySingle = loadFromStorage<string | null>(CURRENT_CHAT_KEY, null);
-const initialModeChats = loadFromStorage<Partial<Record<AppMode, string | null>>>(
+const storedModeChats = loadFromStorage<StoredModeChats>(
 	MODE_CHAT_KEY,
 	legacySingle ? { code: legacySingle } : {}
 );
+const { [REMOVED_CALC_MODE]: _removedCalcChatId, ...initialModeChats } = storedModeChats;
+
+if (REMOVED_CALC_MODE in storedModeChats) {
+	saveToStorage(MODE_CHAT_KEY, initialModeChats);
+}
+
 if (legacySingle) {
 	try {
 		localStorage.removeItem(CURRENT_CHAT_KEY);

--- a/apps/codehelper/src/lib/stores/composerDraft.svelte.ts
+++ b/apps/codehelper/src/lib/stores/composerDraft.svelte.ts
@@ -4,7 +4,14 @@ const STORAGE_KEY = 'smolpc_composer_drafts_v1';
 
 type DraftsByKey = Record<string, string>;
 
-const initialDrafts = loadFromStorage<DraftsByKey>(STORAGE_KEY, {});
+const storedDrafts = loadFromStorage<DraftsByKey>(STORAGE_KEY, {});
+const initialDrafts = Object.fromEntries(
+	Object.entries(storedDrafts).filter(([key]) => !key.startsWith('calc:'))
+);
+
+if (Object.keys(initialDrafts).length !== Object.keys(storedDrafts).length) {
+	saveToStorage(STORAGE_KEY, initialDrafts);
+}
 
 let draftsByKey = $state<DraftsByKey>(initialDrafts);
 

--- a/apps/codehelper/src/lib/stores/mode.svelte.ts
+++ b/apps/codehelper/src/lib/stores/mode.svelte.ts
@@ -1,6 +1,6 @@
 import { getModeStatus, listModes } from '$lib/api/unified';
 import { loadFromStorage, saveToStorage } from '$lib/utils/storage';
-import { FALLBACK_MODE_CONFIGS, type AppMode, type ModeConfigDto } from '$lib/types/mode';
+import { APP_MODES, FALLBACK_MODE_CONFIGS, type AppMode, type ModeConfigDto } from '$lib/types/mode';
 import type { ModeStatusDto } from '$lib/types/provider';
 
 const ACTIVE_MODE_KEY = 'smolpc_unified_active_mode_v1';
@@ -12,6 +12,12 @@ let loading = $state(false);
 let configError = $state<string | null>(null);
 let statusError = $state<string | null>(null);
 let initialized = $state(false);
+
+type StoredMode = AppMode | 'calc';
+
+function isAppMode(value: string): value is AppMode {
+	return (APP_MODES as readonly string[]).includes(value);
+}
 
 function getModeConfig(mode: AppMode): ModeConfigDto | null {
 	return modeConfigs.find((config) => config.id === mode) ?? null;
@@ -74,7 +80,7 @@ export const modeStore = {
 		loading = true;
 		configError = null;
 		statusError = null;
-		const storedMode = loadFromStorage<AppMode>(ACTIVE_MODE_KEY, 'code');
+		const storedMode = loadFromStorage<StoredMode>(ACTIVE_MODE_KEY, 'code');
 
 		try {
 			const remoteModes = await listModes();
@@ -87,7 +93,7 @@ export const modeStore = {
 			modeConfigs = FALLBACK_MODE_CONFIGS;
 		}
 
-		const resolvedMode = getModeConfig(storedMode) ? storedMode : 'code';
+		const resolvedMode = isAppMode(storedMode) && getModeConfig(storedMode) ? storedMode : 'code';
 		activeMode = resolvedMode;
 		saveToStorage(ACTIVE_MODE_KEY, activeMode);
 

--- a/apps/codehelper/src/lib/types/mode.ts
+++ b/apps/codehelper/src/lib/types/mode.ts
@@ -1,4 +1,4 @@
-export const APP_MODES = ['code', 'gimp', 'blender', 'writer', 'calc', 'impress'] as const;
+export const APP_MODES = ['code', 'gimp', 'blender', 'writer', 'impress'] as const;
 
 export type AppMode = (typeof APP_MODES)[number];
 
@@ -103,24 +103,6 @@ export const FALLBACK_MODE_CONFIGS: ModeConfigDto[] = [
 			'Write a short introduction about renewable energy for school.',
 			'Add a two-column table for topic and notes.'
 		],
-		capabilities: {
-			supportsTools: true,
-			supportsUndo: false,
-			showModelInfo: true,
-			showHardwarePanel: true,
-
-			showExport: false,
-			showContextControls: false
-		}
-	},
-	{
-		id: 'calc',
-		label: 'Calc',
-		subtitle: 'Spreadsheet mode is visible, but not active yet',
-		icon: 'table',
-		providerKind: 'mcp',
-		systemPromptKey: 'mode.calc.default',
-		suggestions: [],
 		capabilities: {
 			supportsTools: true,
 			supportsUndo: false,

--- a/crates/smolpc-assistant-types/src/mode.rs
+++ b/crates/smolpc-assistant-types/src/mode.rs
@@ -7,7 +7,6 @@ pub enum AppMode {
     Gimp,
     Blender,
     Writer,
-    Calc,
     Impress,
 }
 

--- a/crates/smolpc-assistant-types/tests/contracts.rs
+++ b/crates/smolpc-assistant-types/tests/contracts.rs
@@ -33,7 +33,8 @@ fn mode_config_uses_camel_case_keys() {
     let value = serde_json::to_value(dto).expect("serialize mode config");
     assert_eq!(value["providerKind"], "local");
     assert_eq!(value["systemPromptKey"], "mode.code.default");
-    assert_eq!(value["capabilities"]["showBenchmarkPanel"], true);
+    assert_eq!(value["capabilities"]["showExport"], true);
+    assert_eq!(value["capabilities"]["showContextControls"], true);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- remove the dead Calc mode from shared mode contracts, frontend mode metadata, and unified-shell UI copy
- purge persisted Calc-specific state from active mode, chats, and composer drafts without migrating it elsewhere
- remove Calc-only LibreOffice scaffold branches and tests so only Writer and Slides remain as supported LibreOffice modes

## Verification
- `npm run check --workspace apps/codehelper`
- `cargo test -p smolpc-assistant-types`
- `cargo test -p smolpc-code-helper` *(currently blocked by an unrelated compile error on `origin/main` in `engine/crates/smolpc-engine-core/src/inference/runtime_adapter.rs`)*

## Notes
- `Cargo.lock` changed while running Cargo in this fresh worktree, but that incidental lockfile churn is intentionally not included in this PR.
- Manual desktop UI testing was not run in this environment.