### PR TITLE
fix(engine): health endpoint returns 200 for Failed readiness state

### DIFF
--- a/engine/crates/smolpc-engine-host/src/routes.rs
+++ b/engine/crates/smolpc-engine-host/src/routes.rs
@@ -37,17 +37,15 @@ pub(crate) async fn health(
     state.last_activity_ms.store(epoch_ms(), Ordering::SeqCst);
     let readiness = state.engine.readiness.lock().await;
     let state_name = format!("{:?}", readiness.state).to_ascii_lowercase();
-    if matches!(readiness.state, ReadinessState::Failed) {
-        Ok((
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(serde_json::json!({"ok": false, "state": state_name})),
-        ))
-    } else {
-        Ok((
-            StatusCode::OK,
-            Json(serde_json::json!({"ok": true, "state": state_name})),
-        ))
-    }
+    // Health is a process-liveness check only. ReadinessState::Failed means the
+    // engine could not load a model — the process is still alive and healthy.
+    // Returning 503 here caused the supervisor to misinterpret an application-level
+    // startup failure as a process death and crash-loop the engine needlessly.
+    // Use /engine/status for readiness and error details.
+    Ok((
+        StatusCode::OK,
+        Json(serde_json::json!({"ok": true, "state": state_name})),
+    ))
 }
 
 pub(crate) async fn meta(


### PR DESCRIPTION
## Root cause

The `/engine/health` endpoint was returning HTTP 503 when the engine's internal readiness transitioned to `ReadinessState::Failed` (e.g. model file missing, model load error). The supervisor treats any non-2xx health response as a process-level failure, so after 3 consecutive 503s (30 seconds) it killed and restarted the engine — a needless crash loop.

This is a semantic mismatch: **process liveness** (is the process running?) vs **application readiness** (has a model loaded?). The supervisor already detects genuine process deaths via connection errors and `is_pid_alive`. Conflating the two means a misconfiguration or missing model file causes infinite restart cycles.

**Observed crash pattern:**
1. Frontend calls `engine_ensure_started` on app launch
2. `/engine/ensure-started` tries to load a default model — fails (file missing)
3. Engine transitions to `ReadinessState::Failed`
4. `/engine/health` returns 503
5. Supervisor's 10 s health interval fires 3× → transitions to `Crashed`, restarts engine
6. After restart the engine stays `Idle` (frontend does not retry `ensure-started` after showing the error) → health returns 200 → stable

The second run was always stable, masking the root cause.

## Fix

Always return HTTP 200 from `/engine/health` when the process is alive and the request is authenticated, regardless of readiness state. The `state` field in the response body still reflects the actual readiness, so callers can distinguish `idle`, `failed`, `ready`, etc. Detailed error information continues to be available at `/engine/status`.

## Files changed

- `engine/crates/smolpc-engine-host/src/routes.rs` — remove the 503 branch in the `health` handler

## Test plan

- [ ] Start the app with no model downloaded → engine enters `Failed` readiness
- [ ] Confirm the supervisor does **not** crash-loop (health stays 200, no restarts)
- [ ] Confirm `/engine/status` still reports `state: "failed"` with the error details
- [ ] Normal flow (model present) → engine reaches `Ready`, health returns `{"ok": true, "state": "ready"}`

https://claude.ai/code/session_01LNMgwvQajVQFEJTx5mUpG1